### PR TITLE
Fix documentation to use ChainRulesCore

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,5 +1,7 @@
 [deps]
+ChainRules = "082447d4-558c-5d27-93f4-14fc19e9eca2"
+ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 
 [compat]
-Documenter = "~0.22"
+Documenter = "~0.23"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,11 +1,17 @@
 using ChainRules
+using ChainRulesCore
 using Documenter
 
-makedocs(modules=[ChainRules],
-         sitename="ChainRules",
-         authors="Jarrett Revels and other contributors",
-         pages=["Introduction" => "index.md",
-                "Getting Started" => "getting_started.md",
-                "ChainRules API Documentation" => "api.md"])
+makedocs(
+    modules=[ChainRules, ChainRulesCore],
+    format=Documenter.HTML(prettyurls=false),
+    sitename="ChainRules",
+    authors="Jarrett Revels and other contributors",
+    pages=[
+        "Introduction" => "index.md",
+        "Getting Started" => "getting_started.md",
+        "API" => "api.md",
+    ],
+)
 
 deploydocs(repo="github.com/JuliaDiff/ChainRules.jl.git")

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,24 +1,5 @@
-# ChainRules API Documentation
+# API Documentation
 
-```@docs
-ChainRules.frule
-ChainRules.rrule
-ChainRules.AbstractRule
-ChainRules.Rule
-ChainRules.DNERule
-ChainRules.WirtingerRule
-ChainRules.accumulate
-ChainRules.accumulate!
-ChainRules.store!
-```
-
-```@docs
-ChainRules.AbstractDifferential
-ChainRules.extern
-ChainRules.Casted
-ChainRules.Wirtinger
-ChainRules.Thunk
-ChainRules.Zero
-ChainRules.DNE
-ChainRules.One
+```@autodocs
+Modules = [ChainRulesCore, ChainRules]
 ```

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,5 +1,5 @@
 # API Documentation
 
 ```@autodocs
-Modules = [ChainRulesCore, ChainRules]
+Modules = [ChainRulesCore]
 ```

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -4,7 +4,7 @@
 It only depends on [Cassette.jl](https://github.com/jrevels/Cassette.jl) which is also light-weight and has no dependencies.
 
 [ChainRules.jl](https://github.com/JuliaDiff/ChainRules.jl) provides the full functionality, including sensitivities for Base Julia and standard libraries.
-Sensitivities for some other packages, currently SpecialFunctions.jl and NanMath.jl, will also be loaded if those packages are in your environment.
+Sensitivities for some other packages, currently SpecialFunctions.jl and NaNMath.jl, will also be loaded if those packages are in your environment.
 In general, we recommend adding custom sensitivities to your own packages with ChainRulesCore.
 
 ## Defining Custom Sensitivities

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -1,8 +1,11 @@
 # Getting Started
 
 [ChainRulesCore.jl](https://github.com/JuliaDiff/ChainRulesCore.jl) is a light-weight dependency for defining sensitivities for functions in your packages, without you needing to depend on ChainRules itself.
+It only depends on [Cassette.jl](https://github.com/jrevels/Cassette.jl) which is also light-weight and has no dependencies.
 
 [ChainRules.jl](https://github.com/JuliaDiff/ChainRules.jl) provides the full functionality, including sensitivities for Base Julia and standard libraries.
+Sensitivities for some other packages, currently SpecialFunctions.jl and NanMath.jl, will also be loaded if those packages are in your environment.
+In general, we recommend adding custom sensitivities to your own packages with ChainRulesCore.
 
 ## Defining Custom Sensitivities
 

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -1,5 +1,13 @@
 # Getting Started
 
+[ChainRulesCore.jl](https://github.com/JuliaDiff/ChainRulesCore.jl) is a light-weight dependency for defining sensitivities for functions in your packages, without you needing to depend on ChainRules itself.
+
+[ChainRules.jl](https://github.com/JuliaDiff/ChainRules.jl) provides the full functionality, including sensitivities for Base Julia and standard libraries.
+
+## Defining Custom Sensitivities
+
+TODO
+
 ## Forward-Mode vs. Reverse-Mode Chain Rule Evaluation
 
 TODO

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,10 +1,9 @@
 ```@meta
-DocTestSetup = :(using ChainRules)
-CurrentModule = ChainRules
+DocTestSetup = :(using ChainRulesCore, ChainRules)
 ```
 
 # ChainRules
 
-Hello! Welcome to ChainRules's documentation.
+[ChainRules.jl](https://github.com/JuliaDiff/ChainRules.jl) provides a variety of common utilities that can be used by downstream automatic differentiation (AD) tools to define and execute forward-, reverse-, and mixed-mode primitives.
 
-For an initial overview of ChainRules, please see the README. Otherwise, feel free to peruse available documentation via the sidebar.
+This package is a work-in-progress, as is the documentation. Contributions welcome!

--- a/src/ChainRules.jl
+++ b/src/ChainRules.jl
@@ -2,13 +2,12 @@ module ChainRules
 using Reexport
 @reexport using ChainRulesCore
 # Basically everything this package does is overloading these, so we make an exception
-# to the normal rule of only overload via `AbstractChainRules.rrule`.
+# to the normal rule of only overload via `ChainRulesCore.rrule`.
 import ChainRulesCore: rrule, frule
 
 # Deal with name clashes, by defining in this module which one we mean.
 const accumulate = ChainRulesCore.accumulate
 const accumulate! = ChainRulesCore.accumulate!
-
 
 using LinearAlgebra
 using LinearAlgebra.BLAS


### PR DESCRIPTION
1. Right now the API docs don't render because `ChainRules.foo` has been moved to `ChainRulesCore.foo`
2. This PR essentially means we have a single set of docs for ChainRules and ChainRules core (https://github.com/JuliaDiff/ChainRulesCore.jl/issues/12)

Before:
![image](https://user-images.githubusercontent.com/13448787/62833334-07b37200-bc35-11e9-8220-c4dcb3b49b81.png)

After:
![image](https://user-images.githubusercontent.com/13448787/62833345-26196d80-bc35-11e9-943c-11355d8b0b13.png)
