### PR TITLE
Add rules for FastMath

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "0.5.2"
+version = "0.5.3"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/ChainRules.jl
+++ b/src/ChainRules.jl
@@ -22,6 +22,7 @@ if VERSION < v"1.3.0-DEV.142"
 end
 
 include("rulesets/Base/base.jl")
+include("rulesets/Base/fastmath_able.jl")
 include("rulesets/Base/array.jl")
 include("rulesets/Base/mapreduce.jl")
 

--- a/src/rulesets/Base/base.jl
+++ b/src/rulesets/Base/base.jl
@@ -6,6 +6,9 @@
 @scalar_rule adjoint(x::Real) One()
 @scalar_rule transpose(x) One()
 @scalar_rule imag(x::Real) Zero()
+@scalar_rule hypot(x::Real) sign(x)
+
+
 @scalar_rule fma(x, y, z) (y, x, One())
 @scalar_rule muladd(x, y, z) (y, x, One())
 @scalar_rule real(x::Real) One()

--- a/src/rulesets/Base/base.jl
+++ b/src/rulesets/Base/base.jl
@@ -1,139 +1,78 @@
-@scalar_rule(one(x), Zero())
-@scalar_rule(zero(x), Zero())
-@scalar_rule(sign(x), Zero())
+# See also fastmath_able.jl for where rules are defined simple base functions
+# that also have FastMath versions.
 
