### PR TITLE
Restrict the scalar multiplication rules to `Number`s

### DIFF
--- a/src/rulesets/Base/base.jl
+++ b/src/rulesets/Base/base.jl
@@ -74,9 +74,9 @@
 
 # product rule requires special care for arguments where `mul` is non-commutative
 
-frule(::typeof(*), x, y) = x * y, Rule((Δx, Δy) -> Δx * y + x * Δy)
+frule(::typeof(*), x::Number, y::Number) = x * y, Rule((Δx, Δy) -> Δx * y + x * Δy)
 
-rrule(::typeof(*), x, y) = x * y, (Rule(ΔΩ -> ΔΩ * y'), Rule(ΔΩ -> x' * ΔΩ))
+rrule(::typeof(*), x::Number, y::Number) = x * y, (Rule(ΔΩ -> ΔΩ * y'), Rule(ΔΩ -> x' * ΔΩ))
 
 frule(::typeof(identity), x) = x, Rule(identity)
 


### PR DESCRIPTION
Before this, e.g. `frule(*, [1,2], Dual(1))` would return a non-nothing. This change helps avoid special casing this in a generic implementation of scalar diff.