### PR TITLE
Allow keyword arguments in the fallback rrule/frule methods

### DIFF
--- a/src/rules.jl
+++ b/src/rules.jl
@@ -319,7 +319,7 @@ true
 
 See also: [`rrule`](@ref), [`AbstractRule`](@ref), [`@scalar_rule`](@ref)
 """
-frule(::Any, ::Vararg{Any}) = nothing
+frule(::Any, ::Vararg{Any}; kwargs...) = nothing
 
 """
     rrule(f, x...)
@@ -375,7 +375,7 @@ true
 
 See also: [`frule`](@ref), [`AbstractRule`](@ref), [`@scalar_rule`](@ref)
 """
-rrule(::Any, ::Vararg{Any}) = nothing
+rrule(::Any, ::Vararg{Any}; kwargs...) = nothing
 
 @noinline function _throw_checked_rrule_error(f, args...; kwargs...)
     io = IOBuffer()

--- a/test/rules.jl
+++ b/test/rules.jl
@@ -4,7 +4,9 @@ cool(x, y) = x + y + 1
 @testset "rules" begin
     @testset "frule and rrule" begin
         @test frule(cool, 1) === nothing
+        @test frule(cool, 1; iscool=true) === nothing
         @test rrule(cool, 1) === nothing
+        @test rrule(cool, 1; iscool=true) === nothing
         ChainRules.@scalar_rule(Main.cool(x), one(x))
         frx, fr = frule(cool, 1)
         @test frx == 2


### PR DESCRIPTION
This permits using `rrule(f, args...; kwargs...)` unconditionally and receiving `nothing` as expected rather than an error about `rrule` not taking keyword arguments.