-@scalar_rule(abs(x::Real), sign(x))
-@scalar_rule(abs2(x), 2x)
-@scalar_rule(exp(x::Real), Ω)
-@scalar_rule(exp10(x), Ω * log(oftype(x, 10)))
-@scalar_rule(exp2(x), Ω * log(oftype(x, 2)))
-@scalar_rule(expm1(x), exp(x))
-@scalar_rule(log(x), inv(x))
-@scalar_rule(log10(x), inv(x) / log(oftype(x, 10)))
-@scalar_rule(log1p(x), inv(x + 1))
-@scalar_rule(log2(x), inv(x) / log(oftype(x, 2)))
-
-@scalar_rule(cos(x), -sin(x))
-@scalar_rule(cosd(x), -(π / oftype(x, 180)) * sind(x))
-@scalar_rule(cospi(x), -π * sinpi(x))
-@scalar_rule(sin(x), cos(x))
-@scalar_rule(sincos(x), @setup((sinx, cosx) = Ω), cosx, -sinx)
-@scalar_rule(sind(x), (π / oftype(x, 180)) * cosd(x))
-@scalar_rule(sinpi(x), π * cospi(x))
-
-@scalar_rule(acos(x), -inv(sqrt(1 - x^2)))
-@scalar_rule(acot(x), -inv(1 + x^2))
-@scalar_rule(acsc(x), -inv(x^2 * sqrt(1 - x^-2)))
-@scalar_rule(acsc(x::Real), -inv(abs(x) * sqrt(x^2 - 1)))
-@scalar_rule(asec(x), inv(x^2 * sqrt(1 - x^-2)))
-@scalar_rule(asec(x::Real), inv(abs(x) * sqrt(x^2 - 1)))
-@scalar_rule(asin(x), inv(sqrt(1 - x^2)))
-@scalar_rule(atan(x), inv(1 + x^2))
-@scalar_rule(atan(y, x), @setup(u = x^2 + y^2), (x / u, -y / u))
-
-@scalar_rule(acosd(x), -oftype(x, 180) / π / sqrt(1 - x^2))
-@scalar_rule(acotd(x), -oftype(x, 180) / π / (1 + x^2))
-@scalar_rule(acscd(x), -oftype(x, 180) / π / x^2 / sqrt(1 - x^-2))
-@scalar_rule(acscd(x::Real), -oftype(x, 180) / π / abs(x) / sqrt(x^2 - 1))
-@scalar_rule(asecd(x), oftype(x, 180) / π / x^2 / sqrt(1 - x^-2))
-@scalar_rule(asecd(x::Real), oftype(x, 180) / π / abs(x) / sqrt(x^2 - 1))
-@scalar_rule(asind(x), oftype(x, 180) / π / sqrt(1 - x^2))
-@scalar_rule(atand(x), oftype(x, 180) / π / (1 + x^2))
-
-@scalar_rule(cosh(x), sinh(x))
-@scalar_rule(coth(x), -(csch(x)^2))
-@scalar_rule(sinh(x), cosh(x))
-@scalar_rule(tanh(x), 1-Ω^2)
-
-# Can't multiply though sqrt in acosh because of negative complex case for x
-@scalar_rule(acosh(x), inv(sqrt(x - 1) * sqrt(x + 1)))
-@scalar_rule(acoth(x), inv(1 - x^2))
-@scalar_rule(acsch(x), -inv(x^2 * sqrt(1 + x^-2)))
-@scalar_rule(acsch(x::Real), -inv(abs(x) * sqrt(1 + x^2)))
-@scalar_rule(asech(x), -inv(x * sqrt(1 - x^2)))
-@scalar_rule(asinh(x), inv(sqrt(x^2 + 1)))
-@scalar_rule(atanh(x), inv(1 - x^2))
-
-@scalar_rule(deg2rad(x), π / oftype(x, 180))
-@scalar_rule(rad2deg(x), oftype(x, 180) / π)
-
-@scalar_rule(adjoint(x::Real), One())
-@scalar_rule(conj(x::Real), One())
-@scalar_rule(transpose(x), One())
-
-@scalar_rule(+(x), One())
-@scalar_rule(-(x), -1)
-@scalar_rule(+(x, y), (One(), One()))
-@scalar_rule(-(x, y), (One(), -1))
-@scalar_rule(/(x, y), (inv(y), -(x / y / y)))
-@scalar_rule(\(x, y), (-(y / x / x), inv(x)))
-
-#log(complex(x)) is require so it give correct complex answer for x<0 
-@scalar_rule(^(x, y), (ifelse(iszero(y), zero(Ω), y * x^(y - 1)), Ω * log(complex(x))))
-
-@scalar_rule(cbrt(x), inv(3 * Ω^2))
-@scalar_rule(inv(x), -Ω^2)
-@scalar_rule(sqrt(x), inv(2 * Ω))
-
-@scalar_rule(cot(x), -(1 + Ω^2))
-@scalar_rule(cotd(x), -(π / oftype(x, 180)) * (1 + Ω^2))
-@scalar_rule(csc(x), -Ω * cot(x))
-@scalar_rule(cscd(x), -(π / oftype(x, 180)) * Ω * cotd(x))
-@scalar_rule(csch(x), -coth(x) * Ω)
-@scalar_rule(sec(x), Ω * tan(x))
-@scalar_rule(secd(x), (π / oftype(x, 180)) * Ω * tand(x))
-@scalar_rule(sech(x), -tanh(x) * Ω)
-@scalar_rule(tan(x), 1 + Ω^2)
-@scalar_rule(tand(x), (π / oftype(x, 180)) * (1 + Ω^2))
-
-@scalar_rule(angle(x::Real), Zero())
-@scalar_rule(hypot(x::Real), sign(x))
-@scalar_rule(hypot(x::Real, y::Real), (x / Ω, y / Ω))
-@scalar_rule(imag(x::Real), Zero())
-
-@scalar_rule(fma(x, y, z), (y, x, One()))
-@scalar_rule(max(x, y), @setup(gt = x > y), (gt, !gt))
-@scalar_rule(min(x, y), @setup(gt = x > y), (!gt, gt))
-@scalar_rule(muladd(x, y, z), (y, x, One()))
+@scalar_rule one(x) Zero()
+@scalar_rule zero(x) Zero()
+@scalar_rule adjoint(x::Real) One()
+@scalar_rule transpose(x) One()
+@scalar_rule imag(x::Real) Zero()
+@scalar_rule fma(x, y, z) (y, x, One())
+@scalar_rule muladd(x, y, z) (y, x, One())
+@scalar_rule real(x::Real) One()
+@scalar_rule rem2pi(x, r::RoundingMode) (One(), DoesNotExist())
 @scalar_rule(
     mod(x, y),
     @setup((u, nan) = promote(x / y, NaN16), isint = isinteger(x / y)),
     (ifelse(isint, nan, one(u)), ifelse(isint, nan, -floor(u))),
 )
