### PR TITLE
Remove uses of add and mul from tests because they have been removed ChainRulesCore

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-ChainRulesCore = "^0.1"
+ChainRulesCore = "^0.2"
 FiniteDifferences = "^0.7"
 julia = "^1.0"
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -1,11 +1,11 @@
 # Getting Started
 
-[ChainRulesCore.jl](https://github.com/JuliaDiff/ChainRulesCore.jl) is a light-weight dependency for defining sensitivities for functions in your packages, without you needing to depend on ChainRules itself.
-It only depends on [Cassette.jl](https://github.com/jrevels/Cassette.jl) which is also light-weight and has no dependencies.
+[ChainRulesCore.jl](https://github.com/JuliaDiff/ChainRulesCore.jl) is a light-weight dependency for defining sensitivities for functions in your packages, without you needing to depend on ChainRules itself. It has no dependencies of its own.
 
 [ChainRules.jl](https://github.com/JuliaDiff/ChainRules.jl) provides the full functionality, including sensitivities for Base Julia and standard libraries.
 Sensitivities for some other packages, currently SpecialFunctions.jl and NaNMath.jl, will also be loaded if those packages are in your environment.
-In general, we recommend adding custom sensitivities to your own packages with ChainRulesCore.
+In general, we recommend adding custom sensitivities to your own packages with ChainRulesCore, rather than adding them to ChainRules.jl.
+
 
 ## Defining Custom Sensitivities
 

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -6,7 +6,6 @@
 Sensitivities for some other packages, currently SpecialFunctions.jl and NaNMath.jl, will also be loaded if those packages are in your environment.
 In general, we recommend adding custom sensitivities to your own packages with ChainRulesCore, rather than adding them to ChainRules.jl.
 
-
 ## Defining Custom Sensitivities
 
 TODO

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,10 +10,9 @@ using Statistics
 using Test
 
 # For testing purposes we use a lot of
-using ChainRulesCore: add, cast, extern, accumulate, accumulate!, store!, @scalar_rule,
-    Wirtinger, wirtinger_primal, wirtinger_conjugate, add_wirtinger, mul_wirtinger,
-    Zero, add_zero, mul_zero, One, add_one, mul_one, Casted, cast, add_casted, mul_casted,
-    DNE, Thunk, Casted, DNERule
+using ChainRulesCore: cast, extern, accumulate, accumulate!, store!, @scalar_rule,
+    Wirtinger, wirtinger_primal, wirtinger_conjugate,
+    Zero, One, Casted, DNE, Thunk, DNERule
 
 include("test_util.jl")
 

--- a/test/test_util.jl
+++ b/test/test_util.jl
@@ -149,7 +149,7 @@ function Base.isapprox(d_ad::Thunk, d_fd; kwargs...)
 end
 
 function test_accumulation(x̄, dx, ȳ, partial)
-    @test all(extern(add(x̄, partial)) .≈ extern(x̄) .+ extern(partial))
+    @test all(extern(x̄ + partial) .≈ extern(x̄) .+ extern(partial))
     test_accumulate(x̄, dx, ȳ, partial)
     test_accumulate!(x̄, dx, ȳ, partial)
     test_store!(x̄, dx, ȳ, partial)


### PR DESCRIPTION
We access some of the internals of ChainRulesCore for testing purposes.

This changes that over to match the changes in
https://github.com/JuliaDiff/ChainRulesCore.jl/pull/35

That PR has to be merged first.

I have tested these together and they do work together.
Passing all tests.