### PR TITLE
Add NotImplemented and NotImplementedRule

### DIFF
--- a/src/differentials.jl
+++ b/src/differentials.jl
@@ -46,7 +46,8 @@ This way, we don't need to implement promotion/conversion rules between subtypes
 of `AbstractDifferential` to resolve potential ambiguities.
 =#
 
-const PRECEDENCE_LIST = [:wirtinger, :casted, :zero, :dne, :one, :thunk, :fallback]
+const PRECEDENCE_LIST = [:wirtinger, :casted, :zero, :dne, :notimplemented, :one,
+                         :thunk, :fallback]
 
 global defs = Expr(:block)
 
@@ -226,6 +227,33 @@ add_dne(a, ::DNE) = a
 mul_dne(::DNE, ::DNE) = DNE()
 mul_dne(::DNE, ::Any) = DNE()
 mul_dne(::Any, ::DNE) = DNE()
+
+#####
+##### `NotImplemented`
+#####
+
+"""
+    NotImplemented <: AbstractDifferential
+
+A differential type which behaves similar to [`DNE`](@ref) but instead signifies that
+the actual differential is not implemented in ChainRules, not that it does not exist.
+"""
+struct NotImplemented <: AbstractDifferential end
+
+extern(::NotImplemented) = error("`NotImplemented` cannot be converted to an external type.")
+
+Base.Broadcast.broadcastable(::NotImplemented) = Ref(NotImplemented())
+
+Base.iterate(x::NotImplemented) = (x, nothing)
+Base.iterate(x::NotImplemented, ::Any) = nothing
+
+add_notimplemented(::NotImplemented, ::NotImplemented) = NotImplemented()
+add_notimplemented(::NotImplemented, b) = b
+add_notimplemented(a, ::NotImplemented) = a
+
+mul_notimplemented(::NotImplemented, ::NotImplemented) = NotImplemented()
+mul_notimplemented(::NotImplemented, ::Any) = NotImplemented()
+mul_notimplemented(::Any, ::NotImplemented) = NotImplemented()
 
 #####
 ##### `One`

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -159,6 +159,20 @@ struct DNERule <: AbstractRule end
 DNERule(args...) = DNE()
 
 #####
+##### `NotImplementedRule`
+#####
+
+"""
+    NotImplementedRule <: AbstractRule
+
+Rule indicating that a particular derivative is not implemented by ChainRules.
+Note that this does not imply nondifferentiability; for that, use [`DNERule`](@ref).
+"""
+struct NotImplementedRule <: AbstractRule end
+
+NotImplementedRule(args...) = NotImplemented()
+
+#####
 ##### `WirtingerRule`
 #####
 


### PR DESCRIPTION
Sometimes you just don't implement something. Maybe it's hard, maybe you're lazy like me, whatever. For such cases, there is the differential `NotImplemented` and its associated rule `NotImplementedRule`.

This was born of not being able to figure out the rule for the scalar multiple parameter in `BLAS.gemm` (#25), but having implemented rules for the matrix parameters. As indicated by the previous paragraph, I am lazy; it is easier to add a rule that admits that to the world than it is to actually figure out how to differentiate wrt alpha.