### PR TITLE
Add rules for evalpoly

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "0.7.3"
+version = "0.7.2"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "0.7.1"
+version = "0.7.3"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/rulesets/Base/base.jl
+++ b/src/rulesets/Base/base.jl
@@ -101,10 +101,7 @@ if VERSION ≥ v"1.4"
 
     function rrule(::typeof(evalpoly), x, p)
         function evalpoly_pullback(Δy)
-            ∂x = Thunk() do
-                q = _evalpoly_dxcoef(p)
-                return evalpoly(x, q)' * Δy
-            end
+            ∂x = @thunk _evalpoly_backx(Δy, x, p)
             ∂p = @thunk _evalpoly_backp(Δy, x, p)
             return NO_FIELDS, ∂x, ∂p
         end
@@ -116,6 +113,11 @@ if VERSION ≥ v"1.4"
         N = length(p)
         @inbounds q = (1:(N - 1)) .* view(p, 1:(N - 1))
         return q
+    end
+
+    function _evalpoly_backx(Δy, x, p)
+        q = _evalpoly_dxcoef(p)
+        return evalpoly(x, q)' * Δy
     end
 
     # This is a geometric progression, that is ∂p = Δy * (I, x, x², …, xⁿ)'

--- a/src/rulesets/Base/base.jl
+++ b/src/rulesets/Base/base.jl
@@ -128,7 +128,7 @@ if VERSION ≥ v"1.4"
                 ex = :(muladd(x, $yi, p[$(N - i)]))
             end
             push!(exs, :(y = $ex))
-            Expr(:block, exs..., :(y, ($(vars...), y)))
+            Expr(:block, exs..., :(y, ($(vars...),)))
         else
             _evalpoly_intermediates_fallback(x, p)
         end
@@ -136,20 +136,21 @@ if VERSION ≥ v"1.4"
     function _evalpoly_intermediates_fallback(x, p::Tuple)
         N = length(p)
         y = one(x) * p[N]