-@scalar_rule(real(x::Real), One())
-@scalar_rule(rem2pi(x, r::RoundingMode), (One(), DoesNotExist()))
-@scalar_rule(
-    rem(x, y),
-    @setup((u, nan) = promote(x / y, NaN16), isint = isinteger(x / y)),
-    (ifelse(isint, nan, one(u)), ifelse(isint, nan, -trunc(u))),
-)
 
-# product rule requires special care for arguments where `mul` is non-commutative
 
-function frule((_, Δx, Δy), ::typeof(*), x::Number, y::Number)
-    # Optimized version of `Δx .* y .+ x .* Δy`. Also, it is potentially more
-    # accurate on machines with FMA instructions, since there are only two
-    # rounding operations, one in `muladd/fma` and the other in `*`.
-    ∂xy = muladd.(Δx, y, x .* Δy)
-    return x * y, ∂xy
-end
+@scalar_rule deg2rad(x) π / oftype(x, 180)
+@scalar_rule rad2deg(x) oftype(x, 180) / π
 
-function rrule(::typeof(*), x::Number, y::Number)
-    function times_pullback(ΔΩ)
-        return (NO_FIELDS,  @thunk(ΔΩ * y), @thunk(x * ΔΩ))
-    end
-    return x * y, times_pullback
-end
 
-function frule((_, ẏ), ::typeof(identity), x)
-    return x, ẏ
+# Can't multiply though sqrt in acosh because of negative complex case for x
+@scalar_rule acosh(x) inv(sqrt(x - 1) * sqrt(x + 1))
+@scalar_rule acoth(x) inv(1 - x ^ 2)
+@scalar_rule acsch(x) -(inv(x ^ 2 * sqrt(1 + x ^ -2)))
+@scalar_rule acsch(x::Real) -(inv(abs(x) * sqrt(1 + x ^ 2)))
+@scalar_rule asech(x) -(inv(x * sqrt(1 - x ^ 2)))
+@scalar_rule asinh(x) inv(sqrt(x ^ 2 + 1))
+@scalar_rule atanh(x) inv(1 - x ^ 2)
+
+
+@scalar_rule acosd(x) (-(oftype(x, 180)) / π) / sqrt(1 - x ^ 2)
+@scalar_rule acotd(x) (-(oftype(x, 180)) / π) / (1 + x ^ 2)
+@scalar_rule acscd(x) ((-(oftype(x, 180)) / π) / x ^ 2) / sqrt(1 - x ^ -2)
+@scalar_rule acscd(x::Real) ((-(oftype(x, 180)) / π) / abs(x)) / sqrt(x ^ 2 - 1)
+@scalar_rule asecd(x) ((oftype(x, 180) / π) / x ^ 2) / sqrt(1 - x ^ -2)
+@scalar_rule asecd(x::Real) ((oftype(x, 180) / π) / abs(x)) / sqrt(x ^ 2 - 1)
+@scalar_rule asind(x) (oftype(x, 180) / π) / sqrt(1 - x ^ 2)
+@scalar_rule atand(x) (oftype(x, 180) / π) / (1 + x ^ 2)
+
+@scalar_rule cot(x) -((1 + Ω ^ 2))
+@scalar_rule coth(x) -(csch(x) ^ 2)
+@scalar_rule cotd(x) -(π / oftype(x, 180)) * (1 + Ω ^ 2)
+@scalar_rule csc(x) -Ω * cot(x)
+@scalar_rule cscd(x) -(π / oftype(x, 180)) * Ω * cotd(x)
+@scalar_rule csch(x) -(coth(x)) * Ω
+@scalar_rule sec(x) Ω * tan(x)
+@scalar_rule secd(x) (π / oftype(x, 180)) * Ω * tand(x)
+@scalar_rule sech(x) -(tanh(x)) * Ω
+
+@scalar_rule acot(x) -(inv(1 + x ^ 2))
+@scalar_rule acsc(x) -(inv(x ^ 2 * sqrt(1 - x ^ -2)))
+@scalar_rule acsc(x::Real) -(inv(abs(x) * sqrt(x ^ 2 - 1)))
+@scalar_rule asec(x) inv(x ^ 2 * sqrt(1 - x ^ -2))
+@scalar_rule asec(x::Real) inv(abs(x) * sqrt(x ^ 2 - 1))
+
+@scalar_rule cosd(x) -(π / oftype(x, 180)) * sind(x)
+@scalar_rule cospi(x) -π * sinpi(x)
+@scalar_rule sind(x) (π / oftype(x, 180)) * cosd(x)
+@scalar_rule sinpi(x) π * cospi(x)
+@scalar_rule tand(x) (π / oftype(x, 180)) * (1 + Ω ^ 2)
+
+@scalar_rule x \ y (-((y / x) / x), inv(x))
+
+function frule((_, ẏ), ::typeof(identity), x)
+    return (x, ẏ)
 end
 
 function rrule(::typeof(identity), x)
