### PR TITLE
Add rules for all Symmetric/Hermitian constructors

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "0.7.1"
+version = "0.7.2"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "0.7.2"
+version = "0.7.3"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "0.7.4"
+version = "0.7.5"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/rulesets/LinearAlgebra/structured.jl
+++ b/src/rulesets/LinearAlgebra/structured.jl
@@ -87,6 +87,7 @@ function rrule(TM::Type{<:Matrix}, A::TA) where {TA<:LinearAlgebra.HermOrSym}
     end
     return TM(A), Matrix_pullback
 end
+rrule(::Type{Array}, A::LinearAlgebra.HermOrSym) = rrule(Matrix, A)
 
 _symhermtype(::Type{<:Symmetric}) = Symmetric
 _symhermtype(::Type{<:Hermitian}) = Hermitian

--- a/src/rulesets/LinearAlgebra/structured.jl
+++ b/src/rulesets/LinearAlgebra/structured.jl
@@ -97,10 +97,12 @@ function rrule(TM::Type{<:Matrix}, A::LinearAlgebra.HermOrSym)
 end
 rrule(::Type{Array}, A::LinearAlgebra.HermOrSym) = rrule(Matrix, A)
 
+# Get type (Symmetric or Hermitian) from type or matrix
 _symhermtype(::Type{<:Symmetric}) = Symmetric
 _symhermtype(::Type{<:Hermitian}) = Hermitian
 _symhermtype(A) = _symhermtype(typeof(A))
 
+# for Ω = Matrix(A::HermOrSym), push forward ΔA to get ∂Ω
 function _symherm_forward(A, ΔA)
     TA = _symhermtype(A)
     return if ΔA isa TA
@@ -110,6 +112,7 @@ function _symherm_forward(A, ΔA)
     end
 end
 
+# for Ω = HermOrSym(A, uplo), pull back ΔΩ to get ∂A
 _symherm_back(::Type{<:Symmetric}, ΔΩ, uplo) = _symmetric_back(ΔΩ, uplo)
 function _symherm_back(::Type{<:Hermitian}, ΔΩ::AbstractMatrix{<:Real}, uplo)
     return _symmetric_back(ΔΩ, uplo)

--- a/src/rulesets/LinearAlgebra/structured.jl
+++ b/src/rulesets/LinearAlgebra/structured.jl
@@ -122,8 +122,8 @@ function _symmetric_back(ΔΩ, uplo)
     return uplo == 'U' ? U .+ transpose(L) - D : L .+ transpose(U) - D
 end
 _symmetric_back(ΔΩ::Diagonal, uplo) = ΔΩ
-_symmetric_back(ΔΩ::UpperTriangular, uplo) = collect(uplo == 'U' ? ΔΩ : transpose(ΔΩ))
-_symmetric_back(ΔΩ::LowerTriangular, uplo) = collect(uplo == 'U' ? transpose(ΔΩ) : ΔΩ)
+_symmetric_back(ΔΩ::UpperTriangular, uplo) = Matrix(uplo == 'U' ? ΔΩ : transpose(ΔΩ))
+_symmetric_back(ΔΩ::LowerTriangular, uplo) = Matrix(uplo == 'U' ? transpose(ΔΩ) : ΔΩ)
 
 _hermitian_back(ΔΩ::AbstractMatrix{<:Real}, uplo) = _symmetric_back(ΔΩ, uplo)
 function _hermitian_back(ΔΩ, uplo)
@@ -134,9 +134,9 @@ _hermitian_back(ΔΩ::Diagonal{<:Complex}, uplo) = real.(ΔΩ)
 function _hermitian_back(ΔΩ::LinearAlgebra.AbstractTriangular{<:Complex}, uplo)
     ∂UL = ΔΩ .- Diagonal(_extract_imag(diag(ΔΩ)))
     return if istriu(ΔΩ)
