### PR TITLE
Initial finite differencing testing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,6 +13,7 @@ julia = "^1.0"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+FDM = "e25cca7e-83ef-51fa-be6c-dfe2a3123128"
 
 [targets]
-test = ["Test"]
+test = ["Test", "FDM"]

--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,6 @@ uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
 
 [deps]
 Cassette = "7057c7e9-c182-5462-911a-8362d720325c"
-FDM = "e25cca7e-83ef-51fa-be6c-dfe2a3123128"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 NaNMath = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"

--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,7 @@ uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
 
 [deps]
 Cassette = "7057c7e9-c182-5462-911a-8362d720325c"
+FDM = "e25cca7e-83ef-51fa-be6c-dfe2a3123128"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 NaNMath = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
@@ -12,8 +13,8 @@ Cassette = "^0.2"
 julia = "^1.0"
 
 [extras]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 FDM = "e25cca7e-83ef-51fa-be6c-dfe2a3123128"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test", "FDM"]

--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,7 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [compat]
 Cassette = "^0.2"
+FDM = "^0.4.0"
 julia = "^1.0"
 
 [extras]

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -65,7 +65,8 @@ TODO
 function accumulate!(Δ, rule::AbstractRule, args...)
     return materialize!(Δ, broadcastable(add(cast(Δ), rule(args...))))
 end
-accumulate!(Δ::Real, rule::AbstractRule, args...) = accumulate(Δ, rule, args...)
+
+accumulate!(Δ::Number, rule::AbstractRule, args...) = accumulate(Δ, rule, args...)
 
 """
 TODO

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -245,7 +245,7 @@ as `Ω`, return the tuple:
 
 where each returned propagation rule `rule_for_Δxᵢ` can be invoked as
 
-    rule_for_Δxᵢ(previous_Δxᵢ, ΔΩ₁, ΔΩ₂, ...)
+    rule_for_Δxᵢ(ΔΩ₁, ΔΩ₂, ...)
 
 to yield `xᵢ`'s corresponding differential `Δxᵢ`. To illustrate, if all involved
 values are real-valued scalars, this differential can be written as:

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -62,7 +62,10 @@ accumulate(Δ, rule::AbstractRule, args...) = add(Δ, rule(args...))
 """
 TODO
 """
-accumulate!(Δ, rule::AbstractRule, args...) = materialize!(Δ, broadcastable(add(cast(Δ), rule(args...))))
+function accumulate!(Δ, rule::AbstractRule, args...)
+    return materialize!(Δ, broadcastable(add(cast(Δ), rule(args...))))
+end
+accumulate!(Δ::Real, rule::AbstractRule, args...) = accumulate(Δ, rule, args...)
 
 """
 TODO

--- a/src/rules/linalg.jl
+++ b/src/rules/linalg.jl
@@ -30,8 +30,8 @@ end
 
 function rrule(::typeof(inv), x::AbstractArray)
     Ω = inv(x)