-    function identity_pullback(ȳ)
-        return (NO_FIELDS, ȳ)
+    function identity_pullback(ȳ)
+        return (NO_FIELDS, ȳ)
     end
-    return x, identity_pullback
+    return (x, identity_pullback)
 end
 
 function rrule(::typeof(identity), x::Tuple)

--- a/src/rulesets/Base/fastmath_able.jl
+++ b/src/rulesets/Base/fastmath_able.jl
@@ -1,10 +1,30 @@
 let
     # Include inside this quote any rules that should have FastMath versions
     fastable_ast = quote
-        @scalar_rule sign(x) Zero()
-        @scalar_rule abs(x::Real) sign(x)
-        @scalar_rule abs2(x) 2x
+        #  Trig-Basics
+        @scalar_rule cos(x) -(sin(x))
+        @scalar_rule sin(x) cos(x)
+        @scalar_rule tan(x) 1 + Ω ^ 2
 
+
+        # Trig-Hyperbolic
+        @scalar_rule cosh(x) sinh(x)
+        @scalar_rule sinh(x) cosh(x)
+        @scalar_rule tanh(x) 1 - Ω ^ 2
+
+        # Trig- Inverses
+        @scalar_rule acos(x) -(inv(sqrt(1 - x ^ 2)))
+        @scalar_rule asin(x) inv(sqrt(1 - x ^ 2))
+        @scalar_rule atan(x) inv(1 + x ^ 2)
+
+        # Trig-Multivariate
+        @scalar_rule atan(y, x) @setup(u = x ^ 2 + y ^ 2) (x / u, -y / u)
+        @scalar_rule sincos(x) @setup((sinx, cosx) = Ω) cosx -sinx
+
+        # exponents
+        @scalar_rule cbrt(x) inv(3 * Ω ^ 2)
+        @scalar_rule inv(x) -(Ω ^ 2)
+        @scalar_rule sqrt(x) inv(2Ω)
         @scalar_rule exp(x::Real) Ω
         @scalar_rule exp10(x) Ω * log(oftype(x, 10))
         @scalar_rule exp2(x) Ω * log(oftype(x, 2))
@@ -14,53 +34,39 @@ let
         @scalar_rule log1p(x) inv(x + 1)
         @scalar_rule log2(x) inv(x) / log(oftype(x, 2))
 
-        @scalar_rule cos(x) -(sin(x))
-        @scalar_rule sin(x) cos(x)
-        @scalar_rule sincos(x) @setup((sinx, cosx) = Ω) cosx -sinx
 
-        @scalar_rule tan(x) 1 + Ω ^ 2
-
-        @scalar_rule acos(x) -(inv(sqrt(1 - x ^ 2)))
-        @scalar_rule asin(x) inv(sqrt(1 - x ^ 2))
-        @scalar_rule atan(x) inv(1 + x ^ 2)
-        @scalar_rule atan(y, x) @setup(u = x ^ 2 + y ^ 2) (x / u, -y / u)
-
-        @scalar_rule cosh(x) sinh(x)
-        @scalar_rule sinh(x) cosh(x)
-        @scalar_rule tanh(x) 1 - Ω ^ 2
-
+        # Unary complex functions
+        @scalar_rule abs(x::Real) sign(x)
+        @scalar_rule abs2(x) 2x
+        @scalar_rule angle(x::Real) Zero()
         @scalar_rule conj(x::Real) One()
 