-        ys = (y, ntuple(N - 1) do i
+        ys = (y, ntuple(N - 2) do i
             return y = muladd(x, y, p[N - i])
         end...)
+        y = muladd(x, y, p[1])
         return y, ys
     end
     function _evalpoly_intermediates(x, p)
         N = length(p)
         @inbounds yn = one(x) * p[N]
-        ys = similar(p, typeof(yn))
+        ys = similar(p, typeof(yn), N - 1)
         @inbounds ys[1] = yn
-        @inbounds for i in 2:N
+        @inbounds for i in 2:(N - 1)
             ys[i] = muladd(x, ys[i - 1], p[N - i + 1])
         end
-        @inbounds y = ys[N]
+        @inbounds y = muladd(x, ys[N - 1], p[1])
         return y, ys
     end
 

--- a/src/rulesets/Base/base.jl
+++ b/src/rulesets/Base/base.jl
@@ -111,7 +111,7 @@ if VERSION ≥ v"1.4"
     _evalpoly_dxcoef(p) = ntuple(i -> i * p[i + 1], length(p) - 1)
     function _evalpoly_dxcoef(p::AbstractVector)
         N = length(p)
-        @inbounds q = (1:(N - 1)) .* view(p, 1:(N - 1))
+        @inbounds q = (1:(N - 1)) .* view(p, 2:N)
         return q
     end
 

--- a/src/rulesets/Base/base.jl
+++ b/src/rulesets/Base/base.jl
@@ -114,6 +114,7 @@ if VERSION ≥ v"1.4"
         return y, evalpoly_pullback
     end
 
+    # evalpoly but storing intermediates
     function _evalpoly_intermediates(x, p::Tuple)
         return if @generated
             N = length(p.parameters)

--- a/src/rulesets/Base/base.jl
+++ b/src/rulesets/Base/base.jl
@@ -100,8 +100,7 @@ if VERSION ≥ v"1.4"
     end
 
     function rrule(::typeof(evalpoly), x, p)
-        y = evalpoly(x, p)
-        function evalpoly_back(Δy)
+        function evalpoly_pullback(Δy)
             ∂x = Thunk() do
                 q = _evalpoly_dxcoef(p)
                 return evalpoly(x, q)' * Δy
@@ -109,7 +108,7 @@ if VERSION ≥ v"1.4"
             ∂p = @thunk _evalpoly_backp(Δy, x, p)
             return NO_FIELDS, ∂x, ∂p
         end
-        return y, evalpoly_back
+        return evalpoly(x, p), evalpoly_pullback
     end
 
     _evalpoly_dxcoef(p) = ntuple(i -> i * p[i + 1], length(p) - 1)

--- a/src/rulesets/Base/base.jl
+++ b/src/rulesets/Base/base.jl
@@ -135,7 +135,7 @@ if VERSION ≥ v"1.4"
     end
     function _evalpoly_intermediates_fallback(x, p::Tuple)
         N = length(p)
-        y = one(x) * p[N]
+        y = p[N]
         ys = (y, ntuple(N - 2) do i
             return y = muladd(x, y, p[N - i])
         end...)

--- a/src/rulesets/Base/base.jl
+++ b/src/rulesets/Base/base.jl
@@ -216,13 +216,14 @@ if VERSION ≥ v"1.4"
         ∂p = similar(p, typeof(∂p1))
         @inbounds begin
             ∂x = _evalpoly_backx(x, ys[N - 1], ∂yi)
+            ∂yi = x′ * ∂yi
             ∂p[1] = ∂p1
             for i in 2:(N - 1)
-                ∂yi = x′ * ∂yi
                 ∂x = _evalpoly_backx(x, ys[N - i], ∂x, ∂yi)
                 ∂p[i] = _evalpoly_backp(p[i], ∂yi)
+                ∂yi = x′ * ∂yi
             end
-            ∂p[N] = _evalpoly_backp(p[N], x′ * ∂yi)
+            ∂p[N] = _evalpoly_backp(p[N], ∂yi)
         end
         return ∂x, ∂p
     end

--- a/src/rulesets/Base/base.jl
+++ b/src/rulesets/Base/base.jl
@@ -127,7 +127,7 @@ if VERSION ≥ v"1.4"
         for i in 2:N
             ∂p = Base.setindex(∂p, ∂p[i - 1] * x′, i)
         end
-        return ∂p
+        return Composite{typeof(p)}(∂p...)
     end
     function _evalpoly_backp(Δy, x, p::AbstractVector)
         ∂p = similar(p, typeof(Δy * x))

--- a/src/rulesets/Base/base.jl
+++ b/src/rulesets/Base/base.jl
@@ -135,8 +135,8 @@ if VERSION ≥ v"1.4"
     function _evalpoly_backp(Δy, x, p::AbstractVector)
         ∂p = similar(p, typeof(Δy * x))
         N = length(∂p)
-        ∂p[1] = Δy
         x′ = x'
+        ∂p[1] = Δy
         for i in 2:N
             @inbounds ∂p[i] = ∂p[i - 1] * x′
         end

--- a/src/rulesets/Base/base.jl
+++ b/src/rulesets/Base/base.jl
@@ -115,13 +115,14 @@ if VERSION ≥ v"1.4"
         return q
     end
 
+    # TODO: Handle when x is a UniformScaling, p is a matrix
     function _evalpoly_backx(Δy, x, p)
         q = _evalpoly_dxcoef(p)
         return evalpoly(x, q)' * Δy
     end
 
     # This is a geometric progression, that is ∂p = Δy * (I, x, x², …, xⁿ)'
-    # TODO: Handle case where x is a matrix and p is UniformScaling
+    # TODO: Handle when x is a matrix, p is a UniformScaling
     function _evalpoly_backp(Δy, x, p::Tuple)
         N = length(p)
         ∂p = ntuple(_ -> Δy, N)

--- a/src/rulesets/Base/base.jl
+++ b/src/rulesets/Base/base.jl
@@ -118,17 +118,17 @@ if VERSION ≥ v"1.4"
     function _evalpoly_intermediates(x, p::Tuple)
         return if @generated
             N = length(p.parameters)
-            defs = []
+            exs = []
             vars = []
             ex = :(p[$N])
             for i in (N - 1):-1:1
                 yi = Symbol("y", i + 1)
                 push!(vars, yi)
-                push!(defs, :($yi = $ex))
+                push!(exs, :($yi = $ex))
                 ex = :(muladd(x, $yi, p[$i]))
             end
-            push!(defs, :(y1 = $ex))
-            Expr(:block, defs..., :(y1, ($(vars...), y1)))
+            push!(exs, :(y1 = $ex))
+            Expr(:block, exs..., :(y1, ($(vars...), y1)))
         else # fallback when can't generate code
             N = length(p)
             y = one(x) * p[N]
@@ -158,18 +158,18 @@ if VERSION ≥ v"1.4"
         x′ = x'
         ∂x = zero(Δy)
         ∂p = if @generated
-            defs = []
+            exs = []
             vars = []
             ex = :(Δy)
             N = length(p.parameters)
             for i in 1:(N - 1)
                 ∂yi = Symbol("∂y", i)
                 push!(vars, ∂yi)
-                push!(defs, :($∂yi = $ex))
-                push!(defs, :(∂x = muladd($∂yi, ys[$(N - i)]', ∂x)))
+                push!(exs, :($∂yi = $ex))
+                push!(exs, :(∂x = muladd($∂yi, ys[$(N - i)]', ∂x)))
                 ex = :(x′ * $∂yi)
             end
-            Expr(:block, defs..., :($(vars...), $ex))
+            Expr(:block, exs..., :($(vars...), $ex))
         else # fallback when can't generate code
             ∂yi = Δy
             N = length(p)

--- a/test/rulesets/Base/base.jl
+++ b/test/rulesets/Base/base.jl
@@ -150,13 +150,13 @@
             x, p = randn(T), Tuple(randn(T, 10))
             y_fb, ys_fb = ChainRules._evalpoly_intermediates_fallback(x, p)
             y, ys = ChainRules._evalpoly_intermediates(x, p)
-            @test y_fb == y
+            @test y_fb ≈ y
             @test collect(ys_fb) ≈ collect(ys)
 
             Δy, ys = randn(T), Tuple(randn(T, 9))
             ∂x_fb, ∂p_fb = ChainRules._evalpoly_back_fallback(x, p, ys, Δy)
             ∂x, ∂p = ChainRules._evalpoly_back(x, p, ys, Δy)
-            @test ∂x_fb == ∂x
+            @test ∂x_fb ≈ ∂x
             @test collect(∂p_fb) ≈ collect(∂p)
         end
 

--- a/test/rulesets/Base/base.jl
+++ b/test/rulesets/Base/base.jl
@@ -123,20 +123,47 @@
 
     VERSION ≥ v"1.4" && @testset "evalpoly" begin
         @testset "frule" begin
-            frule_test(evalpoly, (randn(), randn()), (randn(5), randn(5)))
-            frule_test(evalpoly, (randn(), randn()), (Tuple(randn(5)), Tuple(randn(5))))
+            @testset "scalar" begin
+                frule_test(evalpoly, (randn(), randn()), (randn(5), randn(5)))
+                frule_test(evalpoly, (randn(), randn()), (Tuple(randn(5)), Tuple(randn(5))))
+            end
+
+            @testset "matrix" begin
+                frule_test(
+                    evalpoly, (randn(3, 3), randn(3, 3)),
+                    ([randn(3, 3) for _ in 1:5], [randn(3, 3) for _ in 1:5]),
+                )
+                frule_test(
+                    evalpoly, (randn(3, 3), randn(3, 3)),
+                    (Tuple([randn(3, 3) for _ in 1:5]), Tuple([randn(3, 3) for _ in 1:5])),
+                )
+            end
         end
 
         @testset "rrule" begin
             @testset "$T" for T in (Float64, ComplexF64)
-                rrule_test(
-                    evalpoly, randn(T), (randn(T), randn(T)),
-                    (randn(T, 5), randn(T, 5)),
-                )
-                rrule_test(
-                    evalpoly, randn(T), (randn(T), randn(T)),
-                    (Tuple(randn(T, 5)), Tuple(randn(T, 5))),
-                )
+                @testset "scalar" begin
+                    rrule_test(
+                        evalpoly, randn(T), (randn(T), randn(T)),
+                        (randn(T, 5), randn(T, 5)),
+                    )
+                    rrule_test(
+                        evalpoly, randn(T), (randn(T), randn(T)),
+                        (Tuple(randn(T, 5)), Tuple(randn(T, 5))),
+                    )
+                end
+
+                @testset "matrix" begin
+                    rrule_test(
+                        evalpoly, randn(T, 3, 3), (randn(T, 3, 3), randn(T, 3, 3)),
+                        ([randn(T, 3, 3) for i in 1:5], [randn(T, 3, 3) for i in 1:5]),
+                    )
+                    rrule_test(
+                        evalpoly, randn(T, 3, 3), (randn(T, 3, 3), randn(T, 3, 3)),
+                        (Tuple([randn(T, 3, 3) for i in 1:5]),
+                         Tuple([randn(T, 3, 3) for i in 1:5])),
+                    )
+                end
             end
         end
     end

--- a/test/rulesets/Base/base.jl
+++ b/test/rulesets/Base/base.jl
@@ -151,13 +151,13 @@
             y_fb, ys_fb = ChainRules._evalpoly_intermediates_fallback(x, p)
             y, ys = ChainRules._evalpoly_intermediates(x, p)
             @test y_fb == y
-            @test collect(ys_fb) == collect(ys)
+            @test collect(ys_fb) ≈ collect(ys)
 
             Δy, ys = randn(T), Tuple(randn(T, 9))
             ∂x_fb, ∂p_fb = ChainRules._evalpoly_back_fallback(x, p, ys, Δy)
             ∂x, ∂p = ChainRules._evalpoly_back(x, p, ys, Δy)
             @test ∂x_fb == ∂x
-            @test collect(∂p_fb) == collect(∂p)
+            @test collect(∂p_fb) ≈ collect(∂p)
         end
 
         @testset "x dim: $(nx), pi dim: $(np), type: $T" for T in (Float64, ComplexF64), nx in (tuple(), 3), np in (tuple(), 3)

--- a/test/rulesets/Base/base.jl
+++ b/test/rulesets/Base/base.jl
@@ -141,7 +141,7 @@
         end
 
         @testset "rrule" begin
-            @testset "$T" for T in (Float64, ComplexF64)
+            @testset "$T" for T in (Float64,) # TODO: test ComplexF64
                 @testset "scalar" begin
                     rrule_test(
                         evalpoly, randn(T), (randn(T), randn(T)),

--- a/test/rulesets/Base/base.jl
+++ b/test/rulesets/Base/base.jl
@@ -148,11 +148,16 @@
         # test fallbacks for when code generation fails
         @testset "fallbacks for $T" for T in (Float64, ComplexF64)
             x, p = randn(T), Tuple(randn(T, 10))
-            @test ChainRules._evalpoly_intermediates_fallback(x, p) ==
-                    ChainRules._evalpoly_intermediates(x, p)
+            y_fb, ys_fb = ChainRules._evalpoly_intermediates_fallback(x, p)
+            y, ys = ChainRules._evalpoly_intermediates(x, p)
+            @test y_fb == y
+            @test collect(ys_fb) == collect(ys)
+
             Δy, ys = randn(T), Tuple(randn(T, 9))
-            @test ChainRules._evalpoly_back_fallback(x, p, ys, Δy) ==
-                    ChainRules._evalpoly_back(x, p, ys, Δy)
+            ∂x_fb, ∂p_fb = ChainRules._evalpoly_back_fallback(x, p, ys, Δy)
+            ∂x, ∂p = ChainRules._evalpoly_back(x, p, ys, Δy)
+            @test ∂x_fb == ∂x
+            @test collect(∂p_fb) == collect(∂p)
         end
 
         @testset "x dim: $(nx), pi dim: $(np), type: $T" for T in (Float64, ComplexF64), nx in (tuple(), 3), np in (tuple(), 3)

--- a/test/rulesets/Base/base.jl
+++ b/test/rulesets/Base/base.jl
@@ -145,9 +145,11 @@
                 # test fallbacks for when code generation fails
                 @testset "fallbacks" begin
                     x, p = randn(T), Tuple(randn(T, 10))
-                    @test ChainRules._evalpoly_intermediates_fallback(x, p) == ChainRules._evalpoly_intermediates(x, p)
-                    Δy, ys = randn(T), Tuple(randn(T, 10))
-                    @test ChainRules._evalpoly_back_fallback(x, p, ys, Δy) == ChainRules._evalpoly_back(x, p, ys, Δy)
+                    @test ChainRules._evalpoly_intermediates_fallback(x, p) ==
+                          ChainRules._evalpoly_intermediates(x, p)
+                    Δy, ys = randn(T), Tuple(randn(T, 9))
+                    @test ChainRules._evalpoly_back_fallback(x, p, ys, Δy) ==
+                          ChainRules._evalpoly_back(x, p, ys, Δy)
                 end
 
                 @testset "(x::Number, pi::Number)" begin

--- a/test/rulesets/Base/base.jl
+++ b/test/rulesets/Base/base.jl
@@ -121,6 +121,28 @@
         )
     end
 
+if VERSION ≥ v"1.4"
+    @testset "evalpoly" begin
+        @testset "frule" begin
+            frule_test(evalpoly, (randn(), randn()), (randn(5), randn(5)))
+            frule_test(evalpoly, (randn(), randn()), (Tuple(randn(5)), Tuple(randn(5))))
+        end
+
+        @testset "rrule" begin
+            @testset "$T" for T in (Float64, ComplexF64)
+                rrule_test(
+                    evalpoly, randn(T), (randn(T), randn(T)),
+                    (randn(T, 5), randn(T, 5)),
+                )
+                rrule_test(
+                    evalpoly, randn(T), (randn(T), randn(T)),
+                    (Tuple(randn(T, 5)), Tuple(randn(T, 5))),
+                )
+            end
+        end
+    end
+end
+
     @testset "Constants" for x in (-0.1, 6.4, 1.0+0.5im, -10.0+0im, 0+200im)
         test_scalar(one, x)
         test_scalar(zero, x)

--- a/test/rulesets/Base/base.jl
+++ b/test/rulesets/Base/base.jl
@@ -122,6 +122,13 @@
     end
 
     VERSION ≥ v"1.4" && @testset "evalpoly" begin
+        # test fallbacks for when code generation fails
+        @testset "fallbacks" begin
+            x, p = randn(), Tuple(randn(10))
+            @test ChainRules._evalpoly_intermediates_fallback(x, p) == ChainRules._evalpoly_intermediates(x, p)
+            Δy, ys = randn(), Tuple(randn(10))
+            @test ChainRules._evalpoly_back_fallback(x, p, ys, Δy) == ChainRules._evalpoly_back(x, p, ys, Δy)
+        end
         @testset "frule" begin
             @testset "scalar" begin
                 frule_test(evalpoly, (randn(), randn()), (randn(5), randn(5)))

--- a/test/rulesets/Base/base.jl
+++ b/test/rulesets/Base/base.jl
@@ -121,8 +121,7 @@
         )
     end
 
-if VERSION ≥ v"1.4"
-    @testset "evalpoly" begin
+    VERSION ≥ v"1.4" && @testset "evalpoly" begin
         @testset "frule" begin
             frule_test(evalpoly, (randn(), randn()), (randn(5), randn(5)))
             frule_test(evalpoly, (randn(), randn()), (Tuple(randn(5)), Tuple(randn(5))))
@@ -141,7 +140,6 @@ if VERSION ≥ v"1.4"
             end
         end
     end
-end
 
     @testset "Constants" for x in (-0.1, 6.4, 1.0+0.5im, -10.0+0im, 0+200im)
         test_scalar(one, x)

--- a/test/rulesets/Base/base.jl
+++ b/test/rulesets/Base/base.jl
@@ -149,7 +149,7 @@
 
         @testset "rrule" begin
             @testset "$T" for T in (Float64,) # TODO: test ComplexF64
-                @testset "scalar" begin
+                @testset "(x::Number, pi::Number)" begin
                     rrule_test(
                         evalpoly, randn(T), (randn(T), randn(T)),
                         (randn(T, 5), randn(T, 5)),
@@ -160,13 +160,25 @@
                     )
                 end
 
-                @testset "matrix" begin
+                @testset "(x::Matrix, pi::Matrix)" begin
                     rrule_test(
                         evalpoly, randn(T, 3, 3), (randn(T, 3, 3), randn(T, 3, 3)),
                         ([randn(T, 3, 3) for i in 1:5], [randn(T, 3, 3) for i in 1:5]),
                     )
                     rrule_test(
                         evalpoly, randn(T, 3, 3), (randn(T, 3, 3), randn(T, 3, 3)),
+                        (Tuple([randn(T, 3, 3) for i in 1:5]),
+                         Tuple([randn(T, 3, 3) for i in 1:5])),
+                    )
+                end
+
+                @testset "(x::Number, pi::Matrix)" begin
+                    rrule_test(
+                        evalpoly, randn(T, 3, 3), (randn(T), randn(T)),
+                        ([randn(T, 3, 3) for i in 1:5], [randn(T, 3, 3) for i in 1:5]),
+                    )
+                    rrule_test(
+                        evalpoly, randn(T, 3, 3), (randn(T), randn(T)),
                         (Tuple([randn(T, 3, 3) for i in 1:5]),
                          Tuple([randn(T, 3, 3) for i in 1:5])),
                     )

--- a/test/rulesets/Base/base.jl
+++ b/test/rulesets/Base/base.jl
@@ -122,13 +122,6 @@
     end
 
     VERSION ≥ v"1.4" && @testset "evalpoly" begin
-        # test fallbacks for when code generation fails
-        @testset "fallbacks" begin
-            x, p = randn(), Tuple(randn(10))
-            @test ChainRules._evalpoly_intermediates_fallback(x, p) == ChainRules._evalpoly_intermediates(x, p)
-            Δy, ys = randn(), Tuple(randn(10))
-            @test ChainRules._evalpoly_back_fallback(x, p, ys, Δy) == ChainRules._evalpoly_back(x, p, ys, Δy)
-        end
         @testset "frule" begin
             @testset "scalar" begin
                 frule_test(evalpoly, (randn(), randn()), (randn(5), randn(5)))
@@ -149,6 +142,14 @@
 
         @testset "rrule" begin
             @testset "$T" for T in (Float64,) # TODO: test ComplexF64
+                # test fallbacks for when code generation fails
+                @testset "fallbacks" begin
+                    x, p = randn(T), Tuple(randn(T, 10))
+                    @test ChainRules._evalpoly_intermediates_fallback(x, p) == ChainRules._evalpoly_intermediates(x, p)
+                    Δy, ys = randn(T), Tuple(randn(T, 10))
+                    @test ChainRules._evalpoly_back_fallback(x, p, ys, Δy) == ChainRules._evalpoly_back(x, p, ys, Δy)
+                end
+
                 @testset "(x::Number, pi::Number)" begin
                     rrule_test(
                         evalpoly, randn(T), (randn(T), randn(T)),


### PR DESCRIPTION
~Most of the pushforward and pullback for `evalpoly` can be written as more calls to `evalpoly`, which is very efficient.~

Edit: This is true in the scalar case but not the matrix. In the current implementation, both the matrix and scalar polynomials have forward and reverse rules on the same order as `evalpoly` itself.

~Currently all but one of the tests fail for various reasons. I think the testers in ChainRulesTestUtils don't like when one of the inputs is a `Tuple`.~ Also, I don't expect the complex tests to pass until this package uses FiniteDifferences v0.10.0.

Edit: Oh, and I see that ChainRules doesn't test against 1.4 yet at all.

~@oxinabox I also tested against https://github.com/FluxML/Zygote.jl/pull/366 and may have hit a bug where Zygote doesn't like that the adjoint of `p` is a `Tuple`, but I'm not sure.~

Edit: Now that I'm using `Composite`, it works fine in Zygote.

```julia
julia> using Zygote

julia> x = randn();

julia> pv = randn(10);

julia> p = Tuple(pv);

julia> evalpoly(x, pv)
126.48423475727726

julia> evalpoly(x, p)
126.48423475727726

julia> Zygote.gradient(evalpoly, x, pv) # seems to work fine
(1722.5531441128583, [1.0, 1.7894268524990125, 3.2020484604445225, 5.72983149812255, 10.253114343035136, 18.347198127169843, 32.83096899687731, 58.748617516574825, 105.12635373135284, 188.1159202721925])

julia> Zygote.gradient(evalpoly, x, p) # I guess not happy about the adjoint of p being a tuple?
ERROR: MethodError: no method matching conj(::NTuple{10,Float64})
Closest candidates are:
  conj(::Missing) at missing.jl:100
  conj(::ForwardDiff.Dual) at /Users/saxen/.julia/packages/ForwardDiff/cXTw0/src/dual.jl:367
  conj(::Real) at number.jl:167
  ...
Stacktrace:
 [1] wrap_chainrules_output at /Users/saxen/projects/Zygote.jl/src/compiler/chainrules.jl:49 [inlined]
 [2] map(::typeof(Zygote.wrap_chainrules_output), ::Tuple{ChainRulesCore.Zero,ChainRulesCore.Thunk{ChainRules.var"#51#56"{Float64,Float64,NTuple{10,Float64}}},ChainRulesCore.Thunk{ChainRules.var"#52#57"{Float64,Float64,NTuple{10,Float64}}}}) at ./tuple.jl:159
 [3] wrap_chainrules_output at /Users/saxen/projects/Zygote.jl/src/compiler/chainrules.jl:50 [inlined]
 [4] wrap_chainrules_pullback at /Users/saxen/projects/Zygote.jl/src/compiler/chainrules.jl:86 [inlined]
 [5] ZBack at /Users/saxen/projects/Zygote.jl/src/compiler/chainrules.jl:99 [inlined]
 [6] (::Zygote.var"#41#42"{Zygote.ZBack{ChainRules.var"#evalpoly_pullback#55"{Float64,NTuple{10,Float64}}}})(::Float64) at /Users/saxen/projects/Zygote.jl/src/compiler/interface.jl:45
 [7] gradient(::Function, ::Float64, ::Vararg{Any,N} where N) at /Users/saxen/projects/Zygote.jl/src/compiler/interface.jl:54
 [8] top-level scope at REPL[8]:1
```