### PR TITLE
Add documentation setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 *.jl.cov
 *.jl.*.cov
 *.jl.mem
+Manifest.toml
+docs/build
+docs/site

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ language: julia
 os:
   - linux
 julia:
-  - 0.7
   - 1.0
+  - 1.1
   - nightly
 matrix:
   allow_failures:
@@ -17,7 +17,7 @@ notifications:
 #  - julia -e 'Pkg.clone(pwd()); Pkg.build("ChainRules"); Pkg.test("ChainRules"; coverage=true)'
 after_success:
   # push coverage results to Coveralls
-  - julia -e 'cd(Pkg.dir("ChainRules")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
+  - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
 jobs:
   include:
     - state: "Documentation"

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,12 @@ notifications:
 after_success:
   # push coverage results to Coveralls
   - julia -e 'cd(Pkg.dir("ChainRules")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
-  - julia -e 'ps=Pkg.PackageSpec(name="Documenter", version="0.19"); Pkg.add(ps); Pkg.pin(ps)'
-  - julia -e 'cd(Pkg.dir("ChainRules")); include(joinpath("docs", "make.jl"))'
+jobs:
+  include:
+    - state: "Documentation"
+      julia: 1.0
+      os: linux
+      script:
+        - julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
+        - julia --project=docs/ docs/make.jl
+      after_success: skip

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,19 @@
+name = "ChainRules"
+uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
+
+[deps]
+Cassette = "7057c7e9-c182-5462-911a-8362d720325c"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+NaNMath = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
+SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
+
+[compat]
+Cassette = "^0.2"
+julia = "^1.0"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,5 @@
 julia 1.0.0
 SpecialFunctions
 NaNMath
+ForwardDiff
 Cassette 0.2.0 0.3.0

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,5 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+
+[compat]
+Documenter = "~0.22"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,9 @@
+using ChainRules
+using Documenter
+
+makedocs(modules=[ChainRules],
+         sitename="ChainRules.jl",
+         authors="Jarrett Revels and other contributors",
+         pages=["Home" => "index.md"])
+
+deploydocs(repo="github.com/JuliaDiff/ChainRules.jl.git")

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,1 @@
+# ChainRules.jl


### PR DESCRIPTION
Before you get too excited, this PR does not add _documentation_, it adds documentation _setup_. I've generated the necessary Documenter keys for GitHub and Travis, so this should get everything up and running.

I've also included ~~two~~ three unrelated changes as separate commits: remove 0.7 from Travis since we claim not to support it, add a Project.toml file, and add a missing dependency to REQUIRE.