### PR TITLE
add rules for constant returning zero and one function

### DIFF
--- a/src/rulesets/Base/base.jl
+++ b/src/rulesets/Base/base.jl
@@ -1,3 +1,5 @@
+@scalar_rule(one(x), Zero())
+@scalar_rule(zero(x), Zero())
 @scalar_rule(abs2(x), Wirtinger(x', x))
 @scalar_rule(log(x), inv(x))
 @scalar_rule(log10(x), inv(x) / log(oftype(x, 10)))

--- a/test/rulesets/Base/base.jl
+++ b/test/rulesets/Base/base.jl
@@ -112,7 +112,7 @@ end
 
             y, rule = rrule(f, x)
             @test y == expected
-            @test extern(rule(1))==0.0
+            @test extern(rule(1)) == 0.0
         end
         test_constant(one, 5, 1)
         test_constant(one, -4.1, 1)

--- a/test/rulesets/Base/base.jl
+++ b/test/rulesets/Base/base.jl
@@ -103,5 +103,22 @@ end
         rrule_test(identity, randn(rng), (randn(rng), randn(rng)))
         rrule_test(identity, randn(rng, 4), (randn(rng, 4), randn(rng, 4)))
     end
+
+    @testset "Constants" begin
+        function test_constant(f, x, expected)
+            y, rule = frule(f, x)
+            @test y == expected
+            @test extern(rule(1))==0.0
+
+            y, rule = rrule(f, x)
+            @test y == expected
+            @test extern(rule(1))==0.0
+        end
+        test_constant(one, 5, 1)
+        test_constant(one, -4.1, 1)
+
+        test_constant(zero, 5, 0)
+        test_constant(zero, -4.1, 0)
+    end
 end
 # TODO: Non-trig stuff

--- a/test/rulesets/Base/base.jl
+++ b/test/rulesets/Base/base.jl
@@ -108,7 +108,7 @@ end
         function test_constant(f, x, expected)
             y, rule = frule(f, x)
             @test y == expected
-            @test extern(rule(1))==0.0
+            @test extern(rule(1)) == 0.0
 
             y, rule = rrule(f, x)
             @test y == expected


### PR DESCRIPTION
Is this right?
Should I have some type constraints somewhere 
or does `@scalar_rule` give me that for free?