### PR TITLE
Doc updates for ChainRulesCore 0.5

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -42,7 +42,7 @@ computing `foo(x)` is doing the _primal_ computation.
     Their exact functioning is fairly ChainRules specific, though other tools have similar functions.
     The core notion is sometimes called _custom AD primitives_, _custom adjoints_, _custom_gradients_, _custom sensitivities_.
 
-The rules are encoded as `rrule`s and `frule`s, for use in forward-mode and reverse-mode differentiation respectively.
+The rules are encoded as `frule`s and `rrule`s, for use in forward-mode and reverse-mode differentiation respectively.
 
 The `rrule` for some function `foo`, which takes the positional arguments `args` and keyword arguments `kwargs`, is written:
 
@@ -52,7 +52,7 @@ function rrule(::typeof(foo), args...; kwargs...)
     return y, pullback
 end
 ```
-Where `y` (the primal result) must be equal to `foo(args...; kwargs...)`.
+where `y` (the primal result) must be equal to `foo(args...; kwargs...)`.
 `pullback` is a function to propagate the derivative information backwards at that point.
 That pullback function is used like:
 `∂self, ∂args... = pullback(Δy)`
@@ -238,7 +238,7 @@ Similarly every `pullback` returns an extra `∂self`, which for things without 
 
 The most trivial use of the `pushforward` from within `frule` is to calculate the directional derivative:
 
-If we would like to know the the directional derivative of `f` for an input chage of `(1.5, 0.4, -1)`
+If we would like to know the the directional derivative of `f` for an input change of `(1.5, 0.4, -1)`
 
 ```julia
 direction = (1.5, 0.4, -1) # (ȧ, ḃ, ċ)
@@ -279,7 +279,7 @@ The most important `AbstractDifferential`s when getting started are the ones abo
 
 #### Other `AbstractDifferential`s:
  - `Composite{P}`: this is the differential for tuples and  structs. Use it like a `Tuple` or `NamedTuple`. The type parameter `P` is for the primal type.
- - `DoesNotExist`: Zero-like, represents that the operation on this input is not differentiable. Its primal type is normally integer or boolean.
+ - `DoesNotExist`: Zero-like, represents that the operation on this input is not differentiable. Its primal type is normally `Integer` or `Bool`.
  - `InplaceableThunk`: it is like a Thunk but it can do `store!` and `accumulate!` in-place.
 
  -------------------------------

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -56,7 +56,6 @@ where `y` (the primal result) must be equal to `foo(args...; kwargs...)`.
 `pullback` is a function to propagate the derivative information backwards at that point.
 That pullback function is used like:
 `∂self, ∂args... = pullback(Δy)`
-function takes arguments;:  (more later).
 
 
 Almost always the _pullback_ will be declared locally within the `rrule`, and will be a _closure_ over some of the other arguments, and potentially over the primal result too.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -438,7 +438,7 @@ It is very easy to check gradients or derivatives with a computer algebra system
 
 #### `Δx`, `∂x`, `dx`
 ChainRules uses these perhaps atyptically.
-As a notation that is the same across propagators, regardless of direction. (Incontrast see `ẋ` and `x̄` below)
+As a notation that is the same across propagators, regardless of direction (incontrast see `ẋ` and `x̄` below).
 
  - `Δx` is the input to a propagator, (i.e a _seed_ for a _pullback_; or a _perturbation_ for a _pushforward_)
  - `∂x` is the output of a propagator

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -77,7 +77,7 @@ One could think of writing `∂Y = pushforward(Δself, Δargs)`, and often we wi
     While `rrule` takes only the arguments to the original function (the primal arguments) and returns a function (the pullback) that operates with the derivative information, the `frule` does it all at once.
     This is because the `frule` fuses the primal computation and the pushforward.
     This is an optimization that allows `frule`s to contain single large operations that perform both the primal computation and the pushforward at the same time (for example solving an ODE).
-    This operation is only possible in forward mode (where `frule` is used) because the derivative information the pushforward available with the `frule` is invoked -- it is about the primal function's input.
+This operation is only possible in forward mode (where `frule` is used) because the derivative information needed by the pushforward available with the `frule` is invoked -- it is about the primal function's inputs.
     In contrast, in reverse mode the derivative information needed by the pullback is about the primal function's output.
     Thus the reverse mode returns the pullback function which the caller (usually an AD system) keeps hold of until derivative information about the output is available.
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -278,7 +278,7 @@ The most important `AbstractDifferential`s when getting started are the ones abo
  - `One`, `Zero`: There are special representations of `1` and `0`. They do great things around avoiding expanding `Thunks` in multiplication and (for `Zero`) addition.
 
 #### Other `AbstractDifferential`s:
- - `Composite{P}`: this is the differential for tuples and  structs. Use it like a tuple or named tuple. The type parameter `P` is for the primal type.
+ - `Composite{P}`: this is the differential for tuples and  structs. Use it like a `Tuple` or `NamedTuple`. The type parameter `P` is for the primal type.
  - `DoesNotExist`: Zero-like, represents that the operation on this input is not differentiable. Its primal type is normally integer or boolean.
  - `InplaceableThunk`: it is like a Thunk but it can do `store!` and `accumulate!` in-place.
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -25,7 +25,7 @@ Knowing rules for more complicated functions speeds up the autodiff process as i
     Internally ChainRules tries to be consistent.
     Help with that is always welcomed.
 
