### PR TITLE
Fix rules for `*`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 ChainRulesCore = "^0.2"
-FiniteDifferences = "^0.7"
+FiniteDifferences = "^0.7.2"
 julia = "^1.0"
 
 [extras]

--- a/src/rulesets/Base/base.jl
+++ b/src/rulesets/Base/base.jl
@@ -102,7 +102,7 @@
 
 frule(::typeof(*), x::Number, y::Number) = x * y, Rule((Δx, Δy) -> Δx * y + x * Δy)
 
-rrule(::typeof(*), x::Number, y::Number) = x * y, (Rule(ΔΩ -> ΔΩ * y'), Rule(ΔΩ -> x' * ΔΩ))
+rrule(::typeof(*), x::Number, y::Number) = x * y, (Rule(ΔΩ -> ΔΩ * y), Rule(ΔΩ -> x * ΔΩ))
 
 frule(::typeof(identity), x) = x, Rule(identity)
 

--- a/src/rulesets/LinearAlgebra/dense.jl
+++ b/src/rulesets/LinearAlgebra/dense.jl
@@ -72,8 +72,28 @@ rrule(::typeof(tr), x) = (tr(x), Rule(ΔΩ -> Diagonal(fill(ΔΩ, size(x, 1)))))
 ##### `*`
 #####
 
-function rrule(::typeof(*), A::AbstractMatrix{<:Real}, B::AbstractMatrix{<:Real})
-    return A * B, (Rule(Ȳ -> Ȳ * B'), Rule(Ȳ -> A' * Ȳ))
+function frule(
+               ::typeof(*),
+               A::Union{Number,AbstractMatrix{<:Number}},
+               B::Union{Number,AbstractVecOrMat{<:Number}}
+              )
+    return A * B, Rule((Ẋ, Ẏ) -> Ẋ * B + A * Ẏ)
+end
+
+function frule(::typeof(*), A::AbstractVector{<:Number}, B::Number)
+    return A * B, Rule((Ẋ, Ẏ) -> Ẋ * B + A * Ẏ)
+end
+
+function rrule(
+               ::typeof(*),
+               A::Union{Number,AbstractMatrix{<:Number}},
+               B::Union{Number,AbstractVecOrMat{<:Number}}
+              )
+    return A * B, (Rule(Ȳ -> Ȳ * transpose(B)), Rule(Ȳ -> transpose(A) * Ȳ))
+end
+
+function rrule(::typeof(*), A::AbstractVector{<:Number}, B::Number)
+    return A * B, (Rule(Ȳ -> Ȳ * transpose(B)), Rule(Ȳ -> transpose(A) * Ȳ))
 end
 
 #####

--- a/src/rulesets/LinearAlgebra/dense.jl
+++ b/src/rulesets/LinearAlgebra/dense.jl
@@ -80,7 +80,11 @@ function frule(
     return A * B, Rule((Ẋ, Ẏ) -> Ẋ * B + A * Ẏ)
 end
 
-function frule(::typeof(*), A::AbstractVector{<:Number}, B::Number)
+function frule(
+               ::typeof(*),
+               A::AbstractVector{<:Number},
+               B::Union{Number,AbstractMatrix{<:Number}}
+              )
     return A * B, Rule((Ẋ, Ẏ) -> Ẋ * B + A * Ẏ)
 end
 
@@ -89,11 +93,15 @@ function rrule(
                A::Union{Number,AbstractMatrix{<:Number}},
                B::Union{Number,AbstractVecOrMat{<:Number}}
               )
-    return A * B, (Rule(Ȳ -> Ȳ * transpose(B)), Rule(Ȳ -> transpose(A) * Ȳ))
+    return A * B, (Rule(X̄ -> X̄ * transpose(B)), Rule(Ȳ -> transpose(A) * Ȳ))
 end
 
-function rrule(::typeof(*), A::AbstractVector{<:Number}, B::Number)
-    return A * B, (Rule(Ȳ -> Ȳ * transpose(B)), Rule(Ȳ -> transpose(A) * Ȳ))
+function rrule(
+               ::typeof(*),
+               A::AbstractVector{<:Number},
+               B::Union{Number,AbstractMatrix{<:Number}}
+              )
+    return A * B, (Rule(X̄ -> X̄ * transpose(B)), Rule(Ȳ -> transpose(A) * Ȳ))
 end
 
 #####

--- a/test/rulesets/LinearAlgebra/dense.jl
+++ b/test/rulesets/LinearAlgebra/dense.jl
@@ -58,10 +58,12 @@ end
         dims = [3,4,5]
         for n in dims, m in dims, p in dims
             n > 3 && n == m == p && continue  # don't need to test square case multiple times
-            A = randn(rng, m, n)
-            B = randn(rng, n, p)
-            Ȳ = randn(rng, m, p)
-            rrule_test(*, Ȳ, (A, randn(rng, m, n)), (B, randn(rng, n, p)))
+            for T in (Float64, ComplexF64)
+                A = randn(rng, T, m, n)
+                B = randn(rng, T, n, p)
+                Ȳ = randn(rng, T, m, p)
+                rrule_test(*, Ȳ, (A, randn(rng, T, m, n)), (B, randn(rng, T, n, p)))
+            end
         end
     end
     @testset "$f" for f in [/, \]


### PR DESCRIPTION
Our derivatives for multiplication are wrong for complex numbers. This also adds `rrule` and `frule` for multiplication of matrices with scalars or vectors and for scalar-vector. Still needs more tests.