-        @scalar_rule +x One()
-        @scalar_rule -x -1
+        # Binary functions
+        @scalar_rule hypot(x::Real, y::Real) (x / Ω, y / Ω)
         @scalar_rule x + y (One(), One())
         @scalar_rule x - y (One(), -1)
         @scalar_rule x / y (inv(y), -((x / y) / y))
-
         #log(complex(x)) is require so it give correct complex answer for x<0
         @scalar_rule(x ^ y,
             (ifelse(iszero(y), zero(Ω), y * x ^ (y - 1)), Ω * log(complex(x))),
         )
-
-        @scalar_rule cbrt(x) inv(3 * Ω ^ 2)
-        @scalar_rule inv(x) -(Ω ^ 2)
-        @scalar_rule sqrt(x) inv(2Ω)
-
-        @scalar_rule angle(x::Real) Zero()
-        @scalar_rule hypot(x::Real) sign(x)
-        @scalar_rule hypot(x::Real, y::Real) (x / Ω, y / Ω)
-        @scalar_rule max(x, y) @setup(gt = x > y) (gt, !gt)
-        @scalar_rule min(x, y) @setup(gt = x > y) (!gt, gt)
-
         @scalar_rule(
             rem(x, y),
             @setup((u, nan) = promote(x / y, NaN16), isint = isinteger(x / y)),
             (ifelse(isint, nan, one(u)), ifelse(isint, nan, -trunc(u))),
         )
+        @scalar_rule max(x, y) @setup(gt = x > y) (gt, !gt)
+        @scalar_rule min(x, y) @setup(gt = x > y) (!gt, gt)
+
+        # Unary functions
+        @scalar_rule +x One()
+        @scalar_rule -x -1
+
+
+        @scalar_rule sign(x) Zero()
 
 
         # product rule requires special care for arguments where `mul` is non-commutative
-
         function frule((_, Δx, Δy), ::typeof(*), x::Number, y::Number)
             # Optimized version of `Δx .* y .+ x .* Δy`. Also, it is potentially more
             # accurate on machines with FMA instructions, since there are only two

