### PR TITLE
Make work on IRTools

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,7 @@ uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
 
 [deps]
 Cassette = "7057c7e9-c182-5462-911a-8362d720325c"
+IRTools = "7869d1d1-7146-5819-86e3-90919afe41df"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 NaNMath = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"

--- a/src/ChainRules.jl
+++ b/src/ChainRules.jl
@@ -1,6 +1,7 @@
 module ChainRules
 
-using Cassette
+using IRTools: IRTools, IR, @dynamo, isexpr, xcall
+using IRTools.MacroTools: prewalk
 using LinearAlgebra
 using Base.Broadcast: materialize, materialize!, broadcasted, Broadcasted, broadcastable
 
@@ -20,4 +21,5 @@ include("rules/blas.jl")
 include("rules/nanmath.jl")
 include("rules/specialfunctions.jl")
 
+include("precompile.jl")
 end # module

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,0 +1,5 @@
+# Make sure that IRTools has precompiled
+function __init__()
+    f1, dX1 = rrule(sum, ones(4, 4));
+    dX1(f1)
+end


### PR DESCRIPTION
This swaps out Cassette for IRTools `@dynamo`.

Which was an attempt to solve #35  which it does.
Time of first call for SVD is down to about 1/4 what it was;

## Original, Cassette
3.128563 seconds (11.08 M allocations: 577.564 MiB
0.005609 seconds (2.19 k allocations: 152.170 KiB)

## No Overdubs (Best Case Senario)
0.794261 seconds (2.49 M allocations: 120.038 MiB, 7.86% gc time)
0.000015 seconds (23 allocations: 3.641 KiB)

## IRTools, with precompile.jl (This branch)
0.881375 seconds (2.98 M allocations: 146.369 MiB, 6.39% gc time)
0.000031 seconds (33 allocations: 4.188 KiB)


Note however I added the precompile.jl which makes sure that IRTools itself has been compiled before anything else. Without that it is much worse than anything else.

Next I will try that for Cassette.

Commented out is a sketch of what it should looklike without usiing `IRTools.IR`
which is close to what it should looklike without IRTools at all.
Doesn't quiet work.
Which might be nice since no IRTools dep, no need to precompile IRTools.
This is a **really** simple transform.