### PR TITLE
Use global random number generator

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "0.5.1"
+version = "0.5.2"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/test/rulesets/Base/array.jl
+++ b/test/rulesets/Base/array.jl
@@ -1,9 +1,8 @@
 @testset "reshape" begin
-    rng = MersenneTwister(1)
-    A = randn(rng, 4, 5)
+    A = rand(4, 5)
     B, pullback = rrule(reshape, A, (5, 4))
     @test B == reshape(A, (5, 4))
-    Ȳ = randn(rng, 4, 5)
+    Ȳ = randn(4, 5)
 
     (s̄, Ā, d̄) = pullback(Ȳ)
     @test s̄ == NO_FIELDS
@@ -13,7 +12,7 @@
     B, pullback = rrule(reshape, A, 5, 4)
     @test B == reshape(A, 5, 4)
 
-    Ȳ = randn(rng, 4, 5)
+    Ȳ = randn(4, 5)
     (s̄, Ā, d̄1, d̄2) = pullback(Ȳ)
     @test s̄ == NO_FIELDS
     @test d̄1 isa DoesNotExist
@@ -22,13 +21,12 @@
 end
 
 @testset "hcat" begin
-    rng = MersenneTwister(2)
-    A = randn(rng, 3, 2)
-    B = randn(rng, 3)
-    C = randn(rng, 3, 3)
+    A = randn(3, 2)
+    B = randn(3)
+    C = randn(3, 3)
     H, pullback = rrule(hcat, A, B, C)
     @test H == hcat(A, B, C)
-    H̄ = randn(rng, 3, 6)
+    H̄ = randn(3, 6)
     (ds, dA, dB, dC) = pullback(H̄)
     @test ds == NO_FIELDS
     @test dA ≈ view(H̄, :, 1:2)
@@ -37,13 +35,12 @@ end
 end
 
 @testset "vcat" begin
-    rng = MersenneTwister(3)
-    A = randn(rng, 2, 4)
-    B = randn(rng, 1, 4)
-    C = randn(rng, 3, 4)
+    A = randn(2, 4)
+    B = randn(1, 4)
+    C = randn(3, 4)
     V, pullback = rrule(vcat, A, B, C)
     @test V == vcat(A, B, C)
-    V̄ = randn(rng, 6, 4)
+    V̄ = randn(6, 4)
     (ds, dA, dB, dC) = pullback(V̄)
     @test ds == NO_FIELDS
     @test dA ≈ view(V̄, 1:2, :)

--- a/test/rulesets/Base/base.jl
+++ b/test/rulesets/Base/base.jl
@@ -133,34 +133,31 @@
     end
 
     @testset "binary function ($f)" for f in (hypot, atan, mod, rem, ^)
-        rng = MersenneTwister(123456)
-        x, Δx, x̄ = 10rand(rng, 3)
-        y, Δy, ȳ = rand(rng, 3)
-        Δz = rand(rng)
+        x, Δx, x̄ = 10rand(3)
+        y, Δy, ȳ = rand(3)
+        Δz = rand()
 
         frule_test(f, (x, Δx), (y, Δy))
         rrule_test(f, Δz, (x, x̄), (y, ȳ))
     end
 
     @testset "x^n for x<0" begin
-        rng = MersenneTwister(123456)
-        x = -15*rand(rng)
-        Δx, x̄ = 10rand(rng, 2)
-        y, Δy, ȳ = rand(rng, 3)
-        Δz = rand(rng)
+        x = -15*rand()
+        Δx, x̄ = 10rand(2)
+        y, Δy, ȳ = rand(3)
+        Δz = rand()
 
         frule_test(^, (-x, Δx), (y, Δy))
         rrule_test(^, Δz, (-x, x̄), (y, ȳ))
     end
 
     @testset "identity" begin