--- a/src/rulesets/Base/fastmath_able.jl
+++ b/src/rulesets/Base/fastmath_able.jl
@@ -1,0 +1,84 @@
+let
+    # Include inside this quote any rules that should have FastMath versions
+    fastable_ast = quote
+        @scalar_rule sign(x) Zero()
+        @scalar_rule abs(x::Real) sign(x)
+        @scalar_rule abs2(x) 2x
+
+        @scalar_rule exp(x::Real) Ω
+        @scalar_rule exp10(x) Ω * log(oftype(x, 10))
+        @scalar_rule exp2(x) Ω * log(oftype(x, 2))
+        @scalar_rule expm1(x) exp(x)
+        @scalar_rule log(x) inv(x)
+        @scalar_rule log10(x) inv(x) / log(oftype(x, 10))
+        @scalar_rule log1p(x) inv(x + 1)
+        @scalar_rule log2(x) inv(x) / log(oftype(x, 2))
+
+        @scalar_rule cos(x) -(sin(x))
+        @scalar_rule sin(x) cos(x)
+        @scalar_rule sincos(x) @setup((sinx, cosx) = Ω) cosx -sinx
+
+        @scalar_rule tan(x) 1 + Ω ^ 2
+
+        @scalar_rule acos(x) -(inv(sqrt(1 - x ^ 2)))
+        @scalar_rule asin(x) inv(sqrt(1 - x ^ 2))
+        @scalar_rule atan(x) inv(1 + x ^ 2)
+        @scalar_rule atan(y, x) @setup(u = x ^ 2 + y ^ 2) (x / u, -y / u)
+
+        @scalar_rule cosh(x) sinh(x)
+        @scalar_rule sinh(x) cosh(x)
+        @scalar_rule tanh(x) 1 - Ω ^ 2
+
+        @scalar_rule conj(x::Real) One()
+
+        @scalar_rule +x One()
+        @scalar_rule -x -1
+        @scalar_rule x + y (One(), One())
+        @scalar_rule x - y (One(), -1)
+        @scalar_rule x / y (inv(y), -((x / y) / y))
+
+        #log(complex(x)) is require so it give correct complex answer for x<0
+        @scalar_rule(x ^ y,
+            (ifelse(iszero(y), zero(Ω), y * x ^ (y - 1)), Ω * log(complex(x))),
+        )
+
+        @scalar_rule cbrt(x) inv(3 * Ω ^ 2)
+        @scalar_rule inv(x) -(Ω ^ 2)
+        @scalar_rule sqrt(x) inv(2Ω)
+
+        @scalar_rule angle(x::Real) Zero()
+        @scalar_rule hypot(x::Real) sign(x)
+        @scalar_rule hypot(x::Real, y::Real) (x / Ω, y / Ω)
+        @scalar_rule max(x, y) @setup(gt = x > y) (gt, !gt)
+        @scalar_rule min(x, y) @setup(gt = x > y) (!gt, gt)
+
+        @scalar_rule(
+            rem(x, y),
+            @setup((u, nan) = promote(x / y, NaN16), isint = isinteger(x / y)),
+            (ifelse(isint, nan, one(u)), ifelse(isint, nan, -trunc(u))),
+        )
+
+
+        # product rule requires special care for arguments where `mul` is non-commutative
+
+        function frule((_, Δx, Δy), ::typeof(*), x::Number, y::Number)
+            # Optimized version of `Δx .* y .+ x .* Δy`. Also, it is potentially more
+            # accurate on machines with FMA instructions, since there are only two
+            # rounding operations, one in `muladd/fma` and the other in `*`.
+            ∂xy = muladd.(Δx, y, x .* Δy)
+            return x * y, ∂xy
+        end
+
+        function rrule(::typeof(*), x::Number, y::Number)
+            function times_pullback(ΔΩ)
+                return (NO_FIELDS,  @thunk(ΔΩ * y), @thunk(x * ΔΩ))
+            end
+            return x * y, times_pullback
+        end
+    end
+
+    # Rewrite everything to use fast_math functions, including the type-constraints
+    eval(Base.FastMath.make_fastmath(fastable_ast))
+    eval(fastable_ast)  # Get original definitions
+    # we do this second so it overwrites anything we included by mistake in the fastable
+end

--- a/test/rulesets/Base/base.jl
+++ b/test/rulesets/Base/base.jl
@@ -61,7 +61,6 @@
         end
     end
 
-
     @testset "*(x, y) (scalar)" begin
         # This is pretty important so testing it fairly heavily
         test_points = (0.0, -2.1, 3.2, 3.7+2.12im, 14.2-7.1im)

--- a/test/rulesets/Base/base.jl
+++ b/test/rulesets/Base/base.jl
@@ -1,9 +1,6 @@
 @testset "base" begin
     @testset "Trig" begin
         @testset "Basics" for x = (Float64(π)-0.01, Complex(π, π/2))
-            test_scalar(sin, x)
-            test_scalar(cos, x)
-            test_scalar(tan, x)
             test_scalar(sec, x)
             test_scalar(csc, x)
             test_scalar(cot, x)
@@ -11,9 +8,6 @@
             test_scalar(cospi, x)
         end
         @testset "Hyperbolic" for x = (Float64(π)-0.01, Complex(π-0.01, π/2))
-            test_scalar(sinh, x)
-            test_scalar(cosh, x)
-            test_scalar(tanh, x)
             test_scalar(sech, x)
             test_scalar(csch, x)
             test_scalar(coth, x)
@@ -28,9 +22,6 @@
             test_scalar(cotd, x)
         end
         @testset "Inverses" for x = (0.5, Complex(0.5, 0.25))
