### PR TITLE
Add rrule for Diagonal * AbstractVector

### DIFF
--- a/src/rulesets/LinearAlgebra/structured.jl
+++ b/src/rulesets/LinearAlgebra/structured.jl
@@ -21,9 +21,9 @@ end
 
 function rrule(::typeof(*), D::Diagonal{<:Real}, V::AbstractVector{<:Real})
     function times_pullback(Ȳ)
-        return (NO_FIELDS, @thunk(Diagonal(Ȳ .* V)), @thunk(D.diag .* Ȳ))
+        return (NO_FIELDS, @thunk(Diagonal(Ȳ .* V)), @thunk(D * Ȳ))
     end
-    return D.diag .* V, times_pullback
+    return D * V, times_pullback
 end
 
 #####

--- a/src/rulesets/LinearAlgebra/structured.jl
+++ b/src/rulesets/LinearAlgebra/structured.jl
@@ -19,6 +19,13 @@ function rrule(::typeof(diag), A::AbstractMatrix)
     return diag(A), diag_pullback
 end
 
+function rrule(::typeof(*), D::Diagonal{<:Real}, V::AbstractVector{<:Real})
+    function times_pullback(Ȳ)
+        return (NO_FIELDS, @thunk(Diagonal(Ȳ .* V)), @thunk(D.diag .* Ȳ))
+    end
+    return D.diag .* V, times_pullback
+end
+
 #####
 ##### `Symmetric`
 #####

--- a/test/rulesets/LinearAlgebra/structured.jl
+++ b/test/rulesets/LinearAlgebra/structured.jl
@@ -7,6 +7,12 @@
         # Concrete type instead of UnionAll
         rrule_test(typeof(D), D, (randn(rng, N), randn(rng, N)))
     end
+    @testset "::Diagonal * ::AbstractVector" begin
+        rng, N = MersenneTwister(123456), 3
+        rrule_test(*, randn(rng, N),
+                   (Diagonal(randn(rng, N)), Diagonal(randn(rng, N))),
+                   (randn(rng, N), randn(rng, N)))
+    end
     @testset "diag" begin
         rng, N = MersenneTwister(123456), 7
         rrule_test(diag, randn(rng, N), (randn(rng, N, N), randn(rng, N, N)))

--- a/test/rulesets/LinearAlgebra/structured.jl
+++ b/test/rulesets/LinearAlgebra/structured.jl
@@ -9,9 +9,12 @@
     end
     @testset "::Diagonal * ::AbstractVector" begin
         rng, N = MersenneTwister(123456), 3
-        rrule_test(*, randn(rng, N),
-                   (Diagonal(randn(rng, N)), Diagonal(randn(rng, N))),
-                   (randn(rng, N), randn(rng, N)))
+        rrule_test(
+            *,
+            randn(rng, N),
+            (Diagonal(randn(rng, N)), Diagonal(randn(rng, N))),
+            (randn(rng, N), randn(rng, N)),
+        )
     end
     @testset "diag" begin
         rng, N = MersenneTwister(123456), 7


### PR DESCRIPTION
ref https://github.com/JuliaDiff/ChainRules.jl/issues/52#issuecomment-531146406

Reading #103 and other source code, I suppose we are only defining `rrule`s for `Real` element types at the moment so didn't put `adjoint` in the definition. (By the way, if that's the case, I think it makes sense to mention it in #103.)