-        rng = MersenneTwister(1)
-        rrule_test(identity, randn(rng), (randn(rng), randn(rng)))
-        rrule_test(identity, randn(rng, 4), (randn(rng, 4), randn(rng, 4)))
+        rrule_test(identity, randn(), (randn(), randn()))
+        rrule_test(identity, randn(4), (randn(4), randn(4)))
 
         rrule_test(
-            identity, Tuple(randn(rng, 3)),
-            (Composite{Tuple}(randn(rng, 3)...), Composite{Tuple}(randn(rng, 3)...))
+            identity, Tuple(randn(3)),
+            (Composite{Tuple}(randn(3)...), Composite{Tuple}(randn(3)...))
         )
     end
 
@@ -188,11 +185,10 @@
     end
 
     @testset "trinary ($f)" for f in (muladd, fma)
-        rng = MersenneTwister(123456)
-        x, Δx, x̄ = 10randn(rng, 3)
-        y, Δy, ȳ = randn(rng, 3)
-        z, Δz, z̄ = randn(rng, 3)
-        Δk = randn(rng)
+        x, Δx, x̄ = 10randn(3)
+        y, Δy, ȳ = randn(3)
+        z, Δz, z̄ = randn(3)
+        Δk = randn()
 
         frule_test(f, (x, Δx), (y, Δy), (z, Δz))
         rrule_test(f, Δk, (x, x̄), (y, ȳ), (z, z̄))

--- a/test/rulesets/Base/mapreduce.jl
+++ b/test/rulesets/Base/mapreduce.jl
@@ -1,26 +1,25 @@
 @testset "Maps and Reductions" begin
     @testset "sum" begin
         @testset "Vector" begin
-            rng, M = MersenneTwister(123456), 3
-            frule_test(sum, (randn(rng, M), randn(rng, M)))
-            rrule_test(sum, randn(rng), (randn(rng, M), randn(rng, M)))
+            M = 3
+            frule_test(sum, (randn(M), randn(M)))
+            rrule_test(sum, randn(), (randn(M), randn(M)))
         end
         @testset "Matrix" begin
-            rng, M, N = MersenneTwister(123456), 3, 4
-            frule_test(sum, (randn(rng, M, N), randn(rng, M, N)))
-            rrule_test(sum, randn(rng), (randn(rng, M, N), randn(rng, M, N)))
+            M, N = 3, 4
+            frule_test(sum, (randn(M, N), randn(M, N)))
+            rrule_test(sum, randn(), (randn(M, N), randn(M, N)))
         end
         @testset "Array{T, 3}" begin
-            rng, M, N, P = MersenneTwister(123456), 3, 7, 11
-            frule_test(sum, (randn(rng, M, N, P), randn(rng, M, N, P)))
-            rrule_test(sum, randn(rng), (randn(rng, M, N, P), randn(rng, M, N, P)))
+            M, N, P = 3, 7, 11
+            frule_test(sum, (randn(M, N, P), randn(M, N, P)))
+            rrule_test(sum, randn(), (randn(M, N, P), randn(M, N, P)))
         end
         @testset "keyword arguments" begin
-            rng = MersenneTwister(33)
             n = 4
-            X = randn(rng, n, n+1)
+            X = randn(n, n+1)
             y, pullback = rrule(sum, X; dims=2)
-            ȳ = randn(rng, size(y))
+            ȳ = randn(size(y))
             _, x̄_ad = pullback(ȳ)
             x̄_fd = only(j′vp(central_fdm(5, 1), x->sum(x, dims=2), ȳ, X))
             @test x̄_ad ≈ x̄_fd atol=1e-9 rtol=1e-9

--- a/test/rulesets/LinearAlgebra/blas.jl
+++ b/test/rulesets/LinearAlgebra/blas.jl
@@ -1,39 +1,37 @@
 @testset "BLAS" begin
     @testset "gemm" begin
-        rng = MersenneTwister(1)
         dims = 3:5
         for m in dims, n in dims, p in dims, tA in ('N', 'T'), tB in ('N', 'T')
-            α = randn(rng)
-            A = randn(rng, tA === 'N' ? (m, n) : (n, m))
-            B = randn(rng, tB === 'N' ? (n, p) : (p, n))
+            α = randn()
+            A = randn(tA === 'N' ? (m, n) : (n, m))
+            B = randn(tB === 'N' ? (n, p) : (p, n))
             C = gemm(tA, tB, α, A, B)
