### PR TITLE
[WIP] rrule for eigen decomposition 

### DIFF
--- a/src/rulesets/LinearAlgebra/factorization.jl
+++ b/src/rulesets/LinearAlgebra/factorization.jl
@@ -269,7 +269,7 @@ end
 # this determines how many iterations are differentiated.
 # I am also iffy about the implementation of rrule for eigen in general, the paper
 # ignores the adjoints of the eigenvalues and also relies on the primal input being
-# symmetric positive semidefinte
+# symmetric positive semidefinite
 function rrule(::typeof(eigen), X::AbstractMatrix{<:Real};k=1)
     # The paper only computes the adjoint using the adjoint of the eigenvectors,
     # not the eigenvalues, and uses svd in the forward pass
@@ -295,14 +295,15 @@ function rrule(::typeof(getproperty), F::T, x::Symbol) where T <: Eigen
 end
 
 function eigen_rev(ΛV::Eigen,Λ̄,V̄,k)
-    
+
     Λ = ΛV.values
     V = ΛV.vectors
     A = V*diagm(Λ)*V'
 
     Ā = zeros(size(A))
     tempĀ = zeros(size(A))
-    # eigen(A).values are in descending order
+    # eigen(A).values are in descending order, this current implementation
+    # assumes that the input matrix positive definite
     for j = length(Λ):-1:1
         tempĀ = (I-V[:,j]*V[:,j]') ./ norm(A*V[:,j])
         for i = 1:k-1


### PR DESCRIPTION
This PR implements the rrule for eigen decomposition following the paper referenced in #144.

I have tested the implementation locally, but have yet to write tests for this PR as the implementation (as presented in the paper) is a bit unconventional to me and I think there will need to be modifications to my PR.

Several issues that I have encountered:
- The adjoint of the eigenvalues is not used in the derivation of the adjoint of the eigen decomposition (by the authors). This is reflected in my implementation.
- The paper assumes that the input matrix is symmetric positive semidefinite (i.e a covariance matrix).
- In the paper, the forward pass relies on svd as the underlying implementation of the eigen decomposition (this is possible due to the assumption that the input is symmetric PSD). I assume calling eigen(X) for the forward pass dispatches on a sensible algorithm. 
- The proposed algorithm is to back-propagate through the power iteration, which requires choosing the number of iterations. This leads me to adding an additional parameter for rrule since eigen(X) is not iterative and does not allow a choice of iterations.

My local tests show that the proposed adjoint for eigen decomposition agrees with finite differencing a power iteration algorithm, but in many situations differs from finite differencing the eigen decomposition. This could be that I am incorrectly interpreting the algorithm outside the vase where the adjoint of the eigenvectors dL/dV has at most one non-negative column. 