-            test_scalar(asin, x)
-            test_scalar(acos, x)
-            test_scalar(atan, x)
             test_scalar(asec, 1/x)
             test_scalar(acsc, 1/x)
             test_scalar(acot, 1/x)
@@ -52,37 +43,12 @@
             test_scalar(acscd, 1/x)
             test_scalar(acotd, 1/x)
         end
-        @testset "Multivariate" begin
-            @testset "sincos" begin
-                x, Δx, x̄ = randn(3)
-                Δz = (randn(), randn())
-
-                frule_test(sincos, (x, Δx))
-                rrule_test(sincos, Δz, (x, x̄))
-            end
-        end
     end  # Trig
 
-    @testset "math" begin
+    @testset "Angles" begin
         for x in (-0.1, 6.4)
             test_scalar(deg2rad, x)
             test_scalar(rad2deg, x)
-
-            test_scalar(inv, x)
-
-            test_scalar(exp, x)
-            test_scalar(exp2, x)
-            test_scalar(exp10, x)
-
-            test_scalar(cbrt, x)
-
-            if x >= 0
-                test_scalar(sqrt, x)
-                test_scalar(log, x)
-                test_scalar(log2, x)
-                test_scalar(log10, x)
-                test_scalar(log1p, x)
-            end
         end
     end
 
@@ -90,16 +56,11 @@
         for x in (-4.1, 6.4)
             test_scalar(real, x)
             test_scalar(imag, x)
-
-            test_scalar(abs, x)
             test_scalar(hypot, x)
-
-            test_scalar(angle, x)
-            test_scalar(abs2, x)
-            test_scalar(conj, x)
             test_scalar(adjoint, x)
         end
     end
+
 
     @testset "*(x, y) (scalar)" begin
         # This is pretty important so testing it fairly heavily
@@ -132,7 +93,7 @@
         @test extern(dy) == extern(zeros(2, 5) .+ dy)
     end
 
-    @testset "binary function ($f)" for f in (hypot, atan, mod, rem, ^)
+    @testset "binary function ($f)" for f in (mod, \)
         x, Δx, x̄ = 10rand(3)
         y, Δy, ȳ = rand(3)
         Δz = rand()
@@ -164,24 +125,6 @@
     @testset "Constants" for x in (-0.1, 6.4, 1.0+0.5im, -10.0+0im, 0+200im)
         test_scalar(one, x)
         test_scalar(zero, x)
-    end
-
-    @testset "sign" begin
-        @testset "at points" for x in (-1.1, -1.1, 0.5, 100)
-            test_scalar(sign, x)
-        end
-
-        @testset "Zero over the point discontinuity" begin
-            # Can't do finite differencing because we are lying
-            # following the subgradient convention.
-
-            _, pb = rrule(sign, 0.0)
-            _, x̄ = pb(10.5)
-            @test extern(x̄) == 0
-
-            _, ẏ = frule((Zero(), 10.5), sign, 0.0)
-            @test extern(ẏ) == 0
-        end
     end
 
     @testset "trinary ($f)" for f in (muladd, fma)

--- a/test/rulesets/Base/fastmath_able.jl
+++ b/test/rulesets/Base/fastmath_able.jl
@@ -25,7 +25,7 @@ const FASTABLE_AST = quote
                 rrule_test(sincos, Δz, (x, x̄))
             end
         end
-    end  # Trig
+    end
 
     @testset "exponents" begin
         for x in (-0.1, 6.4)
@@ -51,11 +51,9 @@ const FASTABLE_AST = quote
     @testset "Unary complex functions" begin
         for x in (-4.1, 6.4)
             test_scalar(abs, x)
-
             test_scalar(angle, x)
             test_scalar(abs2, x)
             test_scalar(conj, x)
-
         end
     end
 