-!!! terminology Primal
+!!! terminology "Primal"
 Often we will talk about something as _primal_.
 That means it is related to the original problem, not its derivative.
 For example for `y = foo(x)`
@@ -44,22 +44,22 @@ computing `foo(x)` is doing the _primal_ computation.
 
 The rules are encoded as `rrule`s and `frule`s, for use in forward-mode and reverse-mode differentiation respectively.
 
-The `rrule` for some function `foo`, which takes the positional argument `args` and keyword argument `kwargs`, is written:
+The `rrule` for some function `foo`, which takes the positional arguments `args` and keyword arguments `kwargs`, is written:
 
 ```julia
-function rrule(::typeof(foo), args; kwargs...)
+function rrule(::typeof(foo), args...; kwargs...)
     ...
     return y, pullback
 end
 ```
-Where `y` (the primal result) must be equal to `foo(args; kwargs...)`
+Where `y` (the primal result) must be equal to `foo(args...; kwargs...)`.
 `pullback` is a function to propagate the derivative information backwards at that point.
-That pullback function is used:
+That pullback function is used like:
 `∂self, ∂args... = pullback(Δy)`
 function takes arguments;:  (more later).
 
 
-Almost always the _pullback_ will be declared locally within the `rrule`, and will be a _closure_ over some of the other arguments, and potential the (primal) result.
+Almost always the _pullback_ will be declared locally within the `rrule`, and will be a _closure_ over some of the other arguments, and potentially over the primal result too.
 
 The `frule` is written:
 ```julia
@@ -71,15 +71,15 @@ end
 where again `y = foo(args; kwargs...)`,
 and `∂Y` is the result of propagating the derivative information forwards at that point.
 This propagation is call the pushforward.
-One could think of writing `∂Y = pushforward(Δself, Δargs)`, and often we will think of the `frule` as having the primal computation (`y = foo(args; kwargs...)`), and the push-forward (`∂Y = pushforward(Δself, Δargs)`)
+One could think of writing `∂Y = pushforward(Δself, Δargs)`, and often we will think of the `frule` as having the primal computation `y = foo(args...; kwargs...)`, and the push-forward `∂Y = pushforward(Δself, Δargs...)`
 
 
-!!! note Why rrule returns a pullback but frule doesn't return a pushforward
+!!! note "Why `rrule` returns a pullback but `frule` doesn't return a pushforward"
     While `rrule` takes only the arguments to the original function (the primal arguments) and returns a function (the pullback) that operates with the derivative information, the `frule` does it all at once.
     This is because the `frule` fuses the primal computation and the pushforward.
     This is an optimization that allows `frule`s to contain single large operations that perform both the primal computation and the pushforward at the same time (for example solving an ODE).
     This operation is only possible in forward mode (where `frule` is used) because the derivative information the pushforward available with the `frule` is invoked -- it is about the primal function's input.
-    In contrast, in reverse mode the derivative information needed by the pullback is about the primal functions output.
+    In contrast, in reverse mode the derivative information needed by the pullback is about the primal function's output.
     Thus the reverse mode returns the pullback function which the caller (usually an AD system) keeps hold of until derivative information about the output is available.
 
 
@@ -144,7 +144,7 @@ pushforward to find ``\dfrac{∂f}{∂x}``:
 
 #### The anatomy of pullback and pushforward
 
-For our function `foo(args...; kwargs) = y`:
+For our function `foo(args...; kwargs...) = y`:
 
 
 ```julia
@@ -187,20 +187,20 @@ end
 
 
 The input to the pushforward is often called the _perturbation_.
-If the function is `y = f(x)` often the pushforward will be written `ẏ = last∘frule(f, x, ṡelf, ẋ))`.
-(`ẏ` is commonly used to represent the perturbation for `y`)
+If the function is `y = f(x)` often the pushforward will be written `ẏ = last(frule(f, x, ṡelf, ẋ))`.
+`ẏ` is commonly used to represent the perturbation for `y`.
 
 !!! note
     
-    In the `frule`/pushforward:
+    In the `frule`/pushforward,
     there is one `Δarg` per `arg` to the original function.
     The `Δargs` are similar in type/structure to the corresponding inputs `args` (`Δself` is explained below).
     The `∂y` are similar in type/structure to the original function's output `Y`.
-    In particular if that function returned a tuple then `∂y` will be a tuple of same size.
+    In particular if that function returned a tuple then `∂y` will be a tuple of the same size.
 
 ### Self derivative `Δself`, `∂self`, `s̄elf`, `ṡelf` etc.
 
-!!! terminology  `Δself`, `∂self`, `s̄elf`, `ṡelf`
+!!! terminology  "`Δself`, `∂self`, `s̄elf`, `ṡelf`"
     It is the derivatives with respect to the internal fields of the function.
     To the best of our knowledge there is no standard terminology for this.
     Other good names might be `Δinternal`/`∂internal`.


### PR DESCRIPTION
New docs,
major change is about  the pushforward now fused into the `frule`.