-    m = @thunk(-Ω)
-    return Ω, Rule(ΔΩ -> extern(m)' * ΔΩ * Ω')
+    m = @thunk(-Ω')
+    return Ω, Rule(ΔΩ -> m * ΔΩ * Ω')
 end
 
 #####

--- a/src/rules/linalg.jl
+++ b/src/rules/linalg.jl
@@ -31,7 +31,7 @@ end
 function rrule(::typeof(inv), x::AbstractArray)
     Ω = inv(x)
     m = @thunk(-Ω)
-    return Ω, Rule(ΔΩ -> m' * ΔΩ * Ω')
+    return Ω, Rule(ΔΩ -> extern(m)' * ΔΩ * Ω')
 end
 
 #####

--- a/test/differentials.jl
+++ b/test/differentials.jl
@@ -1,0 +1,46 @@
+@testset "Differentials" begin
+    @testset "Wirtinger" begin
+        w = Wirtinger(1+1im, 2+2im)
+        @test wirtinger_primal(w) == 1+1im
+        @test wirtinger_conjugate(w) == 2+2im
+        @test add_wirtinger(w, w) == Wirtinger(2+2im, 4+4im)
+        # TODO: other add_wirtinger methods stack overflow
+        @test_throws ErrorException mul_wirtinger(w, w)
+        @test_throws ErrorException extern(w)
+        for x in w
+            @test x === w
+        end
+        @test broadcastable(w) == w
+        @test_throws ErrorException conj(w)
+    end
+    @testset "Zero" begin
+        z = Zero()
+        @test extern(z) === false
+        @test add_zero(z, z) == z
+        @test add_zero(z, 1) == 1
+        @test add_zero(1, z) == 1
+        @test mul_zero(z, z) == z
+        @test mul_zero(z, 1) == z
+        @test mul_zero(1, z) == z
+        for x in z
+            @test x === z
+        end
+        @test broadcastable(z) isa Ref{Zero}
+        @test conj(z) == z
+    end
+    @testset "One" begin
+        o = One()
+        @test extern(o) === true
+        @test add_one(o, o) == 2
+        @test add_one(o, 1) == 2
+        @test add_one(1, o) == 2
+        @test mul_one(o, o) == o
+        @test mul_one(o, 1) == 1
+        @test mul_one(1, o) == 1
+        for x in o
+            @test x === o
+        end
+        @test broadcastable(o) isa Ref{One}
+        @test conj(o) == o
+    end
+end

--- a/test/rules.jl
+++ b/test/rules.jl
@@ -1,0 +1,24 @@
+cool(x) = x + 1
+
+@testset "rules" begin
+    @testset "frule and rrule" begin
+        @test frule(cool, 1) === nothing
+        @test rrule(cool, 1) === nothing
+        ChainRules.@scalar_rule(Main.cool(x), one(x))
+        frx, fr = frule(cool, 1)
+        @test frx == 2
+        @test fr(1) == 1
+        rrx, rr = rrule(cool, 1)
+        @test rrx == 2
+        @test rr(1) == 1
+    end
+    @testset "iterating rules" begin
+        _, rule = frule(+, 1)
+        i = 0
+        for r in rule
+            @test r === rule
+            i += 1
+        end
+        @test i == 1  # rules only iterate once, yielding themselves
+    end
+end

--- a/test/rules/base.jl
+++ b/test/rules/base.jl
@@ -8,60 +8,94 @@ function test_scalar(f, f′, xs...)
     end
 end
 
-@testset "Trig" begin
-    @testset "Basics" for x = (Float64(π), Complex(π, π/2))
-        test_scalar(sin, cos, x)
-        test_scalar(cos, x -> -sin(x), x)
-        test_scalar(tan, x -> 1 + tan(x)^2, x)
-        test_scalar(sec, x -> sec(x) * tan(x), x)
-        test_scalar(csc, x -> -csc(x) * cot(x), x)
-        test_scalar(cot, x -> -1 - cot(x)^2, x)
-        test_scalar(sinpi, x -> π * cospi(x), x)
-        test_scalar(cospi, x -> -π * sinpi(x), x)
+@testset "base" begin
+    @testset "Trig" begin
+        @testset "Basics" for x = (Float64(π), Complex(π, π/2))
+            test_scalar(sin, cos, x)
+            test_scalar(cos, x -> -sin(x), x)
+            test_scalar(tan, x -> 1 + tan(x)^2, x)
+            test_scalar(sec, x -> sec(x) * tan(x), x)
+            test_scalar(csc, x -> -csc(x) * cot(x), x)
+            test_scalar(cot, x -> -1 - cot(x)^2, x)
+            test_scalar(sinpi, x -> π * cospi(x), x)
+            test_scalar(cospi, x -> -π * sinpi(x), x)
+        end
+        @testset "Hyperbolic" for x = (Float64(π), Complex(π, π/2))
+            test_scalar(sinh, cosh, x)
+            test_scalar(cosh, sinh, x)
+            test_scalar(tanh, x -> sech(x)^2, x)
+            test_scalar(sech, x -> -tanh(x) * sech(x), x)
+            test_scalar(csch, x -> -coth(x) * csch(x), x)
+            test_scalar(coth, x -> -csch(x)^2, x)
+        end
+        @testset "Degrees" begin
+            x = 45.0
+            test_scalar(sind, x -> (π / 180) * cosd(x), x)
+            test_scalar(cosd, x -> (-π / 180) * sind(x), x)
+            test_scalar(tand, x -> (π / 180) * (1 + tand(x)^2), x)
+            test_scalar(secd, x -> (π / 180) * secd(x) * tand(x), x)
+            test_scalar(cscd, x -> (-π / 180) * cscd(x) * cotd(x), x)
+            test_scalar(cotd, x -> (-π / 180) * (1 + cotd(x)^2), x)
+        end
+        @testset "Inverses" for x = (1.0, Complex(1.0, 0.25))
+            test_scalar(asin, x -> 1 / sqrt(1 - x^2), x)
+            test_scalar(acos, x -> -1 / sqrt(1 - x^2), x)
+            test_scalar(atan, x -> 1 / (1 + x^2), x)
+            test_scalar(asec, x -> 1 / (abs(x) * sqrt(x^2 - 1)), x)
+            test_scalar(acsc, x -> -1 / (abs(x) * sqrt(x^2 - 1)), x)
+            test_scalar(acot, x -> -1 / (1 + x^2), x)
+        end
+        @testset "Inverse hyperbolic" for x = (0.0, Complex(0.0, 0.25))
+            test_scalar(asinh, x -> 1 / sqrt(x^2 + 1), x)
+            test_scalar(acosh, x -> 1 / sqrt(x^2 - 1), x + 1)  # +1 accounts for domain
+            test_scalar(atanh, x -> 1 / (1 - x^2), x)
+            test_scalar(asech, x -> -1 / x / sqrt(1 - x^2), x)
+            test_scalar(acsch, x -> -1 / abs(x) / sqrt(1 + x^2), x)
+            test_scalar(acoth, x -> 1 / (1 - x^2), x + 1)
+        end
+        @testset "Inverse degrees" begin
+            x = 1.0
+            test_scalar(asind, x -> 180 / π / sqrt(1 - x^2), x)
+            test_scalar(acosd, x -> -180 / π / sqrt(1 - x^2), x)
+            test_scalar(atand, x -> 180 / π / (1 + x^2), x)
+            test_scalar(asecd, x -> 180 / π / abs(x) / sqrt(x^2 - 1), x)
+            test_scalar(acscd, x -> -180 / π / abs(x) / sqrt(x^2 - 1), x)
+            test_scalar(acotd, x -> -180 / π / (1 + x^2), x)
+        end
+        # TODO: atan2 sincos
     end
-    @testset "Hyperbolic" for x = (Float64(π), Complex(π, π/2))
-        test_scalar(sinh, cosh, x)
-        test_scalar(cosh, sinh, x)
-        test_scalar(tanh, x -> sech(x)^2, x)
-        test_scalar(sech, x -> -tanh(x) * sech(x), x)
-        test_scalar(csch, x -> -coth(x) * csch(x), x)
-        test_scalar(coth, x -> -csch(x)^2, x)
-    end
-    @testset "Degrees" begin
-        x = 45.0
-        test_scalar(sind, x -> (π / 180) * cosd(x), x)
-        test_scalar(cosd, x -> (-π / 180) * sind(x), x)
-        test_scalar(tand, x -> (π / 180) * (1 + tand(x)^2), x)
-        test_scalar(secd, x -> (π / 180) * secd(x) * tand(x), x)
-        test_scalar(cscd, x -> (-π / 180) * cscd(x) * cotd(x), x)
-        test_scalar(cotd, x -> (-π / 180) * (1 + cotd(x)^2), x)
-    end
-    @testset "Inverses" for x = (1.0, Complex(1.0, 0.25))
-        test_scalar(asin, x -> 1 / sqrt(1 - x^2), x)
-        test_scalar(acos, x -> -1 / sqrt(1 - x^2), x)
-        test_scalar(atan, x -> 1 / (1 + x^2), x)
-        test_scalar(asec, x -> 1 / (abs(x) * sqrt(x^2 - 1)), x)
-        test_scalar(acsc, x -> -1 / (abs(x) * sqrt(x^2 - 1)), x)
-        test_scalar(acot, x -> -1 / (1 + x^2), x)
-    end
-    @testset "Inverse hyperbolic" for x = (0.0, Complex(0.0, 0.25))
-        test_scalar(asinh, x -> 1 / sqrt(x^2 + 1), x)
-        test_scalar(acosh, x -> 1 / sqrt(x^2 - 1), x + 1)  # +1 accounts for domain
-        test_scalar(atanh, x -> 1 / (1 - x^2), x)
-        test_scalar(asech, x -> -1 / x / sqrt(1 - x^2), x)
-        test_scalar(acsch, x -> -1 / abs(x) / sqrt(1 + x^2), x)
-        test_scalar(acoth, x -> 1 / (1 - x^2), x + 1)
-    end
-    @testset "Inverse degrees" begin
-        x = 1.0
-        test_scalar(asind, x -> 180 / π / sqrt(1 - x^2), x)
-        test_scalar(acosd, x -> -180 / π / sqrt(1 - x^2), x)
-        test_scalar(atand, x -> 180 / π / (1 + x^2), x)
-        test_scalar(asecd, x -> 180 / π / abs(x) / sqrt(x^2 - 1), x)
-        test_scalar(acscd, x -> -180 / π / abs(x) / sqrt(x^2 - 1), x)
-        test_scalar(acotd, x -> -180 / π / (1 + x^2), x)
-    end
-    # TODO: atan2 sincos
-end
+    @testset "Misc. Tests" begin
+        @testset "*(x, y)" begin
+            x, y = rand(3, 2), rand(2, 5)
+            z, (dx, dy) = rrule(*, x, y)
 
+            @test z == x * y
+
+            z̄ = rand(3, 5)
+
+            @test dx(z̄) == extern(accumulate(zeros(3, 2), dx, z̄))
+            @test dy(z̄) == extern(accumulate(zeros(2, 5), dy, z̄))
+
+            test_adjoint!(rand(3, 2), dx, z̄, z̄ * y')
+            test_adjoint!(rand(2, 5), dy, z̄, x' * z̄)
+        end
+        @testset "hypot(x, y)" begin
+            x, y = rand(2)
+            h, dxy = frule(hypot, x, y)
+
+            @test extern(dxy(One(), Zero())) === y / h
+            @test extern(dxy(Zero(), One())) === x / h
+
+            cx, cy = cast((One(), Zero())), cast((Zero(), One()))
+            dx, dy = extern(dxy(cx, cy))
+            @test dx === y / h
+            @test dy === x / h
+
+            cx, cy = cast((rand(), Zero())), cast((Zero(), rand()))
+            dx, dy = extern(dxy(cx, cy))
+            @test dx === y / h * cx.value[1]
+            @test dy === x / h * cy.value[2]
+        end
+    end
+end
 # TODO: Non-trig stuff

--- a/test/rules/broadcast.jl
+++ b/test/rules/broadcast.jl
@@ -1,0 +1,20 @@
+@testset "broadcast" begin
+    @testset "Misc. Tests" begin
+        @testset "sin.(x)" begin
+            x = rand(3, 3)
+            y, (dsin, dx) = rrule(broadcast, sin, x)
+
+            @test y == sin.(x)
+            @test extern(dx(One())) == cos.(x)
+
+            x̄, ȳ = rand(), rand()
+            @test extern(accumulate(x̄, dx, ȳ)) == x̄ .+ ȳ .* cos.(x)
+
+            x̄, ȳ = Zero(), rand(3, 3)
+            @test extern(accumulate(x̄, dx, ȳ)) == ȳ .* cos.(x)
+
+            x̄, ȳ = Zero(), cast(rand(3, 3))
+            @test extern(accumulate(x̄, dx, ȳ)) == extern(ȳ) .* cos.(x)
+        end
+    end
+end

--- a/test/rules/linalg.jl
+++ b/test/rules/linalg.jl
@@ -1,36 +1,73 @@
-function construct_well_conditioned_matrix(rng, N)
+function generate_well_conditioned_matrix(rng, N)
     A = randn(rng, N, N)
     return A * A' + I
 end
 
 @testset "linalg" begin
     @testset "sum" begin
-        rng, M, N = MersenneTwister(123456), 3, 4
-        frule_test(sum, randn(rng, M, N), randn(rng, M, N))
-        rrule_test(sum, randn(rng), randn(rng, M, N), randn(rng, M, N))
+        @testset "Vector" begin
+            rng, M = MersenneTwister(123456), 3
+            frule_test(sum, (randn(rng, M), randn(rng, M)))
+            rrule_test(sum, randn(rng), (randn(rng, M), randn(rng, M)))
+        end
+        @testset "Matrix" begin
+            rng, M, N = MersenneTwister(123456), 3, 4
+            frule_test(sum, (randn(rng, M, N), randn(rng, M, N)))
+            rrule_test(sum, randn(rng), (randn(rng, M, N), randn(rng, M, N)))
+        end
+        @testset "Array{T, 3}" begin
+            rng, M, N, P = MersenneTwister(123456), 3, 7, 11
+            frule_test(sum, (randn(rng, M, N, P), randn(rng, M, N, P)))
+            rrule_test(sum, randn(rng), (randn(rng, M, N, P), randn(rng, M, N, P)))
+        end
     end
     @testset "dot" begin
-        rng, M, N = MersenneTwister(123456), 3, 4
-        x, y = randn(rng, M, N), randn(rng, M, N)
-        ẋ, ẏ = randn(rng, M, N), randn(rng, M, N)
-        frule_test(dot, (x, y), (ẋ, ẏ))
+        @testset "Vector" begin
+            rng, M = MersenneTwister(123456), 3
+            x, y = randn(rng, M), randn(rng, M)
+            ẋ, ẏ = randn(rng, M), randn(rng, M)
+            x̄, ȳ = randn(rng, M), randn(rng, M)
+            frule_test(dot, (x, ẋ), (y, ẏ))
+            rrule_test(dot, randn(rng), (x, x̄), (y, ȳ))
+        end
+        @testset "Matrix" begin
+            rng, M, N = MersenneTwister(123456), 3, 4
+            x, y = randn(rng, M, N), randn(rng, M, N)
+            ẋ, ẏ = randn(rng, M, N), randn(rng, M, N)
+            x̄, ȳ = randn(rng, M, N), randn(rng, M, N)
+            frule_test(dot, (x, ẋ), (y, ẏ))
+            rrule_test(dot, randn(rng), (x, x̄), (y, ȳ))
+        end
+        @testset "Array{T, 3}" begin
+            rng, M, N, P = MersenneTwister(123456), 3, 4, 5
+            x, y = randn(rng, M, N, P), randn(rng, M, N, P)
+            ẋ, ẏ = randn(rng, M, N, P), randn(rng, M, N, P)
+            x̄, ȳ = randn(rng, M, N, P), randn(rng, M, N, P)
+            frule_test(dot, (x, ẋ), (y, ẏ))
+            rrule_test(dot, randn(rng), (x, x̄), (y, ȳ))
+        end
     end
     @testset "inv" begin
         rng, N = MersenneTwister(123456), 3
-        B = construct_well_conditioned_matrix(rng, N)
-        frule_test(inv, B, randn(rng, N, N))
-        rrule_test(inv, randn(rng, N, N), B, randn(rng, N, N))
+        B = generate_well_conditioned_matrix(rng, N)
+        frule_test(inv, (B, randn(rng, N, N)))
+        rrule_test(inv, randn(rng, N, N), (B, randn(rng, N, N)))
     end
     @testset "det" begin
         rng, N = MersenneTwister(123456), 3
-        B = construct_well_conditioned_matrix(rng, N)
-        frule_test(det, B, randn(rng, N, N))
-        rrule_test(det, randn(rng), B, randn(rng, N, N))
+        B = generate_well_conditioned_matrix(rng, N)
+        frule_test(det, (B, randn(rng, N, N)))
+        rrule_test(det, randn(rng), (B, randn(rng, N, N)))
     end
     @testset "logdet" begin
         rng, N = MersenneTwister(123456), 3
-        B = construct_well_conditioned_matrix(rng, N)
-        frule_test(logdet, B, randn(rng, N, N))
-        rrule_test(logdet, randn(rng), B, randn(rng, N, N))
+        B = generate_well_conditioned_matrix(rng, N)
+        frule_test(logdet, (B, randn(rng, N, N)))
+        rrule_test(logdet, randn(rng), (B, randn(rng, N, N)))
+    end
+    @testset "tr" begin
+        rng, N = MersenneTwister(123456), 4
+        frule_test(tr, (randn(rng, N, N), randn(rng, N, N)))
+        rrule_test(tr, randn(rng), (randn(rng, N, N), randn(rng, N, N)))
     end
 end

--- a/test/rules/linalg.jl
+++ b/test/rules/linalg.jl
@@ -1,0 +1,36 @@
+function construct_well_conditioned_matrix(rng, N)
+    A = randn(rng, N, N)
+    return A * A' + I
+end
+
+@testset "linalg" begin
+    @testset "sum" begin
+        rng, M, N = MersenneTwister(123456), 3, 4
+        frule_test(sum, randn(rng, M, N), randn(rng, M, N))
+        rrule_test(sum, randn(rng), randn(rng, M, N), randn(rng, M, N))
+    end
+    @testset "dot" begin
+        rng, M, N = MersenneTwister(123456), 3, 4
+        x, y = randn(rng, M, N), randn(rng, M, N)
+        ẋ, ẏ = randn(rng, M, N), randn(rng, M, N)
+        frule_test(dot, (x, y), (ẋ, ẏ))
+    end
+    @testset "inv" begin
+        rng, N = MersenneTwister(123456), 3
+        B = construct_well_conditioned_matrix(rng, N)
+        frule_test(inv, B, randn(rng, N, N))
+        rrule_test(inv, randn(rng, N, N), B, randn(rng, N, N))
+    end
+    @testset "det" begin
+        rng, N = MersenneTwister(123456), 3
+        B = construct_well_conditioned_matrix(rng, N)
+        frule_test(det, B, randn(rng, N, N))
+        rrule_test(det, randn(rng), B, randn(rng, N, N))
+    end
+    @testset "logdet" begin
+        rng, N = MersenneTwister(123456), 3
+        B = construct_well_conditioned_matrix(rng, N)
+        frule_test(logdet, B, randn(rng, N, N))
+        rrule_test(logdet, randn(rng), B, randn(rng, N, N))
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,146 +7,76 @@ using ChainRules: rrule, frule, extern, accumulate, accumulate!, store!, @scalar
     DNE, Thunk, Casted, Wirtinger
 using Base.Broadcast: broadcastable
 
-cool(x) = x + 1
-@testset "frule and rrule" begin
-    @test frule(cool, 1) === nothing
-    @test rrule(cool, 1) === nothing
-    ChainRules.@scalar_rule(Main.cool(x), one(x))
-    frx, fr = frule(cool, 1)
-    @test frx == 2
-    @test fr(1) == 1
-    rrx, rr = rrule(cool, 1)
-    @test rrx == 2
-    @test rr(1) == 1
-end
-
-@testset "iterating rules" begin
-    _, rule = frule(+, 1)
-    i = 0
-    for r in rule
-        @test r === rule
-        i += 1
-    end
-    @test i == 1  # rules only iterate once, yielding themselves
-end
-
-@testset "Differentials" begin
-    @testset "Wirtinger" begin
-        w = Wirtinger(1+1im, 2+2im)
-        @test wirtinger_primal(w) == 1+1im
-        @test wirtinger_conjugate(w) == 2+2im
-        @test add_wirtinger(w, w) == Wirtinger(2+2im, 4+4im)
-        # TODO: other add_wirtinger methods stack overflow
-        @test_throws ErrorException mul_wirtinger(w, w)
-        @test_throws ErrorException extern(w)
-        for x in w
-            @test x === w
-        end
-        @test broadcastable(w) == w
-        @test_throws ErrorException conj(w)
-    end
-    @testset "Zero" begin
-        z = Zero()
-        @test extern(z) === false
-        @test add_zero(z, z) == z
-        @test add_zero(z, 1) == 1
-        @test add_zero(1, z) == 1
-        @test mul_zero(z, z) == z
-        @test mul_zero(z, 1) == z
-        @test mul_zero(1, z) == z
-        for x in z
-            @test x === z
-        end
-        @test broadcastable(z) isa Ref{Zero}
-        @test conj(z) == z
-    end
-    @testset "One" begin
-        o = One()
-        @test extern(o) === true
-        @test add_one(o, o) == 2
-        @test add_one(o, 1) == 2
-        @test add_one(1, o) == 2
-        @test mul_one(o, o) == o
-        @test mul_one(o, 1) == 1
-        @test mul_one(1, o) == 1
-        for x in o
-            @test x === o
-        end
-        @test broadcastable(o) isa Ref{One}
-        @test conj(o) == o
-    end
-end
-
 include("test_util.jl")
 
-@testset "Legacy Tests" begin
+# @testset "Misc. Tests" begin
 
-    #####
-    ##### `*(x, y)`
-    #####
+#     #####
+#     ##### `*(x, y)`
+#     #####
 
-    x, y = rand(3, 2), rand(2, 5)
-    z, (dx, dy) = rrule(*, x, y)
+#     x, y = rand(3, 2), rand(2, 5)
+#     z, (dx, dy) = rrule(*, x, y)
 
-    @test z == x * y
+#     @test z == x * y
 
-    z̄ = rand(3, 5)
+#     z̄ = rand(3, 5)
 
-    @test dx(z̄) == extern(accumulate(zeros(3, 2), dx, z̄))
-    @test dy(z̄) == extern(accumulate(zeros(2, 5), dy, z̄))
+#     @test dx(z̄) == extern(accumulate(zeros(3, 2), dx, z̄))
+#     @test dy(z̄) == extern(accumulate(zeros(2, 5), dy, z̄))
 
-    test_adjoint!(rand(3, 2), dx, z̄, z̄ * y')
-    test_adjoint!(rand(2, 5), dy, z̄, x' * z̄)
+#     test_adjoint!(rand(3, 2), dx, z̄, z̄ * y')
+#     test_adjoint!(rand(2, 5), dy, z̄, x' * z̄)
 
-    #####
-    ##### `sin.(x)`
-    #####
+#     #####
+#     ##### `sin.(x)`
+#     #####
 
-    x = rand(3, 3)
-    y, (dsin, dx) = rrule(broadcast, sin, x)
+#     x = rand(3, 3)
+#     y, (dsin, dx) = rrule(broadcast, sin, x)
 
-    @test y == sin.(x)
-    @test extern(dx(One())) == cos.(x)
+#     @test y == sin.(x)
+#     @test extern(dx(One())) == cos.(x)
 
-    x̄, ȳ = rand(), rand()
-    @test extern(accumulate(x̄, dx, ȳ)) == x̄ .+ ȳ .* cos.(x)
+#     x̄, ȳ = rand(), rand()
+#     @test extern(accumulate(x̄, dx, ȳ)) == x̄ .+ ȳ .* cos.(x)
 
-    x̄, ȳ = Zero(), rand(3, 3)
-    @test extern(accumulate(x̄, dx, ȳ)) == ȳ .* cos.(x)
+#     x̄, ȳ = Zero(), rand(3, 3)
+#     @test extern(accumulate(x̄, dx, ȳ)) == ȳ .* cos.(x)
 
-    x̄, ȳ = Zero(), cast(rand(3, 3))
-    @test extern(accumulate(x̄, dx, ȳ)) == extern(ȳ) .* cos.(x)
+#     x̄, ȳ = Zero(), cast(rand(3, 3))
+#     @test extern(accumulate(x̄, dx, ȳ)) == extern(ȳ) .* cos.(x)
 
-    #####
-    ##### `hypot(x, y)`
-    #####
+#     #####
+#     ##### `hypot(x, y)`
+#     #####
 
-    x, y = rand(2)
-    h, dxy = frule(hypot, x, y)
+#     x, y = rand(2)
+#     h, dxy = frule(hypot, x, y)
 
-    @test extern(dxy(One(), Zero())) === y / h
-    @test extern(dxy(Zero(), One())) === x / h
+#     @test extern(dxy(One(), Zero())) === y / h
+#     @test extern(dxy(Zero(), One())) === x / h
 
-    cx, cy = cast((One(), Zero())), cast((Zero(), One()))
-    dx, dy = extern(dxy(cx, cy))
-    @test dx === y / h
-    @test dy === x / h
+#     cx, cy = cast((One(), Zero())), cast((Zero(), One()))
+#     dx, dy = extern(dxy(cx, cy))
+#     @test dx === y / h
+#     @test dy === x / h
 
-    cx, cy = cast((rand(), Zero())), cast((Zero(), rand()))
-    dx, dy = extern(dxy(cx, cy))
-    @test dx === y / h * cx.value[1]
-    @test dy === x / h * cy.value[2]
-end
-
-include("test_util.jl")
+#     cx, cy = cast((rand(), Zero())), cast((Zero(), rand()))
+#     dx, dy = extern(dxy(cx, cy))
+#     @test dx === y / h * cx.value[1]
+#     @test dy === x / h * cy.value[2]
+# end
 
 @testset "ChainRules" begin
+    # include("differentials.jl")
+    # include("rules.jl")
     @testset "rules" begin
-        include(joinpath("rules", "base.jl"))
-        include(joinpath("rules", "broadcast.jl"))
+        # include(joinpath("rules", "base.jl"))
+        # include(joinpath("rules", "broadcast.jl"))
         include(joinpath("rules", "linalg.jl"))
-        include(joinpath("rules", "blas.jl"))
-        include(joinpath("rules", "nanmath.jl"))
-        include(joinpath("rules", "specialfunctions.jl"))
+        # include(joinpath("rules", "blas.jl"))
+        # include(joinpath("rules", "nanmath.jl"))
+        # include(joinpath("rules", "specialfunctions.jl"))
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,79 +1,80 @@
 # TODO: more tests!
 
-using ChainRules, Test
-using ChainRules: One, Zero, rrule, frule, extern, cast, accumulate, accumulate!, store!
+using ChainRules, Test, FDM, LinearAlgebra, Random
+using ChainRules: One, Zero, rrule, frule, extern, cast, accumulate, accumulate!, store!,
+    Casted, Wirtinger, DNE, Thunk
 
-#####
-##### `*(x, y)`
-#####
+include("test_util.jl")
 
-function test_adjoint!(x̄, dx, ȳ, partial)
-    x̄_old = copy(x̄)
-    x̄_zeros = zero.(x̄)
+@testset "Legacy Tests" begin
 
-    @test extern(accumulate(Zero(), dx, ȳ)) == extern(accumulate(x̄_zeros, dx, ȳ))
-    @test extern(accumulate(x̄, dx, ȳ)) == (x̄ .+ partial)
-    @test x̄ == x̄_old
+    #####
+    ##### `*(x, y)`
+    #####
 
-    accumulate!(x̄, dx, ȳ)
-    @test x̄ == (x̄_old .+ partial)
-    x̄ .= x̄_old
+    x, y = rand(3, 2), rand(2, 5)
+    z, (dx, dy) = rrule(*, x, y)
 
-    store!(x̄, dx, ȳ)
-    @test x̄ == partial
-    x̄ .= x̄_old
+    @test z == x * y
 
-    return nothing
+    z̄ = rand(3, 5)
+
+    @test dx(z̄) == extern(accumulate(zeros(3, 2), dx, z̄))
+    @test dy(z̄) == extern(accumulate(zeros(2, 5), dy, z̄))
+
+    test_adjoint!(rand(3, 2), dx, z̄, z̄ * y')
+    test_adjoint!(rand(2, 5), dy, z̄, x' * z̄)
+
+    #####
+    ##### `sin.(x)`
+    #####
+
+    x = rand(3, 3)
+    y, (dsin, dx) = rrule(broadcast, sin, x)
+
+    @test y == sin.(x)
+    @test extern(dx(One())) == cos.(x)
+
+    x̄, ȳ = rand(), rand()
+    @test extern(accumulate(x̄, dx, ȳ)) == x̄ .+ ȳ .* cos.(x)
+
+    x̄, ȳ = Zero(), rand(3, 3)
+    @test extern(accumulate(x̄, dx, ȳ)) == ȳ .* cos.(x)
+
+    x̄, ȳ = Zero(), cast(rand(3, 3))
+    @test extern(accumulate(x̄, dx, ȳ)) == extern(ȳ) .* cos.(x)
+
+    #####
+    ##### `hypot(x, y)`
+    #####
+
+    x, y = rand(2)
+    h, dxy = frule(hypot, x, y)
+
+    @test extern(dxy(One(), Zero())) === y / h
+    @test extern(dxy(Zero(), One())) === x / h
+
+    cx, cy = cast((One(), Zero())), cast((Zero(), One()))
+    dx, dy = extern(dxy(cx, cy))
+    @test dx === y / h
+    @test dy === x / h
+
+    cx, cy = cast((rand(), Zero())), cast((Zero(), rand()))
+    dx, dy = extern(dxy(cx, cy))
+    @test dx === y / h * cx.value[1]
+    @test dy === x / h * cy.value[2]
+
 end
 
-x, y = rand(3, 2), rand(2, 5)
-z, (dx, dy) = rrule(*, x, y)
+include("test_util.jl")
 
-@test z == x * y
-
-z̄ = rand(3, 5)
-
-@test dx(z̄) == extern(accumulate(zeros(3, 2), dx, z̄))
-@test dy(z̄) == extern(accumulate(zeros(2, 5), dy, z̄))
-
-test_adjoint!(rand(3, 2), dx, z̄, z̄ * y')
-test_adjoint!(rand(2, 5), dy, z̄, x' * z̄)
-
-#####
-##### `sin.(x)`
-#####
-
-x = rand(3, 3)
-y, (dsin, dx) = rrule(broadcast, sin, x)
-
-@test y == sin.(x)
-@test extern(dx(One())) == cos.(x)
-
-x̄, ȳ = rand(), rand()
-@test extern(accumulate(x̄, dx, ȳ)) == x̄ .+ ȳ .* cos.(x)
-
-x̄, ȳ = Zero(), rand(3, 3)
-@test extern(accumulate(x̄, dx, ȳ)) == ȳ .* cos.(x)
-
-x̄, ȳ = Zero(), cast(rand(3, 3))
-@test extern(accumulate(x̄, dx, ȳ)) == extern(ȳ) .* cos.(x)
-
-#####
-##### `hypot(x, y)`
-#####
-
-x, y = rand(2)
-h, dxy = frule(hypot, x, y)
-
-@test extern(dxy(One(), Zero())) === y / h
-@test extern(dxy(Zero(), One())) === x / h
-
-cx, cy = cast((One(), Zero())), cast((Zero(), One()))
-dx, dy = extern(dxy(cx, cy))
-@test dx === y / h
-@test dy === x / h
-
-cx, cy = cast((rand(), Zero())), cast((Zero(), rand()))
-dx, dy = extern(dxy(cx, cy))
-@test dx === y / h * cx.value[1]
-@test dy === x / h * cy.value[2]
+@testset "ChainRules" begin
+    @testset "rules" begin
+        include("rules/base.jl")
+        include("rules/broadcast.jl")
+        include("rules/linalg.jl")
+        include("rules/blas.jl")
+        include("rules/nanmath.jl")
+        include("rules/specialfunctions.jl")
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,74 +9,15 @@ using Base.Broadcast: broadcastable
 
 include("test_util.jl")
 
-# @testset "Misc. Tests" begin
-
-#     #####
-#     ##### `*(x, y)`
-#     #####
-
-#     x, y = rand(3, 2), rand(2, 5)
-#     z, (dx, dy) = rrule(*, x, y)
-
-#     @test z == x * y
-
-#     z̄ = rand(3, 5)
-
-#     @test dx(z̄) == extern(accumulate(zeros(3, 2), dx, z̄))
-#     @test dy(z̄) == extern(accumulate(zeros(2, 5), dy, z̄))
-
-#     test_adjoint!(rand(3, 2), dx, z̄, z̄ * y')
-#     test_adjoint!(rand(2, 5), dy, z̄, x' * z̄)
-
-#     #####
-#     ##### `sin.(x)`
-#     #####
-
-#     x = rand(3, 3)
-#     y, (dsin, dx) = rrule(broadcast, sin, x)
-
-#     @test y == sin.(x)
-#     @test extern(dx(One())) == cos.(x)
-
-#     x̄, ȳ = rand(), rand()
-#     @test extern(accumulate(x̄, dx, ȳ)) == x̄ .+ ȳ .* cos.(x)
-
-#     x̄, ȳ = Zero(), rand(3, 3)
-#     @test extern(accumulate(x̄, dx, ȳ)) == ȳ .* cos.(x)
-
-#     x̄, ȳ = Zero(), cast(rand(3, 3))
-#     @test extern(accumulate(x̄, dx, ȳ)) == extern(ȳ) .* cos.(x)
-
-#     #####
-#     ##### `hypot(x, y)`
-#     #####
-
-#     x, y = rand(2)
-#     h, dxy = frule(hypot, x, y)
-
-#     @test extern(dxy(One(), Zero())) === y / h
-#     @test extern(dxy(Zero(), One())) === x / h
-
-#     cx, cy = cast((One(), Zero())), cast((Zero(), One()))
-#     dx, dy = extern(dxy(cx, cy))
-#     @test dx === y / h
-#     @test dy === x / h
-
-#     cx, cy = cast((rand(), Zero())), cast((Zero(), rand()))
-#     dx, dy = extern(dxy(cx, cy))
-#     @test dx === y / h * cx.value[1]
-#     @test dy === x / h * cy.value[2]
-# end
-
 @testset "ChainRules" begin
-    # include("differentials.jl")
-    # include("rules.jl")
+    include("differentials.jl")
+    include("rules.jl")
     @testset "rules" begin
-        # include(joinpath("rules", "base.jl"))
-        # include(joinpath("rules", "broadcast.jl"))
+        include(joinpath("rules", "base.jl"))
+        include(joinpath("rules", "broadcast.jl"))
         include(joinpath("rules", "linalg.jl"))
-        # include(joinpath("rules", "blas.jl"))
-        # include(joinpath("rules", "nanmath.jl"))
-        # include(joinpath("rules", "specialfunctions.jl"))
+        include(joinpath("rules", "blas.jl"))
+        include(joinpath("rules", "nanmath.jl"))
+        include(joinpath("rules", "specialfunctions.jl"))
     end
 end

--- a/test/test_util.jl
+++ b/test/test_util.jl
@@ -1,113 +1,30 @@
-using LinearAlgebra: AbstractTriangular
+using FDM: jvp, j′vp
 
-#####
-##### We need to be able to convert everything into into a vector for use with FDM.jl
-#####
-
-# Transform `x` into a vector, and return a closure which inverts the transformation.
-to_vec(x::Nothing) = (x, nothing)
-to_vec(x::Real) = ([x], x->x[1])
-
-# Arrays.
-to_vec(x::Vector{<:Real}) = (x, identity)
-to_vec(x::Array) = vec(x), x_vec->reshape(x_vec, size(x))
-
-# AbstractArrays.
-function to_vec(x::T) where {T<:AbstractTriangular}
-    x_vec, back = to_vec(Matrix(x))
-    return x_vec, x_vec->T(reshape(back(x_vec), size(x)))
-end
-to_vec(x::Symmetric) = vec(Matrix(x)), x_vec->Symmetric(reshape(x_vec, size(x)))
-to_vec(X::Diagonal) = vec(Matrix(X)), x_vec->Diagonal(reshape(x_vec, size(X)...))
-
-# Non-array data structures.
-function to_vec(x::Tuple)
-    x_vecs, x_backs = zip(map(to_vec, x)...)
-    sz = cumsum([map(length, x_vecs)...])
-    return vcat(x_vecs...), v->([x_backs[n](v[sz[n]-length(x[n])+1:sz[n]]) for n in 1:length(x)]...,)
-end
-
-function FDM.jvp(fdm, f, x, ẋ)
-    x_vec, vec_to_x = to_vec(x)
-    ẋ_vec, _ = to_vec(ẋ)
-    y = f(x)
-    _, vec_to_y = to_vec(y)
-    return vec_to_y(FDM.jvp(fdm, x_vec->to_vec(f(vec_to_x(x_vec)))[1], x_vec, ẋ_vec))
-end
-
-function FDM.j′vp(fdm, f, ȳ, x)
-    x_vec, vec_to_x = to_vec(x)
-    ȳ_vec, _ = to_vec(ȳ)
-    return vec_to_x(FDM.j′vp(fdm, x_vec->to_vec(f(vec_to_x(x_vec)))[1], ȳ_vec, x_vec))
-end
-
-function j′vp(fdm, f, ȳ, xs...)
-    return (map(enumerate(xs)) do (p, x)
-        return FDM.j′vp(
-            fdm,
-            function(x)
-                xs_ = [xs...]
-                xs_[p] = x
-                return f(xs_...)
-            end,
-            ȳ,
-            x,
-        )    
-    end...,)
-end
-
-# My version of isapprox
-function fd_isapprox(x_ad::Nothing, x_fd, rtol, atol)
-    return isapprox(x_fd, zero(x_fd); rtol=rtol, atol=atol)
-end
-function fd_isapprox(x_ad::AbstractArray, x_fd::AbstractArray, rtol, atol)
-    return isapprox(x_ad, x_fd; rtol=rtol, atol=atol)
-end
-function fd_isapprox(x_ad::Real, x_fd::Real, rtol, atol)
-    return isapprox(x_ad, x_fd; rtol=rtol, atol=atol)
-end
-function fd_isapprox(x_ad::NamedTuple, x_fd, rtol, atol)
-    f = (x_ad, x_fd)->fd_isapprox(x_ad, x_fd, rtol, atol)
-    return all([f(getfield(x_ad, key), getfield(x_fd, key)) for key in keys(x_ad)])
-end
-function fd_isapprox(x_ad::Tuple, x_fd::Tuple, rtol, atol)
-    return all(map((x, x′)->fd_isapprox(x, x′, rtol, atol), x_ad, x_fd))
-end
-
-# Ensure that `to_vec` and j′vp works correctly.
-for x in [
-        randn(10), 5.0, randn(10, 10), (5.0, 4.0), (randn(10), randn(11)),
-        Diagonal(randn(10)),
-    ]
-    x_vec, back = to_vec(x)
-    @test x_vec isa AbstractVector{<:Real}
-    @test back(x_vec) == x
-    @test fd_isapprox(j′vp(central_fdm(5, 1), identity, x, x), (x,), 1e-10, 1e-10)
-end
+const _fdm = central_fdm(5, 1)
 
 """
-    frule_test(f, x, ẋ; rtol=1e-9, atol=1e-9, fdm=central_fdm(5, 1))
+    frule_test(f, (x, ẋ)...; rtol=1e-9, atol=1e-9, fdm=central_fdm(5, 1))
 
 # Arguments
 - `f`: Function for which the `frule` should be tested.
 - `x`: input at which to evaluate `f` (should generally be set randomly).
 - `ẋ`: differential w.r.t. `x` (should generally be set randomly).
 """
-function frule_test(f, (x, ẋ); rtol=1e-9, atol=1e-9, fdm=central_fdm(5, 1))
+function frule_test(f, (x, ẋ); rtol=1e-9, atol=1e-9, fdm=_fdm)
     return frule_test(f, ((x, ẋ),); rtol=rtol, atol=atol, fdm=fdm)
 end
 
-function frule_test(f, xẋs::Tuple{Any, Any}...; rtol=1e-9, atol=1e-9, fdm=central_fdm(5, 1))
+function frule_test(f, xẋs::Tuple{Any, Any}...; rtol=1e-9, atol=1e-9, fdm=_fdm)
     xs, ẋs = collect(zip(xẋs...))
     Ω, dΩ_rule = ChainRules.frule(f, xs...)
     @test f(xs...) == Ω
 
-    dΩ_ad, dΩ_fd = dΩ_rule(ẋs...), FDM.jvp(fdm, xs->f(xs...), xs, ẋs)
+    dΩ_ad, dΩ_fd = dΩ_rule(ẋs...), jvp(fdm, xs->f(xs...), (xs, ẋs))
     @test chain_rules_isapprox(dΩ_ad, dΩ_fd, rtol, atol)
 end
 
 """
-    rrule_test(f, ȳ, (x, x̄); rtol=1e-9, atol=1e-9, fdm=central_fdm(5, 1))
+    rrule_test(f, ȳ, (x, x̄)...; rtol=1e-9, atol=1e-9, fdm=central_fdm(5, 1))
 
 # Arguments
 - `f`: Function to which rule should be applied.
@@ -115,26 +32,20 @@ end
 - `x`: input at which to evaluate `f` (should generally be set randomly).
 - `x̄`: currently accumulated adjoint (should generally be set randomly).
 """
-function rrule_test(
-    f, ȳ, (x, x̄)::Tuple{Any, Any};
-    rtol=1e-9, atol=1e-9, fdm=central_fdm(5, 1),
-)
+function rrule_test(f, ȳ, (x, x̄)::Tuple{Any, Any}; rtol=1e-9, atol=1e-9, fdm=_fdm)
     # Check correctness of evaluation.
     fx, dx = ChainRules.rrule(f, x)
     @test fx ≈ f(x)
 
     # Correctness testing via finite differencing.
-    x̄_ad, x̄_fd = dx(ȳ), j′vp(fdm, f, ȳ, x)[1]
-    @test chain_rules_isapprox(x̄_ad, x̄_fd, rtol, atol)
+    x̄_ad, x̄_fd = dx(ȳ), j′vp(fdm, f, ȳ, x)
+    @test cr_isapprox(x̄_ad, x̄_fd, rtol, atol)
 
     # Assuming x̄_ad to be correct, check that other ChainRules mechanisms are correct.
     test_adjoint!(x̄, dx, ȳ, x̄_ad)
 end
 
-function rrule_test(
-    f, ȳ, xx̄s::Tuple{Any, Any}...;
-    rtol=1e-9, atol=1e-9, fdm=central_fdm(5, 1),
-)
+function rrule_test(f, ȳ, xx̄s::Tuple{Any, Any}...; rtol=1e-9, atol=1e-9, fdm=_fdm)
     # Check correctness of evaluation.
     xs, x̄s = collect(zip(xx̄s...))
     Ω, Δx_rules = ChainRules.rrule(f, xs...)
@@ -142,29 +53,25 @@ function rrule_test(
 
     # Correctness testing via finite differencing.
     Δxs_ad, Δxs_fd = map(Δx_rule->Δx_rule(ȳ), Δx_rules), j′vp(fdm, f, ȳ, xs...)
-    @test all(map(
-        (Δx_ad, Δx_fd)->chain_rules_isapprox(Δx_ad, Δx_fd, rtol, atol),
-        Δxs_ad,
-        Δxs_fd,
-    ))
+    @test all(map((Δx_ad, Δx_fd)->cr_isapprox(Δx_ad, Δx_fd, rtol, atol), Δxs_ad, Δxs_fd))
 
     # Assuming the above to be correct, check that other ChainRules mechanisms are correct.
     map((x̄, Δx_rule, Δx_ad)->test_adjoint!(x̄, Δx_rule, ȳ, Δx_ad), x̄s, Δx_rules, Δxs_ad)
 end
 
-function chain_rules_isapprox(d_ad, d_fd, rtol, atol)
+function cr_isapprox(d_ad, d_fd, rtol, atol)
     return isapprox(d_ad, d_fd; rtol=rtol, atol=atol)
 end
-function chain_rules_isapprox(ad::Wirtinger, fd, rtol, atol)
+function cr_isapprox(ad::Wirtinger, fd, rtol, atol)
     error("Finite differencing with Wirtinger rules not implemented")
 end
-function chain_rules_isapprox(d_ad::Casted, d_fd, rtol, atol)
+function cr_isapprox(d_ad::Casted, d_fd, rtol, atol)
     return all(isapprox.(extern(d_ad), d_fd; rtol=rtol, atol=atol))
 end
-function chain_rules_isapprox(d_ad::DNE, d_fd, rtol, atol)
+function cr_isapprox(d_ad::DNE, d_fd, rtol, atol)
     error("Tried to differentiate w.r.t. a DNE")
 end
-function chain_rules_isapprox(d_ad::Thunk, d_fd, rtol, atol)
+function cr_isapprox(d_ad::Thunk, d_fd, rtol, atol)
     return isapprox(extern(d_ad), d_fd; rtol=rtol, atol=atol)
 end
 

--- a/test/test_util.jl
+++ b/test/test_util.jl
@@ -1,0 +1,182 @@
+using LinearAlgebra: AbstractTriangular
+
+#####
+##### We need to be able to convert everything into into a vector for use with FDM.jl
+#####
+
+# Transform `x` into a vector, and return a closure which inverts the transformation.
+to_vec(x::Nothing) = (x, nothing)
+to_vec(x::Real) = ([x], x->x[1])
+
+# Arrays.
+to_vec(x::Vector{<:Real}) = (x, identity)
+to_vec(x::Array) = vec(x), x_vec->reshape(x_vec, size(x))
+
+# AbstractArrays.
+function to_vec(x::T) where {T<:AbstractTriangular}
+    x_vec, back = to_vec(Matrix(x))
+    return x_vec, x_vec->T(reshape(back(x_vec), size(x)))
+end
+to_vec(x::Symmetric) = vec(Matrix(x)), x_vec->Symmetric(reshape(x_vec, size(x)))
+to_vec(X::Diagonal) = vec(Matrix(X)), x_vec->Diagonal(reshape(x_vec, size(X)...))
+
+# Non-array data structures.
+function to_vec(x::Tuple)
+    x_vecs, x_backs = zip(map(to_vec, x)...)
+    sz = cumsum([map(length, x_vecs)...])
+    return vcat(x...), v->([x_backs[n](v[sz[n]-length(x[n])+1:sz[n]]) for n in 1:length(x)]...,)
+end
+
+function FDM.jvp(fdm, f, x, ẋ)
+    x_vec, vec_to_x = to_vec(x)
+    ẋ_vec, _ = to_vec(ẋ)
+    y = f(x)
+    _, vec_to_y = to_vec(y)
+    return vec_to_y(FDM.jvp(fdm, x_vec->to_vec(f(vec_to_x(x_vec)))[1], x_vec, ẋ_vec))
+end
+
+function FDM.j′vp(fdm, f, ȳ, x)
+    x_vec, vec_to_x = to_vec(x)
+    ȳ_vec, _ = to_vec(ȳ)
+    return vec_to_x(FDM.j′vp(fdm, x_vec->to_vec(f(vec_to_x(x_vec)))[1], ȳ_vec, x_vec))
+end
+
+function j′vp(fdm, f, ȳ, xs...)
+    return (map(enumerate(xs)) do (p, x)
+        return FDM.j′vp(
+            fdm,
+            function(x)
+                xs_ = [xs...]
+                xs_[p] = x
+                return f(xs_...)
+            end,
+            ȳ,
+            x,
+        )    
+    end...,)
+end
+
+# My version of isapprox
+function fd_isapprox(x_ad::Nothing, x_fd, rtol, atol)
+    return isapprox(x_fd, zero(x_fd); rtol=rtol, atol=atol)
+end
+function fd_isapprox(x_ad::AbstractArray, x_fd::AbstractArray, rtol, atol)
+    return isapprox(x_ad, x_fd; rtol=rtol, atol=atol)
+end
+function fd_isapprox(x_ad::Real, x_fd::Real, rtol, atol)
+    return isapprox(x_ad, x_fd; rtol=rtol, atol=atol)
+end
+function fd_isapprox(x_ad::NamedTuple, x_fd, rtol, atol)
+    f = (x_ad, x_fd)->fd_isapprox(x_ad, x_fd, rtol, atol)
+    return all([f(getfield(x_ad, key), getfield(x_fd, key)) for key in keys(x_ad)])
+end
+function fd_isapprox(x_ad::Tuple, x_fd::Tuple, rtol, atol)
+    return all(map((x, x′)->fd_isapprox(x, x′, rtol, atol), x_ad, x_fd))
+end
+
+# Ensure that `to_vec` and j′vp works correctly.
+for x in [
+        randn(10), 5.0, randn(10, 10), (5.0, 4.0), (randn(10), randn(11)),
+        Diagonal(randn(10)),
+    ]
+    x_vec, back = to_vec(x)
+    @test x_vec isa AbstractVector{<:Real}
+    @test back(x_vec) == x
+    @test fd_isapprox(j′vp(central_fdm(5, 1), identity, x, x), (x,), 1e-10, 1e-10)
+end
+
+# # Check rrule correctness using finite differencing.
+# function rrule_test(f, ȳ, x...; rtol=1e-9, atol=1e-9, fdm=central_fdm(5, 1))
+
+#     # Compute forwards-pass and j′vp.
+#     fx, dxs = ChainRules.rrule(f, x...)
+#     adj_ad = dxs(ȳ)
+#     adj_fd = j′vp(fdm, f, ȳ, x...)
+
+#     # Check that forwards-pass agrees with plain forwards-pass.
+#     @test fx ≈ f(x...)
+
+#     # Check that ad and fd adjoints (approximately) agree.
+#     # print_adjoints(adj_ad, adj_fd, rtol, atol)
+#     @test fd_isapprox(adj_ad, adj_fd, rtol, atol)
+# end
+
+"""
+    frule_test(f, x, ẋ; rtol=1e-9, atol=1e-9, fdm=central_fdm(5, 1))
+
+# Arguments
+- `f`: Function for which the `frule` should be tested.
+- `x`: input at which to evaluate `f` (should generally be set randomly).
+- `ẋ`: differential w.r.t. `x` (should generally be set randomly).
+"""
+function frule_test(f, x, ẋ; rtol=1e-9, atol=1e-9, fdm=central_fdm(5, 1))
+    Ω, dΩ_rule = ChainRules.frule(f, x)
+    dΩ_ad, dΩ_fd = dΩ_rule(ẋ), FDM.jvp(fdm, f, x, ẋ)
+    @test Ω ≈ f(x)
+    @test chain_rules_isapprox(dΩ_ad, dΩ_fd, rtol, atol)
+end
+
+function frule_test(f, xẋ::Tuple{Any, Any}; rtol=1e-9, atol=1e-9, fdm=central_fdm(5, 1))
+    xs, ẋs = collect(zip(xẋ...))
+    Ω, dΩ_rules = ChainRules.frule(f, xs...)
+    dΩ_ad = map((dΩ_rule, ẋ)->dΩ_rule(ẋ), dΩ_rules, ẋs)
+    #dΩ_fd = 
+end
+
+"""
+    rrule_test(f, ȳ, x, x̄; rtol=1e-9, atol=1e-9, fdm=central_fdm(5, 1))
+
+# Arguments
+- `f`: Function to which rule should be applied.
+- `ȳ`: adjoint w.r.t. output of `f` (should generally be set randomly).
+- `x`: input at which to evaluate `f` (should generally be set randomly).
+- `x̄`: currently accumulated adjoint (should generally be set randomly).
+"""
+function rrule_test(f, ȳ, x, x̄; rtol=1e-9, atol=1e-9, fdm=central_fdm(5, 1))
+
+    # Check correctness of evaluation.
+    fx, dx = ChainRules.rrule(f, x)
+    @test fx ≈ f(x)
+
+    # Correctness testing via finite differencing.
+    x̄_ad, x̄_fd = dx(ȳ), j′vp(fdm, f, ȳ, x)[1]
+    @test chain_rules_isapprox(x̄_ad, x̄_fd, rtol, atol)
+
+    # Assuming x̄_ad to be correct, check that other ChainRules mechanisms are correct.
+    test_adjoint!(x̄, dx, ȳ, x̄_ad)
+end
+
+function chain_rules_isapprox(d_ad, d_fd, rtol, atol)
+    return isapprox(d_ad, d_fd; rtol=rtol, atol=atol)
+end
+function chain_rules_isapprox(ad::Wirtinger, fd, rtol, atol)
+    error("Finite differencing with Wirtinger rules not implemented")
+end
+function chain_rules_isapprox(d_ad::Casted, d_fd, rtol, atol)
+    return all(isapprox.(extern(d_ad), d_fd; rtol=rtol, atol=atol))
+end
+function chain_rules_isapprox(d_ad::DNE, d_fd, rtol, atol)
+    error("Tried to differentiate w.r.t. a DNE")
+end
+function chain_rules_isapprox(d_ad::Thunk, d_fd, rtol, atol)
+    return isapprox(extern(d_ad), d_fd; rtol=rtol, atol=atol)
+end
+
+function test_adjoint!(x̄, dx, ȳ, partial)
+    x̄_old = copy(x̄)
+    x̄_zeros = zero.(x̄)
+
+    @test all(accumulate(Zero(), dx, ȳ) .== accumulate(x̄_zeros, dx, ȳ))
+    @test all(accumulate(x̄, dx, ȳ) .== (x̄ .+ partial))
+    @test x̄ == x̄_old
+
+    accumulate!(x̄, dx, ȳ)
+    @test x̄ == (x̄_old .+ partial)
+    x̄ .= x̄_old
+
+    store!(x̄, dx, ȳ)
+    @test all(x̄ .== partial)
+    x̄ .= x̄_old
+
+    return nothing
+end

--- a/test/test_util.jl
+++ b/test/test_util.jl
@@ -20,7 +20,7 @@ function frule_test(f, xẋs::Tuple{Any, Any}...; rtol=1e-9, atol=1e-9, fdm=_fdm
     @test f(xs...) == Ω
 
     dΩ_ad, dΩ_fd = dΩ_rule(ẋs...), jvp(fdm, xs->f(xs...), (xs, ẋs))
-    @test chain_rules_isapprox(dΩ_ad, dΩ_fd, rtol, atol)
+    @test cr_isapprox(dΩ_ad, dΩ_fd, rtol, atol)
 end
 
 """


### PR DESCRIPTION
This is some initial work to set up systematic testing for `frule`s and `rrule`s. This initial work covers:

- Some utility functionality to make running finite-differencing straightforward. This depends on FDM.jl
- I've extended `accumulate!` very slightly to accomodate scalars. @jrevels I could use your input here, this might be totally inconsistent with what you have in mind.
- I've moved some tests around and established a nested testset with 1-1 mapping between `src` and `test` files.
- All `frule`s and `rrule`s in `linalg` are now covered as a demonstration of the functionality.

There are a few things that need to be addressed before I go about adding extra finite-differencing test-coverage (in a later PR) / before this could be merged:

- What have I got structurally wrong in this PR? i.e. have I missed the point with everything.
- What is missing? i.e. if we extended the types of tests in `test/linalg.jl` to cover the entire codebase, what still wouldn't be covered? The `test_adjoint!` function was already here when I started, so I've kept that. Does it need extending? Do we need a forwards-mode equivalent?
- There are some tests left in `runtests.jl` that I've wrapped in a `Misc Tests` testset. These would ideally go somewhere else. I'm not entirely sure where the optimal location is though and could do with some advice.