--- a/test/rulesets/Base/fastmath_able.jl
+++ b/test/rulesets/Base/fastmath_able.jl
@@ -1,0 +1,107 @@
+# Add tests to the quote for functions with  FastMath varients.
+const FASTABLE_AST = quote
+    @testset "Trig" begin
+        @testset "Basics" for x = (Float64(π)-0.01, Complex(π, π/2))
+            test_scalar(sin, x)
+            test_scalar(cos, x)
+            test_scalar(tan, x)
+        end
+        @testset "Hyperbolic" for x = (Float64(π)-0.01, Complex(π-0.01, π/2))
+            test_scalar(sinh, x)
+            test_scalar(cosh, x)
+            test_scalar(tanh, x)
+        end
+        @testset "Inverses" for x = (0.5, Complex(0.5, 0.25))
+            test_scalar(asin, x)
+            test_scalar(acos, x)
+            test_scalar(atan, x)
+        end
+        @testset "Multivariate" begin
+            @testset "sincos" begin
+                x, Δx, x̄ = randn(3)
+                Δz = (randn(), randn())
+
+                frule_test(sincos, (x, Δx))
+                rrule_test(sincos, Δz, (x, x̄))
+            end
+        end
+    end  # Trig
+
+    @testset "exponents" begin
+        for x in (-0.1, 6.4)
+            test_scalar(inv, x)
+
+            test_scalar(exp, x)
+            test_scalar(exp2, x)
+            test_scalar(exp10, x)
+            test_scalar(expm1, x)
+
+            test_scalar(cbrt, x)
+
+            if x >= 0
+                test_scalar(sqrt, x)
+                test_scalar(log, x)
+                test_scalar(log2, x)
+                test_scalar(log10, x)
+                test_scalar(log1p, x)
+            end
+        end
+    end
+
+    @testset "Unary complex functions" begin
+        for x in (-4.1, 6.4)
+            test_scalar(abs, x)
+
+            test_scalar(angle, x)
+            test_scalar(abs2, x)
+            test_scalar(conj, x)
+
+        end
+    end
+
+    @testset "Unary functions" begin
+        for x in (-4.1, 6.4)
+            test_scalar(+, x)
+            test_scalar(-, x)
+        end
+    end
+
+    @testset "binary function ($f)" for f in (/, +, -, hypot, atan, rem, ^, max, min)
+        x, Δx, x̄ = 10rand(3)
+        y, Δy, ȳ = rand(3)
+        Δz = rand()
+
+        frule_test(f, (x, Δx), (y, Δy))
+        rrule_test(f, Δz, (x, x̄), (y, ȳ))
+    end
+
+
+
+    @testset "sign" begin
+        @testset "at points" for x in (-1.1, -1.1, 0.5, 100)
+            test_scalar(sign, x)
+        end
+
+        @testset "Zero over the point discontinuity" begin
+            # Can't do finite differencing because we are lying
+            # following the subgradient convention.
+
+            _, pb = rrule(sign, 0.0)
+            _, x̄ = pb(10.5)
+            @test extern(x̄) == 0
+
+            _, ẏ = frule((Zero(), 10.5), sign, 0.0)
+            @test extern(ẏ) == 0
+        end
+    end
+end
+
+# Now we generate tests for fast and nonfast versions
+@eval @testset "fastmath_able Base functions" begin
+    $FASTABLE_AST
+end
+
+
+@eval @testset "fastmath_able FastMath functions" begin
+    $(Base.FastMath.make_fastmath(FASTABLE_AST))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,6 +19,7 @@ println("Testing ChainRules.jl")
     @testset "rulesets" begin
         @testset "Base" begin
             include(joinpath("rulesets", "Base", "base.jl"))
+            include(joinpath("rulesets", "Base", "fastmath_able.jl"))
             include(joinpath("rulesets", "Base", "array.jl"))
             include(joinpath("rulesets", "Base", "mapreduce.jl"))
         end


### PR DESCRIPTION
Closes #174 
(cc @mikeinnes)

Needs tests still.
The code has tests, in that it is still the same basic source as before, so the base cases are tested.
there are no tests of the fast math versions though.
Those tests can be generated in the same way however, if that is acceptable?

---
This PR also adds some missing tests for things that have fast math varients:
  - `expm1`
  - binary `+` and `-`, `/`, `\`, `max`, `min`

They are added in the trivial way, by adding them to the loops identical to others of their class.
