### PR TITLE
remove old atan2 tests

### DIFF
--- a/test/rulesets/Base/base.jl
+++ b/test/rulesets/Base/base.jl
@@ -51,32 +51,13 @@
             test_scalar(acscd, 1/x)
             test_scalar(acotd, 1/x)
         end
-        @testset "Multivariate" begin
-            @testset "atan2" begin
-                # https://en.wikipedia.org/wiki/Atan2
-                x, y = rand(2)
-                ratan = atan(x, y)
-                u = x^2 + y^2
-                datan = y/u - 2x/u
+        
+        @testset "sincos" begin
+            x, Δx, x̄ = randn(3)
+            Δz = (randn(), randn())
 
-                r, pushforward = frule(atan, x, y)
-                @test r === ratan
-                @test pushforward(NamedTuple(), 1, 2) === datan
-
-                r, pullback = rrule(atan, x, y)
-                @test r === ratan
-                dself, df1, df2 = pullback(1)
-                @test dself == NO_FIELDS
-                @test df1 + 2df2 === datan
-            end
-
-            @testset "sincos" begin
-                x, Δx, x̄ = randn(3)
-                Δz = (randn(), randn())
-
-                frule_test(sincos, (x, Δx))
-                rrule_test(sincos, Δz, (x, x̄))
-            end
+            frule_test(sincos, (x, Δx))
+            rrule_test(sincos, Δz, (x, x̄))
         end
     end  # Trig
 


### PR DESCRIPTION
I think when we switch `atan2` tests to use `frule_test` and `rrule_test` we forgot to delete the old bad tests.

I think this is now tested well using 
https://github.com/JuliaDiff/ChainRules.jl/blob/3e6eee3228cf7b1be2ce35c4ddc87ca5a65b0a60/test/rulesets/Base/base.jl#L140-L148