-        return collect(uplo == 'U' ? ∂UL : ∂UL')
+        return Matrix(uplo == 'U' ? ∂UL : ∂UL')
     else
-        return collect(uplo == 'U' ? ∂UL' : ∂UL)
+        return Matrix(uplo == 'U' ? ∂UL' : ∂UL)
     end
 end
 

--- a/src/rulesets/LinearAlgebra/structured.jl
+++ b/src/rulesets/LinearAlgebra/structured.jl
@@ -125,14 +125,13 @@ _symmetric_back(ΔΩ::Diagonal, uplo) = ΔΩ
 _symmetric_back(ΔΩ::UpperTriangular, uplo) = collect(uplo == 'U' ? ΔΩ : transpose(ΔΩ))
 _symmetric_back(ΔΩ::LowerTriangular, uplo) = collect(uplo == 'U' ? transpose(ΔΩ) : ΔΩ)
 
+_hermitian_back(ΔΩ::AbstractMatrix{<:Real}, uplo) = _symmetric_back(ΔΩ, uplo)
 function _hermitian_back(ΔΩ, uplo)
-    isreal(ΔΩ) && return _symmetric_back(ΔΩ, uplo)
     L, U, rD = LowerTriangular(ΔΩ), UpperTriangular(ΔΩ), real.(Diagonal(ΔΩ))
     return uplo == 'U' ? U .+ L' - rD : L .+ U' - rD
 end
-_hermitian_back(ΔΩ::Diagonal, uplo) = real.(ΔΩ)
-function _hermitian_back(ΔΩ::LinearAlgebra.AbstractTriangular, uplo)
-    isreal(ΔΩ) && return _symmetric_back(ΔΩ, uplo)
+_hermitian_back(ΔΩ::Diagonal{<:Complex}, uplo) = real.(ΔΩ)
+function _hermitian_back(ΔΩ::LinearAlgebra.AbstractTriangular{<:Complex}, uplo)
     ∂UL = ΔΩ .- Diagonal(_extract_imag(diag(ΔΩ)))
     return if istriu(ΔΩ)
         return collect(uplo == 'U' ? ∂UL : ∂UL')

--- a/src/rulesets/LinearAlgebra/structured.jl
+++ b/src/rulesets/LinearAlgebra/structured.jl
@@ -78,6 +78,19 @@ function rrule(T::Type{<:LinearAlgebra.HermOrSym}, A::AbstractMatrix, uplo)
     return Ω, HermOrSym_pullback
 end
 
+function rrule(TM::Type{<:Matrix}, A::TA) where {TA<:LinearAlgebra.HermOrSym}
+    function Matrix_pullback(ΔΩ)
+        T∂A = _symhermtype(TA){eltype(ΔΩ),typeof(ΔΩ)}
+        uplo = A.uplo
+        ∂A = T∂A(_symherm_back(TA, ΔΩ, uplo), uplo)
+        return NO_FIELDS, ∂A
+    end
+    return TM(A), Matrix_pullback
+end
+
+_symhermtype(::Type{<:Symmetric}) = Symmetric
+_symhermtype(::Type{<:Hermitian}) = Hermitian
+
 _symherm_back(::Type{<:Symmetric}, ΔΩ, uplo) = _symmetric_back(ΔΩ, uplo)
 function _symherm_back(::Type{<:Hermitian}, ΔΩ::AbstractMatrix{<:Real}, uplo)
     return _symmetric_back(ΔΩ, uplo)

--- a/src/rulesets/LinearAlgebra/structured.jl
+++ b/src/rulesets/LinearAlgebra/structured.jl
@@ -128,13 +128,12 @@ _symmetric_back(ΔΩ::Diagonal, uplo) = ΔΩ
 _symmetric_back(ΔΩ::UpperTriangular, uplo) = Matrix(uplo == 'U' ? ΔΩ : transpose(ΔΩ))
 _symmetric_back(ΔΩ::LowerTriangular, uplo) = Matrix(uplo == 'U' ? transpose(ΔΩ) : ΔΩ)
 
-_hermitian_back(ΔΩ::AbstractMatrix{<:Real}, uplo) = _symmetric_back(ΔΩ, uplo)
 function _hermitian_back(ΔΩ, uplo)
     L, U, rD = LowerTriangular(ΔΩ), UpperTriangular(ΔΩ), real.(Diagonal(ΔΩ))
     return uplo == 'U' ? U .+ L' - rD : L .+ U' - rD
 end
-_hermitian_back(ΔΩ::Diagonal{<:Complex}, uplo) = real.(ΔΩ)
-function _hermitian_back(ΔΩ::LinearAlgebra.AbstractTriangular{<:Complex}, uplo)
+_hermitian_back(ΔΩ::Diagonal, uplo) = real.(ΔΩ)
+function _hermitian_back(ΔΩ::LinearAlgebra.AbstractTriangular, uplo)
     ∂UL = ΔΩ .- Diagonal(_extract_imag(diag(ΔΩ)))
     return if istriu(ΔΩ)
         return Matrix(uplo == 'U' ? ∂UL : ∂UL')

--- a/src/rulesets/LinearAlgebra/structured.jl
+++ b/src/rulesets/LinearAlgebra/structured.jl
@@ -66,16 +66,11 @@ end
 ##### `Symmetric`/`Hermitian`
 #####
 
-function frule(
-    (_, ΔA, _),
-    ::Type{T},
-    A::AbstractMatrix,
-    uplo,
-) where {T<:LinearAlgebra.HermOrSym}
+function frule((_, ΔA, _), T::Type{<:LinearAlgebra.HermOrSym}, A::AbstractMatrix, uplo)
     return T(A, uplo), T(ΔA, uplo)
 end
 
-function rrule(::Type{T}, A::AbstractMatrix, uplo) where {T<:LinearAlgebra.HermOrSym}
+function rrule(T::Type{<:LinearAlgebra.HermOrSym}, A::AbstractMatrix, uplo)
     Ω = T(A, uplo)
     function HermOrSym_pullback(ΔΩ)
         return (NO_FIELDS, @thunk(_symherm_back(T, ΔΩ, Ω.uplo)), DoesNotExist())

--- a/src/rulesets/LinearAlgebra/structured.jl
+++ b/src/rulesets/LinearAlgebra/structured.jl
@@ -66,6 +66,15 @@ end
 ##### `Symmetric`/`Hermitian`
 #####
 
+function frule(
+    (_, ΔA, _),
+    ::Type{T},
+    A::AbstractMatrix,
+    uplo,
+) where {T<:LinearAlgebra.HermOrSym}
+    return T(A, uplo), T(ΔA, uplo)
+end
+
 function rrule(::Type{T}, A::AbstractMatrix, uplo) where {T<:LinearAlgebra.HermOrSym}
     Ω = T(A, uplo)
     function HermOrSym_pullback(ΔΩ)

--- a/src/rulesets/LinearAlgebra/structured.jl
+++ b/src/rulesets/LinearAlgebra/structured.jl
@@ -134,7 +134,7 @@ function _hermitian_back(ΔΩ, uplo)
 end
 _hermitian_back(ΔΩ::Diagonal, uplo) = real.(ΔΩ)
 function _hermitian_back(ΔΩ::LinearAlgebra.AbstractTriangular, uplo)
-    ∂UL = ΔΩ .- Diagonal(_extract_imag(diag(ΔΩ)))
+    ∂UL = ΔΩ .- Diagonal(_extract_imag.(diag(ΔΩ)))
     return if istriu(ΔΩ)
         return Matrix(uplo == 'U' ? ∂UL : ∂UL')
     else

--- a/src/rulesets/LinearAlgebra/utils.jl
+++ b/src/rulesets/LinearAlgebra/utils.jl
@@ -35,4 +35,4 @@ function _add!(X::AbstractVecOrMat{T}, Y::AbstractVecOrMat{T}) where T<:Real
 end
 _add!(X, Y) = X + Y  # handles all `AbstractZero` overloads
 
-_extract_imag(x) = (x -> complex(0, imag(x))).(x)
+_extract_imag(x) = complex(0, imag(x))

--- a/src/rulesets/LinearAlgebra/utils.jl
+++ b/src/rulesets/LinearAlgebra/utils.jl
@@ -34,3 +34,5 @@ function _add!(X::AbstractVecOrMat{T}, Y::AbstractVecOrMat{T}) where T<:Real
     return X
 end
 _add!(X, Y) = X + Y  # handles all `AbstractZero` overloads
+
+_extract_imag(x) = (x -> complex(0, imag(x))).(x)

--- a/test/rulesets/LinearAlgebra/structured.jl
+++ b/test/rulesets/LinearAlgebra/structured.jl
@@ -78,7 +78,8 @@
             end
         end
     end
-    @testset "$(TA)(::AbstractMatrix{$T}, '$(uplo)')" for TA in (Symmetric, Hermitian),
+    @testset "$(SymHerm)(::AbstractMatrix{$T}, :$(uplo))" for
+        SymHerm in (Symmetric, Hermitian),
         T in (Float64, ComplexF64),
         uplo in (:U, :L)
 
@@ -87,10 +88,10 @@
             x = randn(T, N, N)
             Δx = randn(T, N, N)
             # can't use frule_test here because it doesn't yet ignore nothing tangents
-            Ω = TA(x, uplo)
-            Ω_ad, ∂Ω_ad = frule((Zero(), Δx, Zero()), TA, x, uplo)
+            Ω = SymHerm(x, uplo)
+            Ω_ad, ∂Ω_ad = frule((Zero(), Δx, Zero()), SymHerm, x, uplo)
             @test Ω_ad == Ω
-            ∂Ω_fd = jvp(_fdm, z -> TA(z, uplo), (x, Δx))
+            ∂Ω_fd = jvp(_fdm, z -> SymHerm(z, uplo), (x, Δx))
             @test ∂Ω_ad ≈ ∂Ω_fd
         end
         @testset "rrule" begin
@@ -98,26 +99,26 @@
             ∂x = randn(T, N, N)
             ΔΩ = randn(T, N, N)
             @testset "back(::$MT)" for MT in (Matrix, LowerTriangular, UpperTriangular)
-                rrule_test(TA, MT(ΔΩ), (x, ∂x), (uplo, nothing))
+                rrule_test(SymHerm, MT(ΔΩ), (x, ∂x), (uplo, nothing))
             end
             @testset "back(::Diagonal)" begin
-                rrule_test(TA, Diagonal(ΔΩ), (x, Diagonal(∂x)), (uplo, nothing))
+                rrule_test(SymHerm, Diagonal(ΔΩ), (x, Diagonal(∂x)), (uplo, nothing))
             end
         end
     end
-    @testset "$(TM)(::$(TA){$T}) with uplo='$uplo'" for TM in (Matrix, Array),
-        TA in (Symmetric, Hermitian),
+    @testset "$(f)(::$(SymHerm){$T}) with uplo=:$uplo" for f in (Matrix, Array),
+        SymHerm in (Symmetric, Hermitian),
         T in (Float64, ComplexF64),
         uplo in (:U, :L)
 
         N = 3
-        x = TA(randn(T, N, N), uplo)
+        x = SymHerm(randn(T, N, N), uplo)
         Δx = randn(T, N, N)
-        ∂x = TA(randn(T, N, N), uplo)
-        ΔΩ = TM(TA(randn(T, N, N), uplo))
-        frule_test(TM, (x, Δx))
-        frule_test(TM, (x, TA(Δx, uplo)))
-        rrule_test(TM, ΔΩ, (x, ∂x))
+        ∂x = SymHerm(randn(T, N, N), uplo)
+        ΔΩ = f(SymHerm(randn(T, N, N), uplo))
+        frule_test(f, (x, Δx))
+        frule_test(f, (x, SymHerm(Δx, uplo)))
+        rrule_test(f, ΔΩ, (x, ∂x))
     end
     @testset "$f" for f in (Adjoint, adjoint, Transpose, transpose)
         n = 5

--- a/test/rulesets/LinearAlgebra/structured.jl
+++ b/test/rulesets/LinearAlgebra/structured.jl
@@ -102,6 +102,13 @@
             end
         end
     end
+    @testset "Matrix(::$(TA){$T}) with uplo='$uplo'" for TA in (Symmetric, Hermitian), T in (Float64, ComplexF64), uplo in (:U, :L)
+        N = 3
+        x = TA(randn(T, N, N), uplo)
+        ∂x = TA(randn(T, N, N), uplo)
+        ΔΩ = Matrix(TA(randn(T, N, N), uplo))
+        rrule_test(Matrix, ΔΩ, (x, ∂x))
+    end
     @testset "$f" for f in (Adjoint, adjoint, Transpose, transpose)
         n = 5
         m = 3

--- a/test/rulesets/LinearAlgebra/structured.jl
+++ b/test/rulesets/LinearAlgebra/structured.jl
@@ -42,6 +42,16 @@
             rrule_test(Symmetric, Diagonal(randn(T, N, N)), (randn(T, N, N), Diagonal(randn(T, N, N))), (:L, nothing))
         end
     end
+    @testset "Hermitian" begin
+        N = 3
+        @testset "$T" for T in (Float64, ComplexF64)
+            @testset "back(::$MT)" for MT in (Matrix, LowerTriangular, UpperTriangular)
+                rrule_test(Hermitian, MT(randn(T, N, N)), (randn(T, N, N), randn(T, N, N)), (:U, nothing))
+                rrule_test(Hermitian, MT(randn(T, N, N)), (randn(T, N, N), randn(T, N, N)), (:L, nothing))
+            end
+            rrule_test(Hermitian, Diagonal(randn(T, N, N)), (randn(T, N, N), Diagonal(randn(T, N, N))), (:U, nothing))
+            rrule_test(Hermitian, Diagonal(randn(T, N, N)), (randn(T, N, N), Diagonal(randn(T, N, N))), (:L, nothing))
+        end
     end
     @testset "$f" for f in (Adjoint, adjoint, Transpose, transpose)
         n = 5

--- a/test/rulesets/LinearAlgebra/structured.jl
+++ b/test/rulesets/LinearAlgebra/structured.jl
@@ -102,12 +102,12 @@
             end
         end
     end
-    @testset "Matrix(::$(TA){$T}) with uplo='$uplo'" for TA in (Symmetric, Hermitian), T in (Float64, ComplexF64), uplo in (:U, :L)
+    @testset "$(TM)(::$(TA){$T}) with uplo='$uplo'" for TM in (Matrix, Array), TA in (Symmetric, Hermitian), T in (Float64, ComplexF64), uplo in (:U, :L)
         N = 3
         x = TA(randn(T, N, N), uplo)
         ∂x = TA(randn(T, N, N), uplo)
-        ΔΩ = Matrix(TA(randn(T, N, N), uplo))
-        rrule_test(Matrix, ΔΩ, (x, ∂x))
+        ΔΩ = TM(TA(randn(T, N, N), uplo))
+        rrule_test(TM, ΔΩ, (x, ∂x))
     end
     @testset "$f" for f in (Adjoint, adjoint, Transpose, transpose)
         n = 5

--- a/test/rulesets/LinearAlgebra/structured.jl
+++ b/test/rulesets/LinearAlgebra/structured.jl
@@ -78,7 +78,10 @@
             end
         end
     end
-    @testset "$(TA)(::AbstractMatrix{$T}, '$(uplo)')" for TA in (Symmetric, Hermitian), T in (Float64, ComplexF64), uplo in (:U, :L)
+    @testset "$(TA)(::AbstractMatrix{$T}, '$(uplo)')" for TA in (Symmetric, Hermitian),
+        T in (Float64, ComplexF64),
+        uplo in (:U, :L)
+
         N = 3
         @testset "frule" begin
             x = randn(T, N, N)
@@ -102,7 +105,11 @@
             end
         end
     end
-    @testset "$(TM)(::$(TA){$T}) with uplo='$uplo'" for TM in (Matrix, Array), TA in (Symmetric, Hermitian), T in (Float64, ComplexF64), uplo in (:U, :L)
+    @testset "$(TM)(::$(TA){$T}) with uplo='$uplo'" for TM in (Matrix, Array),
+        TA in (Symmetric, Hermitian),
+        T in (Float64, ComplexF64),
+        uplo in (:U, :L)
+
         N = 3
         x = TA(randn(T, N, N), uplo)
         Δx = randn(T, N, N)

--- a/test/rulesets/LinearAlgebra/structured.jl
+++ b/test/rulesets/LinearAlgebra/structured.jl
@@ -80,6 +80,16 @@
     end
     @testset "$(TA)(::AbstractMatrix{$T}, '$(uplo)')" for TA in (Symmetric, Hermitian), T in (Float64, ComplexF64), uplo in (:U, :L)
         N = 3
+        @testset "frule" begin
+            x = randn(T, N, N)
+            Δx = randn(T, N, N)
+            # can't use frule_test here because it doesn't yet ignore nothing tangents
+            Ω = TA(x, uplo)
+            Ω_ad, ∂Ω_ad = frule((Zero(), Δx, Zero()), TA, x, uplo)
+            @test Ω_ad == Ω
+            ∂Ω_fd = jvp(_fdm, z -> TA(z, uplo), (x, Δx))
+            @test ∂Ω_ad ≈ ∂Ω_fd
+        end
         @testset "rrule" begin
             x = randn(T, N, N)
             ∂x = randn(T, N, N)

--- a/test/rulesets/LinearAlgebra/structured.jl
+++ b/test/rulesets/LinearAlgebra/structured.jl
@@ -105,8 +105,11 @@
     @testset "$(TM)(::$(TA){$T}) with uplo='$uplo'" for TM in (Matrix, Array), TA in (Symmetric, Hermitian), T in (Float64, ComplexF64), uplo in (:U, :L)
         N = 3
         x = TA(randn(T, N, N), uplo)
+        Δx = randn(T, N, N)
         ∂x = TA(randn(T, N, N), uplo)
         ΔΩ = TM(TA(randn(T, N, N), uplo))
+        frule_test(TM, (x, Δx))
+        frule_test(TM, (x, TA(Δx, uplo)))
         rrule_test(TM, ΔΩ, (x, ∂x))
     end
     @testset "$f" for f in (Adjoint, adjoint, Transpose, transpose)

--- a/test/rulesets/LinearAlgebra/structured.jl
+++ b/test/rulesets/LinearAlgebra/structured.jl
@@ -78,26 +78,18 @@
             end
         end
     end
-    @testset "Symmetric(::AbstractMatrix{$T})" for T in (Float64, ComplexF64)
+    @testset "$(TA)(::AbstractMatrix{$T}, '$(uplo)')" for TA in (Symmetric, Hermitian), T in (Float64, ComplexF64), uplo in (:U, :L)
         N = 3
-        @testset "$T" for T in (Float64, ComplexF64)
+        @testset "rrule" begin
+            x = randn(T, N, N)
+            ∂x = randn(T, N, N)
+            ΔΩ = randn(T, N, N)
             @testset "back(::$MT)" for MT in (Matrix, LowerTriangular, UpperTriangular)
-                rrule_test(Symmetric, MT(randn(T, N, N)), (randn(T, N, N), randn(T, N, N)), (:U, nothing))
-                rrule_test(Symmetric, MT(randn(T, N, N)), (randn(T, N, N), randn(T, N, N)), (:L, nothing))
+                rrule_test(TA, MT(ΔΩ), (x, ∂x), (uplo, nothing))
             end
-            rrule_test(Symmetric, Diagonal(randn(T, N, N)), (randn(T, N, N), Diagonal(randn(T, N, N))), (:U, nothing))
-            rrule_test(Symmetric, Diagonal(randn(T, N, N)), (randn(T, N, N), Diagonal(randn(T, N, N))), (:L, nothing))
-        end
-    end
-    @testset "Hermitian" begin
-        N = 3
-        @testset "$T" for T in (Float64, ComplexF64)
-            @testset "back(::$MT)" for MT in (Matrix, LowerTriangular, UpperTriangular)
-                rrule_test(Hermitian, MT(randn(T, N, N)), (randn(T, N, N), randn(T, N, N)), (:U, nothing))
-                rrule_test(Hermitian, MT(randn(T, N, N)), (randn(T, N, N), randn(T, N, N)), (:L, nothing))
+            @testset "back(::Diagonal)" begin
+                rrule_test(TA, Diagonal(ΔΩ), (x, Diagonal(∂x)), (uplo, nothing))
             end
-            rrule_test(Hermitian, Diagonal(randn(T, N, N)), (randn(T, N, N), Diagonal(randn(T, N, N))), (:U, nothing))
-            rrule_test(Hermitian, Diagonal(randn(T, N, N)), (randn(T, N, N), Diagonal(randn(T, N, N))), (:L, nothing))
         end
     end
     @testset "$f" for f in (Adjoint, adjoint, Transpose, transpose)

--- a/test/rulesets/LinearAlgebra/structured.jl
+++ b/test/rulesets/LinearAlgebra/structured.jl
@@ -33,7 +33,15 @@
     end
     @testset "Symmetric" begin
         N = 3
-        rrule_test(Symmetric, randn(N, N), (randn(N, N), randn(N, N)))
+        @testset "$T" for T in (Float64, ComplexF64)
+            @testset "back(::$MT)" for MT in (Matrix, LowerTriangular, UpperTriangular)
+                rrule_test(Symmetric, MT(randn(T, N, N)), (randn(T, N, N), randn(T, N, N)), (:U, nothing))
+                rrule_test(Symmetric, MT(randn(T, N, N)), (randn(T, N, N), randn(T, N, N)), (:L, nothing))
+            end
+            rrule_test(Symmetric, Diagonal(randn(T, N, N)), (randn(T, N, N), Diagonal(randn(T, N, N))), (:U, nothing))
+            rrule_test(Symmetric, Diagonal(randn(T, N, N)), (randn(T, N, N), Diagonal(randn(T, N, N))), (:L, nothing))
+        end
+    end
     end
     @testset "$f" for f in (Adjoint, adjoint, Transpose, transpose)
         n = 5


### PR DESCRIPTION
Fixes #178 by porting the rules from Zygote, along with the `Hermitian` rules (see https://github.com/FluxML/Zygote.jl/blob/0b3e32d5c0f8e5ef3b061a6f84ed5505f5a202a0/src/lib/array.jl#L454-L491).

Tests currently do not pass I think because ChainRulesTestUtils seems to interpret the `:U` variable as a variable of name `U`, which does not exist. We may also need FiniteDifference v0.10.0 for the complex tests.