### PR TITLE
Bring in BLAS names that are used without qualification

### DIFF
--- a/src/ChainRules.jl
+++ b/src/ChainRules.jl
@@ -2,9 +2,17 @@ module ChainRules
 
 using Cassette
 using LinearAlgebra
+using LinearAlgebra.BLAS
 using Base.Broadcast: materialize, materialize!, broadcasted, Broadcasted, broadcastable
 
-import NaNMath, SpecialFunctions, LinearAlgebra, LinearAlgebra.BLAS
+if VERSION < v"1.3.0-DEV.142"
+    # In prior versions, the BLAS submodule also exported `dot`, which caused a conflict
+    # with its parent module. To get around this, we can simply create a hard binding for
+    # the one we want to use without qualification.
+    import LinearAlgebra: dot
+end
+
+import NaNMath, SpecialFunctions
 
 export AbstractRule, Rule, frule, rrule
 

--- a/src/rules/linalg/blas.jl
+++ b/src/rules/linalg/blas.jl
@@ -4,7 +4,6 @@ package (https://github.com/invenia/DiffLinearAlgebra.jl).
 =#
 
 using LinearAlgebra: BlasFloat
-using LinearAlgebra.BLAS: gemm
 
 _zeros(x) = fill!(similar(x), zero(eltype(x)))
 


### PR DESCRIPTION
Currently some of the rules are calling `blascopy!` and `scal!` without qualification, which fails, since we haven't done a full `using` for the BLAS submodule. (We can do that later, but currently there's an export
conflict with LinearAlgebra itself.) So for now we can just selectively use the names.