### PR TITLE
WIP: support SpecialFunctions 0.8 and 0.7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.2.1"
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"

--- a/src/ChainRules.jl
+++ b/src/ChainRules.jl
@@ -12,6 +12,7 @@ const accumulate! = ChainRulesCore.accumulate!
 using LinearAlgebra
 using LinearAlgebra.BLAS
 using Requires
+using Pkg: Pkg
 using Statistics
 using Base.Broadcast: materialize, materialize!, broadcasted, Broadcasted, broadcastable
 
@@ -22,6 +23,7 @@ if VERSION < v"1.3.0-DEV.142"
     import LinearAlgebra: dot
 end
 
+include("glue_utils.jl")
 include("helper_functions.jl")
 
 include("rulesets/Base/base.jl")

--- a/src/glue_utils.jl
+++ b/src/glue_utils.jl
@@ -50,14 +50,7 @@ elseif VERSION ∈ version_spec"~1.1"
         pkg_info = Pkg.Types.manifest_info(env, pkg_id.uuid)
         return VersionNumber(pkg_info.version)
     end
-elseif VERSION ∈ version_spec"~1.2"
-    function pkg_version(_module::Module)
-        pkg_id = Base.PkgId(_module)
-        env = Pkg.Types.Context().env
-        pkg_info = Pkg.Types.manifest_info(env, pkg_id.uuid)
-        return pkg_info.version
-    end
-elseif VERSION ∈ version_spec"~1.3"
+elseif VERSION ∈ version_spec"~1.2, ~1.3"
     function pkg_version(_module::Module)
         pkg_id = Base.PkgId(_module)
         env = Pkg.Types.Context().env

--- a/src/glue_utils.jl
+++ b/src/glue_utils.jl
@@ -1,0 +1,74 @@
+"""
+    @version_spec_str(str::String)
+
+Returns a `VersionSpec` object which represents the range of compatible verions,
+for a given Pkg3 style semver compat specifier.
+
+Example:
+```jldoctest
+julia> v"2.0.1" ∈ ChainRules.version_spec"1.2"
+false
+
+julia> v"1.5.1" ∈ ChainRules.version_spec"1.2"
+true
+
+julia> v"2.0.1" ∈ ChainRules.version_spec"1, 2"
+true
+
+julia> v"1.0.1" ∈ ChainRules.version_spec"1, 2"
+true
+
+julia> v"1.3.0" ∈ ChainRules.version_spec"~1.0, ~1.1"
+false
+
+julia> v"1.1.2" ∈ ChainRules.version_spec"~1.0, ~1.1"
+true
+"""
+macro version_spec_str(str::String)
+    return Pkg.Types.semver_spec(str)
+end
+
+"""
+    pkg_version(_module::Module)
+
+Returns the version of the package that defined a given module.
+Does not work on the current module, or on standard libraries
+"""
+pkg_version(_module::Module)
+
+@static if VERSION ∈ version_spec"~1.0"
+    function pkg_version(_module::Module)
+        pkg_id = Base.PkgId(_module)
+        env = Pkg.Types.Context().env
+        pkg_info = Pkg.Types.manifest_info(env, pkg_id.uuid)
+        return VersionNumber(pkg_info["version"])
+    end
+elseif VERSION ∈ version_spec"~1.1"
+    function pkg_version(_module::Module)
+        pkg_id = Base.PkgId(_module)
+        env = Pkg.Types.Context().env
+        pkg_info = Pkg.Types.manifest_info(env, pkg_id.uuid)
+        return VersionNumber(pkg_info.version)
+    end
+elseif VERSION ∈ version_spec"~1.2"
+    function pkg_version(_module::Module)
+        pkg_id = Base.PkgId(_module)
+        env = Pkg.Types.Context().env
+        pkg_info = Pkg.Types.manifest_info(env, pkg_id.uuid)
+        return pkg_info.version
+    end
+elseif VERSION ∈ version_spec"~1.3"
+    function pkg_version(_module::Module)
+        pkg_id = Base.PkgId(_module)
+        env = Pkg.Types.Context().env
+        pkg_info = Pkg.Types.manifest_info(env, pkg_id.uuid)
+        return pkg_info.version
+    end
+else  # tested in 1.4.0-DEV.265
+    function pkg_version(_module::Module)
+        pkg_id = Base.PkgId(_module)
+        ctx = Pkg.Types.Context()
+        pkg_info = Pkg.Types.manifest_info(ctx, pkg_id.uuid)
+        return pkg_info.version
+    end
+end

--- a/src/rulesets/packages/SpecialFunctions.jl
+++ b/src/rulesets/packages/SpecialFunctions.jl
@@ -3,7 +3,6 @@ using ChainRulesCore
 using ..SpecialFunctions
 
 
-@scalar_rule(SpecialFunctions.lgamma(x), SpecialFunctions.digamma(x))
 @scalar_rule(SpecialFunctions.erf(x), (2 / sqrt(π)) * exp(-x * x))
 @scalar_rule(SpecialFunctions.erfc(x), -(2 / sqrt(π)) * exp(-x * x))
 @scalar_rule(SpecialFunctions.erfi(x), (2 / sqrt(π)) * exp(x * x))
@@ -23,5 +22,11 @@ using ..SpecialFunctions
 @scalar_rule(SpecialFunctions.erfcinv(x), -(sqrt(π) / 2) * exp(Ω^2))
 @scalar_rule(SpecialFunctions.erfcx(x), (2 * x * Ω) - (2 / sqrt(π)))
 @scalar_rule(SpecialFunctions.dawson(x), 1 - (2 * x * Ω))
+
+@static if pkg_version(SpecialFunctions) < v"0.8"
+    @scalar_rule(SpecialFunctions.lgamma(x), SpecialFunctions.digamma(x))
+else
+    @scalar_rule(SpecialFunctions.loggamma(x), SpecialFunctions.digamma(x))
+end
 
 end #module

--- a/test/glue_utils.jl
+++ b/test/glue_utils.jl
@@ -1,0 +1,4 @@
+@testset "Package version checking" begin
+    # This test needs to be updated when we allow a new version of ChainRulesCore
+    @test ChainRules.pkg_version(ChainRulesCore) ∈ ChainRules.version_spec"0.3"
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,6 +18,8 @@ include("test_util.jl")
 
 println("Testing ChainRules.jl")
 @testset "ChainRules" begin
+    include("glue_utils.jl")
+    exit()
     include("helper_functions.jl")
     @testset "rulesets" begin
         @testset "Base" begin


### PR DESCRIPTION
When done will close #118 
it basically requires solving https://github.com/MikeInnes/Requires.jl/issues/3

Right now this just contains the tooling for how to findout package versions and a single example of using it.
Cross-ref: 

TODO:
 - [ ]Go through and split up deprecations https://github.com/JuliaMath/SpecialFunctions.jl/blob/master/src/deprecated.jl
 - [ ] split-up tests across the versions
 - [ ] decide what to do for as yet unreleased breaking version of SpecialFunctions.jl, (maybe a Warning and then not load any rules?)

Maybe there is a better way.
Ideally from ChainRules perspective would just put the rules into SpecialFunctions.jl
and then they would always be the right version.
However @ararslan as a maintainer of SpecialFunctions.jl makes the reasonable argument that the SpecialFunctions.jl maintainers should not be obliged to take on responsibility for maintaining the derivatives of the SpecialFunctions.
Particularly while ChainRules is still in alpha.