-            ȳ = randn(rng, size(C)...)
+            ȳ = randn(size(C)...)
             rrule_test(
                 gemm,
                 ȳ,
                 (tA, nothing),
                 (tB, nothing),
-                (α, randn(rng)),
-                (A, randn(rng, size(A))),
-                (B, randn(rng, size(B))),
+                (α, randn()),
+                (A, randn(size(A))),
+                (B, randn(size(B))),
             )
         end
     end
     @testset "gemv" begin
-        rng = MersenneTwister(2)
         for n in 3:5, m in 3:5, t in ('N', 'T')
-            α = randn(rng)
-            A = randn(rng, m, n)
-            x = randn(rng, t === 'N' ? n : m)
+            α = randn()
+            A = randn(m, n)
+            x = randn(t === 'N' ? n : m)
             y = α * (t === 'N' ? A : A') * x
-            ȳ = randn(rng, size(y)...)
+            ȳ = randn(size(y)...)
             rrule_test(
                 gemv,
                 ȳ,
                 (t, nothing),
-                (α, randn(rng)),
-                (A, randn(rng, size(A))),
-                (x, randn(rng, size(x))),
+                (α, randn()),
+                (A, randn(size(A))),
+                (x, randn(size(x))),
             )
         end
     end

--- a/test/rulesets/LinearAlgebra/dense.jl
+++ b/test/rulesets/LinearAlgebra/dense.jl
@@ -1,118 +1,115 @@
 @testset "linalg" begin
     @testset "dot" begin
         @testset "Vector" begin
-            rng, M = MersenneTwister(123456), 3
-            x, y = randn(rng, M), randn(rng, M)
-            ẋ, ẏ = randn(rng, M), randn(rng, M)
-            x̄, ȳ = randn(rng, M), randn(rng, M)
+            M = 3
+            x, y = randn(M), randn(M)
+            ẋ, ẏ = randn(M), randn(M)
+            x̄, ȳ = randn(M), randn(M)
             frule_test(dot, (x, ẋ), (y, ẏ))
-            rrule_test(dot, randn(rng), (x, x̄), (y, ȳ))
+            rrule_test(dot, randn(), (x, x̄), (y, ȳ))
         end
         @testset "Matrix" begin
-            rng, M, N = MersenneTwister(123456), 3, 4
-            x, y = randn(rng, M, N), randn(rng, M, N)
-            ẋ, ẏ = randn(rng, M, N), randn(rng, M, N)
-            x̄, ȳ = randn(rng, M, N), randn(rng, M, N)
+            M, N = 3, 4
+            x, y = randn(M, N), randn(M, N)
+            ẋ, ẏ = randn(M, N), randn(M, N)
+            x̄, ȳ = randn(M, N), randn(M, N)
             frule_test(dot, (x, ẋ), (y, ẏ))
-            rrule_test(dot, randn(rng), (x, x̄), (y, ȳ))
+            rrule_test(dot, randn(), (x, x̄), (y, ȳ))
         end
         @testset "Array{T, 3}" begin
-            rng, M, N, P = MersenneTwister(123456), 3, 4, 5
-            x, y = randn(rng, M, N, P), randn(rng, M, N, P)
-            ẋ, ẏ = randn(rng, M, N, P), randn(rng, M, N, P)
-            x̄, ȳ = randn(rng, M, N, P), randn(rng, M, N, P)
+            M, N, P = 3, 4, 5
+            x, y = randn(M, N, P), randn(M, N, P)
+            ẋ, ẏ = randn(M, N, P), randn(M, N, P)
+            x̄, ȳ = randn(M, N, P), randn(M, N, P)
             frule_test(dot, (x, ẋ), (y, ẏ))
-            rrule_test(dot, randn(rng), (x, x̄), (y, ȳ))
+            rrule_test(dot, randn(), (x, x̄), (y, ȳ))
         end
     end
     @testset "inv" begin
-        rng, N = MersenneTwister(123456), 3
-        B = generate_well_conditioned_matrix(rng, N)
-        frule_test(inv, (B, randn(rng, N, N)))
-        rrule_test(inv, randn(rng, N, N), (B, randn(rng, N, N)))
+        N = 3
+        B = generate_well_conditioned_matrix(N)
+        frule_test(inv, (B, randn(N, N)))
+        rrule_test(inv, randn(N, N), (B, randn(N, N)))
     end
     @testset "det" begin
-        rng, N = MersenneTwister(123456), 3
-        B = generate_well_conditioned_matrix(rng, N)
-        frule_test(det, (B, randn(rng, N, N)))
-        rrule_test(det, randn(rng), (B, randn(rng, N, N)))
+        N = 3
+        B = generate_well_conditioned_matrix(N)
+        frule_test(det, (B, randn(N, N)))
+        rrule_test(det, randn(), (B, randn(N, N)))
     end
     @testset "logdet" begin
-        rng, N = MersenneTwister(123456), 3
-        B = generate_well_conditioned_matrix(rng, N)
-        frule_test(logdet, (B, randn(rng, N, N)))
-        rrule_test(logdet, randn(rng), (B, randn(rng, N, N)))
+        N = 3
+        B = generate_well_conditioned_matrix(N)
+        frule_test(logdet, (B, randn(N, N)))
+        rrule_test(logdet, randn(), (B, randn(N, N)))
     end
     @testset "tr" begin
-        rng, N = MersenneTwister(123456), 4
-        frule_test(tr, (randn(rng, N, N), randn(rng, N, N)))
-        rrule_test(tr, randn(rng), (randn(rng, N, N), randn(rng, N, N)))
+        N = 4
+        frule_test(tr, (randn(N, N), randn(N, N)))
+        rrule_test(tr, randn(), (randn(N, N), randn(N, N)))
     end
     @testset "*" begin
-        rng = MersenneTwister(123456)
         dims = [3,4,5]
         for n in dims, m in dims, p in dims
             n > 3 && n == m == p && continue  # don't need to test square case multiple times
-            A = randn(rng, m, n)
-            B = randn(rng, n, p)
-            Ȳ = randn(rng, m, p)
-            rrule_test(*, Ȳ, (A, randn(rng, m, n)), (B, randn(rng, n, p)))
+            A = randn(m, n)
+            B = randn(n, p)
+            Ȳ = randn(m, p)
+            rrule_test(*, Ȳ, (A, randn(m, n)), (B, randn(n, p)))
         end
     end
     @testset "$f" for f in [/, \]
-        rng = MersenneTwister(42)
         @testset "Matrix" begin
             for n in 3:5, m in 3:5
-                A = randn(rng, m, n)
-                B = randn(rng, m, n)
-                Ȳ = randn(rng, size(f(A, B)))
-                rrule_test(f, Ȳ, (A, randn(rng, m, n)), (B, randn(rng, m, n)))
+                A = randn(m, n)
+                B = randn(m, n)
+                Ȳ = randn(size(f(A, B)))
+                rrule_test(f, Ȳ, (A, randn(m, n)), (B, randn(m, n)))
             end
         end
         @testset "Vector" begin
-            x = randn(rng, 10)
-            y = randn(rng, 10)
-            ȳ = randn(rng, size(f(x, y))...)
-            rrule_test(f, ȳ, (x, randn(rng, 10)), (y, randn(rng, 10)))
+            x = randn(10)
+            y = randn(10)
+            ȳ = randn(size(f(x, y))...)
+            rrule_test(f, ȳ, (x, randn(10)), (y, randn(10)))
         end
         if f == (/)
             @testset "$T on the RHS" for T in (Diagonal, UpperTriangular, LowerTriangular)
-                RHS = T(randn(rng, T == Diagonal ? 10 : (10, 10)))
-                Y = randn(rng, 5, 10)
-                Ȳ = randn(rng, size(f(Y, RHS))...)
-                rrule_test(f, Ȳ, (Y, randn(rng, size(Y))), (RHS, randn(rng, size(RHS))))
+                RHS = T(randn(T == Diagonal ? 10 : (10, 10)))
+                Y = randn(5, 10)
+                Ȳ = randn(size(f(Y, RHS))...)
+                rrule_test(f, Ȳ, (Y, randn(size(Y))), (RHS, randn(size(RHS))))
             end
         else
             @testset "$T on LHS" for T in (Diagonal, UpperTriangular, LowerTriangular)
-                LHS = T(randn(rng, T == Diagonal ? 10 : (10, 10)))
-                y = randn(rng, 10)
-                ȳ = randn(rng, size(f(LHS, y))...)
-                rrule_test(f, ȳ, (LHS, randn(rng, size(LHS))), (y, randn(rng, 10)))
-                Y = randn(rng, 10, 10)
-                Ȳ = randn(rng, 10, 10)
-                rrule_test(f, Ȳ, (LHS, randn(rng, size(LHS))), (Y, randn(rng, size(Y))))
+                LHS = T(randn(T == Diagonal ? 10 : (10, 10)))
+                y = randn(10)
+                ȳ = randn(size(f(LHS, y))...)
+                rrule_test(f, ȳ, (LHS, randn(size(LHS))), (y, randn(10)))
+                Y = randn(10, 10)
+                Ȳ = randn(10, 10)
+                rrule_test(f, Ȳ, (LHS, randn(size(LHS))), (Y, randn(size(Y))))
             end
             @testset "Matrix $f Vector" begin
-                X = randn(rng, 10, 4)
-                y = randn(rng, 10)
-                ȳ = randn(rng, size(f(X, y))...)
-                rrule_test(f, ȳ, (X, randn(rng, size(X))), (y, randn(rng, 10)))
+                X = randn(10, 4)
+                y = randn(10)
+                ȳ = randn(size(f(X, y))...)
+                rrule_test(f, ȳ, (X, randn(size(X))), (y, randn(10)))
             end
             @testset "Vector $f Matrix" begin
-                x = randn(rng, 10)
-                Y = randn(rng, 10, 4)
-                ȳ = randn(rng, size(f(x, Y))...)
-                rrule_test(f, ȳ, (x, randn(rng, size(x))), (Y, randn(rng, size(Y))))
+                x = randn(10)
+                Y = randn(10, 4)
+                ȳ = randn(size(f(x, Y))...)
+                rrule_test(f, ȳ, (x, randn(size(x))), (Y, randn(size(Y))))
             end
         end
     end
     @testset "norm" begin
-        rng = MersenneTwister(3)
         for dims in [(), (5,), (3, 2), (7, 3, 2)]
-            A = randn(rng, dims...)
-            p = randn(rng)
-            ȳ = randn(rng)
-            rrule_test(norm, ȳ, (A, randn(rng, dims...)), (p, randn(rng)))
+            A = randn(dims...)
+            p = randn()
+            ȳ = randn()
+            rrule_test(norm, ȳ, (A, randn(dims...)), (p, randn()))
         end
     end
 end

--- a/test/rulesets/LinearAlgebra/factorization.jl
+++ b/test/rulesets/LinearAlgebra/factorization.jl
@@ -2,13 +2,12 @@ using ChainRules: level2partition, level3partition, chol_blocked_rev, chol_unblo
 
 @testset "Factorizations" begin
     @testset "svd" begin
-        rng = MersenneTwister(3)
         for n in [4, 6, 10], m in [3, 5, 10]
-            X = randn(rng, n, m)
+            X = randn(n, m)
             F, dX_pullback = rrule(svd, X)
             for p in [:U, :S, :V]
                 Y, dF_pullback = rrule(getproperty, F, p)
-                Ȳ = randn(rng, size(Y)...)
+                Ȳ = randn(size(Y)...)
 
                 dself1, dF, dp = dF_pullback(Ȳ)
                 @test dself1 === NO_FIELDS
@@ -23,7 +22,7 @@ using ChainRules: level2partition, level3partition, chol_blocked_rev, chol_unblo
             end
             @testset "Vt" begin
                 Y, dF_pullback = rrule(getproperty, F, :Vt)
-                Ȳ = randn(rng, size(Y)...)
+                Ȳ = randn(size(Y)...)
                 @test_throws ArgumentError dF_pullback(Ȳ)
             end
         end
@@ -46,22 +45,21 @@ using ChainRules: level2partition, level3partition, chol_blocked_rev, chol_unblo
         end
 
         @testset "Helper functions" begin
-            X = randn(rng, 10, 10)
-            Y = randn(rng, 10, 10)
+            X = randn(10, 10)
+            Y = randn(10, 10)
             @test ChainRules._mulsubtrans!(copy(X), Y) ≈ Y .* (X - X')
             @test ChainRules._eyesubx!(copy(X)) ≈ I - X
             @test ChainRules._add!(copy(X), Y) ≈ X + Y
         end
     end
     @testset "cholesky" begin
-        rng = MersenneTwister(4)
         @testset "the thing" begin
-            X = generate_well_conditioned_matrix(rng, 10)
-            V = generate_well_conditioned_matrix(rng, 10)
+            X = generate_well_conditioned_matrix(10)
+            V = generate_well_conditioned_matrix(10)
             F, dX_pullback = rrule(cholesky, X)
             for p in [:U, :L]
                 Y, dF_pullback = rrule(getproperty, F, p)
-                Ȳ = (p === :U ? UpperTriangular : LowerTriangular)(randn(rng, size(Y)))
+                Ȳ = (p === :U ? UpperTriangular : LowerTriangular)(randn(size(Y)))
                 (dself, dF, dp) = dF_pullback(Ȳ)
                 @test dself === NO_FIELDS
                 @test dp === DoesNotExist()
@@ -80,7 +78,7 @@ using ChainRules: level2partition, level3partition, chol_blocked_rev, chol_unblo
             end
         end
         @testset "helper functions" begin
-            A = randn(rng, 5, 5)
+            A = randn(5, 5)
             r, d, B2, c = level2partition(A, 4, false)
             R, D, B3, C = level3partition(A, 4, 4, false)
             @test all(r .== R')
@@ -103,8 +101,8 @@ using ChainRules: level2partition, level3partition, chol_blocked_rev, chol_unblo
             @test transpose(B3) == B3ᵀ
             @test transpose(C) == Cᵀ
 
-            A = Matrix(LowerTriangular(randn(rng, 10, 10)))
-            Ā = Matrix(LowerTriangular(randn(rng, 10, 10)))
+            A = Matrix(LowerTriangular(randn(10, 10)))
+            Ā = Matrix(LowerTriangular(randn(10, 10)))
             # NOTE: BLAS gets angry if we don't materialize the Transpose objects first
             B = Matrix(transpose(A))
             B̄ = Matrix(transpose(Ā))

--- a/test/rulesets/LinearAlgebra/structured.jl
+++ b/test/rulesets/LinearAlgebra/structured.jl
@@ -1,11 +1,11 @@
 @testset "Structured Matrices" begin
     @testset "Diagonal" begin
-        rng, N = MersenneTwister(123456), 3
-        rrule_test(Diagonal, randn(rng, N, N), (randn(rng, N), randn(rng, N)))
-        D = Diagonal(randn(rng, N))
-        rrule_test(Diagonal, D, (randn(rng, N), randn(rng, N)))
+        N = 3
+        rrule_test(Diagonal, randn(N, N), (randn(N), randn(N)))
+        D = Diagonal(randn( N))
+        rrule_test(Diagonal, D, (randn(N), randn(N)))
         # Concrete type instead of UnionAll
-        rrule_test(typeof(D), D, (randn(rng, N), randn(rng, N)))
+        rrule_test(typeof(D), D, (randn(N), randn(N)))
 
         # TODO: replace this with a `rrule_test` once we have that working
         # see https://github.com/JuliaDiff/ChainRulesTestUtils.jl/issues/24
@@ -16,35 +16,33 @@
     end
     
     @testset "::Diagonal * ::AbstractVector" begin
-        rng, N = MersenneTwister(123456), 3
+        N = 3
         rrule_test(
             *,
-            randn(rng, N),
-            (Diagonal(randn(rng, N)), Diagonal(randn(rng, N))),
-            (randn(rng, N), randn(rng, N)),
+            randn(N),
+            (Diagonal(randn(N)), Diagonal(randn(N))),
+            (randn(N), randn(N)),
         )
     end
     @testset "diag" begin
-        rng, N = MersenneTwister(123456), 7
-        rrule_test(diag, randn(rng, N), (randn(rng, N, N), randn(rng, N, N)))
-        rrule_test(diag, randn(rng, N), (Diagonal(randn(rng, N)), randn(rng, N, N)))
-        rrule_test(diag, randn(rng, N), (randn(rng, N, N), Diagonal(randn(rng, N))))
-        rrule_test(diag, randn(rng, N), (Diagonal(randn(rng, N)), Diagonal(randn(rng, N))))
+        N = 7
+        rrule_test(diag, randn(N), (randn(N, N), randn(N, N)))
+        rrule_test(diag, randn(N), (Diagonal(randn(N)), randn(N, N)))
+        rrule_test(diag, randn(N), (randn(N, N), Diagonal(randn(N))))
+        rrule_test(diag, randn(N), (Diagonal(randn(N)), Diagonal(randn(N))))
     end
     @testset "Symmetric" begin
-        rng, N = MersenneTwister(123456), 3
-        rrule_test(Symmetric, randn(rng, N, N), (randn(rng, N, N), randn(rng, N, N)))
+        N = 3
+        rrule_test(Symmetric, randn(N, N), (randn(N, N), randn(N, N)))
     end
     @testset "$f" for f in (Adjoint, adjoint, Transpose, transpose)
-        rng = MersenneTwister(32)
         n = 5
         m = 3
-        rrule_test(f, randn(rng, m, n), (randn(rng, n, m), randn(rng, n, m)))
-        rrule_test(f, randn(rng, 1, n), (randn(rng, n), randn(rng, n)))
+        rrule_test(f, randn(m, n), (randn(n, m), randn(n, m)))
+        rrule_test(f, randn(1, n), (randn(n), randn(n)))
     end
     @testset "$T" for T in (UpperTriangular, LowerTriangular)
-        rng = MersenneTwister(33)
         n = 5
-        rrule_test(T, T(randn(rng, n, n)), (randn(rng, n, n), randn(rng, n, n)))
+        rrule_test(T, T(randn(n, n)), (randn(n, n), randn(n, n)))
     end
 end

--- a/test/rulesets/Statistics/statistics.jl
+++ b/test/rulesets/Statistics/statistics.jl
@@ -1,15 +1,14 @@
 @testset "mean" begin
-    rng = MersenneTwister(999)
     n = 9
 
     @testset "Basic" begin
-        rrule_test(mean, randn(rng), (randn(rng, n), randn(rng, n)))
+        rrule_test(mean, randn(), (randn(n), randn(n)))
     end
 
     @testset "with dims kwargs" begin
-        X = randn(rng, n, n+1)
+        X = randn(n, n+1)
         y, mean_pullback = rrule(mean, X; dims=1)
-        ȳ = randn(rng, size(y))
+        ȳ = randn(size(y))
         _, dX = mean_pullback(ȳ)
         X̄_ad = extern(dX)
         X̄_fd = only(j′vp(_fdm, x->mean(x, dims=1), ȳ, X))


### PR DESCRIPTION
Resolves: #180 

From the Test [documentation](https://docs.julialang.org/en/v1/stdlib/Test/#Test.@testset) for `@testset`:

> Before the execution of the body of a @testset, there is an implicit call to Random.seed!(seed) where seed is the current seed of the global RNG.

So we do not need to manually seed our `@testsets`.