### PR TITLE
fix `BLAS.nrm2` and `BLAS.dot`

### DIFF
--- a/src/differentials.jl
+++ b/src/differentials.jl
@@ -295,6 +295,10 @@ mul_thunk(a, b::Thunk) = mul(a, extern(b))
 ##### misc.
 #####
 
+function Wirtinger(primal::AbstractArray, conjugate::AbstractArray)
+    return Wirtinger.(primal, conjugate)
+end
+
 """
     Wirtinger(primal::Real, conjugate::Real)
 

--- a/src/rules/linalg/blas.jl
+++ b/src/rules/linalg/blas.jl
@@ -32,7 +32,7 @@ end
 function frule(::typeof(BLAS.nrm2), x)
     Ω = BLAS.nrm2(x)
     if eltype(x) <: Real
-        return Ω, Rule(ΔΩ -> ΔΩ * @thunk(x ./ Ω))
+        return Ω, Rule(Δx -> sum(Δx * cast(@thunk(x ./ Ω))))
     else
         return Ω, WirtingerRule(
             Rule(Δx -> sum(Δx * cast(@thunk(conj.(x) ./ 2Ω)))),
@@ -47,8 +47,8 @@ function rrule(::typeof(BLAS.nrm2), x)
         return Ω, Rule(ΔΩ -> ΔΩ * @thunk(x ./ Ω))
     else
         return Ω, WirtingerRule(
-            Rule(Δx -> sum(Δx * cast(@thunk(conj.(x) ./ 2Ω)))),
-            Rule(Δx -> sum(Δx * cast(@thunk(x ./ 2Ω))))
+            Rule(ΔΩ -> ΔΩ * @thunk(conj.(x) ./ 2Ω)),
+            Rule(ΔΩ -> ΔΩ * @thunk(x ./ 2Ω))
         )
     end
 end


### PR DESCRIPTION
The rules for the strided methods were completely broken. `BLAS.nrm2` now correctly returns wirtinger derivatives, if arguments are complex. I added a constructor for `Wirtinger` for arrays, which just returns an array of `Wirtinger`s in order for that to work. Still needs tests.