### PR TITLE
[WIP] Replace all uses of add and mul with + and * and define promotions etc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ notifications:
 #  - julia -e 'Pkg.clone(pwd()); Pkg.build("ChainRules"); Pkg.test("ChainRules"; coverage=true)'
 after_success:
   # push coverage results to Coveralls
-  - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
+  - julia -e 'using Pkg; Pkg.+(Coveralls.process_folder())'
 jobs:
   include:
     - state: "Documentation"

--- a/demo.jl
+++ b/demo.jl
@@ -1,0 +1,34 @@
+using Pkg: @pkg_str
+pkg"activate ."
+
+using ChainRules, LinearAlgebra
+#==
+f1, dX1 = rrule(sum, randn(4, 4));
+@time dX1(f1)
+@time dX1(f1)
+==#
+F, dX = rrule(svd, randn(4, 4));
+nt = (U=F.U, S=F.S, V=F.V);
+
+@time dX(nt)
+
+@time dX(nt)
+
+
+#=
+## Original, Cassette
+3.128563 seconds (11.08 M allocations: 577.564 MiB
+0.005609 seconds (2.19 k allocations: 152.170 KiB)
+
+# No Overdubs (Best Case Senario)
+0.794261 seconds (2.49 M allocations: 120.038 MiB, 7.86% gc time)
+0.000015 seconds (23 allocations: 3.641 KiB)
+
+# IRTools, with precompile.jl
+0.881375 seconds (2.98 M allocations: 146.369 MiB, 6.39% gc time)
+0.000031 seconds (33 allocations: 4.188 KiB)
+
+### Cassette with precompile.jl
+2.838656 seconds (11.13 M allocations: 580.525 MiB, 7.72% gc time)
+0.004810 seconds (2.19 k allocations: 152.170 KiB)
+=#

--- a/src/rules/base.jl
+++ b/src/rules/base.jl
@@ -72,7 +72,7 @@
 @scalar_rule(rem(x, y), @setup((u, nan) = promote(x / y, NaN16)),
              (ifelse(isint, nan, one(u)), ifelse(isint, nan, -trunc(u))))
 
-# product rule requires special care for arguments where `mul` is non-commutative
+# product rule requires special care for arguments where `*` is non-commutative
 
 frule(::typeof(*), x, y) = x * y, Rule((Δx, Δy) -> Δx * y + x * Δy)
 

--- a/test/differentials.jl
+++ b/test/differentials.jl
@@ -3,9 +3,9 @@
         w = Wirtinger(1+1im, 2+2im)
         @test wirtinger_primal(w) == 1+1im
         @test wirtinger_conjugate(w) == 2+2im
-        @test add_wirtinger(w, w) == Wirtinger(2+2im, 4+4im)
+        @test +(w, w) == Wirtinger(2+2im, 4+4im)
         # TODO: other add_wirtinger methods stack overflow
-        @test_throws ErrorException mul_wirtinger(w, w)
+        @test_throws ErrorException (w * w)
         @test_throws ErrorException extern(w)
         for x in w
             @test x === w
@@ -16,12 +16,12 @@
     @testset "Zero" begin
         z = Zero()
         @test extern(z) === false
-        @test add_zero(z, z) == z
-        @test add_zero(z, 1) == 1
-        @test add_zero(1, z) == 1
-        @test mul_zero(z, z) == z
-        @test mul_zero(z, 1) == z
-        @test mul_zero(1, z) == z
+        @test +(z, z) == z
+        @test +(z, 1) == 1
+        @test +(1, z) == 1
+        @test *(z, z) == z
+        @test *(z, 1) == z
+        @test *(1, z) == z
         for x in z
             @test x === z
         end
@@ -31,12 +31,12 @@
     @testset "One" begin
         o = One()
         @test extern(o) === true
-        @test add_one(o, o) == 2
-        @test add_one(o, 1) == 2
-        @test add_one(1, o) == 2
-        @test mul_one(o, o) == o
-        @test mul_one(o, 1) == 1
-        @test mul_one(1, o) == 1
+        @test +(o, o) == 2
+        @test +(o, 1) == 2
+        @test +(1, o) == 2
+        @test *(o, o) == o
+        @test *(o, 1) == 1
+        @test *(1, o) == 1
         for x in o
             @test x === o
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,8 +2,8 @@
 
 using ChainRules, Test, FDM, LinearAlgebra, Random
 using ChainRules: extern, accumulate, accumulate!, store!, @scalar_rule,
-    Wirtinger, wirtinger_primal, wirtinger_conjugate, add_wirtinger, mul_wirtinger,
-    Zero, add_zero, mul_zero, One, add_one, mul_one, Casted, cast, add_casted, mul_casted,
+    Wirtinger, wirtinger_primal, wirtinger_conjugate,
+    Zero, One, Casted, cast,
     DNE, Thunk, Casted
 using Base.Broadcast: broadcastable
 

--- a/test/test_util.jl
+++ b/test/test_util.jl
@@ -84,7 +84,7 @@ function Base.isapprox(d_ad::Thunk, d_fd; kwargs...)
 end
 
 function test_accumulation(x̄, dx, ȳ, partial)
-    @test all(extern(ChainRules.add(x̄, partial)) .== extern(x̄) .+ extern(partial))
+    @test all(extern(+(x̄, partial)) .== extern(x̄) .+ extern(partial))
     test_accumulate(x̄, dx, ȳ, partial)
     test_accumulate!(x̄, dx, ȳ, partial)
     test_store!(x̄, dx, ȳ, partial)


### PR DESCRIPTION
From @ararslan https://github.com/JuliaDiff/ChainRules.jl/pull/37#issuecomment-496666401

> According to @jrevels, the use of Cassette in this package is purely an implementation detail and could be replaced with regular ol' multiple dispatch. The reason why Jarrett didn't do that to begin with is it requires defining a fair number of methods to resolve ambiguities between the various differential types, rule types, etc. I think going that route will be a cleaner solution overall than replacing the dependency on Cassette with on one IRTools.



This is going to require so much code.
I've just done the build find and replace so far,
next comes fixing all the ambiguities.
by rewriting a bunch of it to use promotion rules etc
And deleting redundant code after that