### PR TITLE
Rules for cross-product

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "0.6.4"
+version = "0.6.5"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "0.6.3"
+version = "0.6.4"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "0.6.1"
+version = "0.6.2"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/rulesets/LinearAlgebra/dense.jl
+++ b/src/rulesets/LinearAlgebra/dense.jl
@@ -26,12 +26,6 @@ end
 function frule((_, Δa, Δb), ::typeof(cross), a::AbstractVector, b::AbstractVector)
     return cross(a, b), cross(Δa, b) .+ cross(a, Δb)
 end
-# chunked mode
-function frule((_, Δa, Δb)::Tuple{<:Any,<:AbstractMatrix,<:AbstractMatrix},
-               ::typeof(cross), a::AbstractVector, b::AbstractVector)
-    aₓ, bₓ = _crossmat(a), _crossmat(b)
-    return aₓ * b, Δa * bₓ .- Δb * aₓ
-end
 
 # TODO: support complex vectors
 function rrule(::typeof(cross), a::AbstractVector{<:Real}, b::AbstractVector{<:Real})

--- a/src/rulesets/LinearAlgebra/dense.jl
+++ b/src/rulesets/LinearAlgebra/dense.jl
@@ -20,6 +20,32 @@ function rrule(::typeof(dot), x, y)
 end
 
 #####
+##### `cross`
+#####
+
+function frule((_, Δa, Δb), ::typeof(cross), a::AbstractVector, b::AbstractVector)
+    return cross(a, b), cross(Δa, b) .+ cross(a, Δb)
+end
+# chunked mode
+function frule((_, Δa, Δb)::Tuple{<:Any,<:AbstractMatrix,<:AbstractMatrix},
+               ::typeof(cross), a::AbstractVector, b::AbstractVector)
+    aₓ, bₓ = _crossmat(a), _crossmat(b)
+    return aₓ * b, Δa * bₓ .- Δb * aₓ
+end
+
+# TODO: support complex vectors
+function rrule(::typeof(cross), a::AbstractVector{<:Real}, b::AbstractVector{<:Real})
+    Ω = cross(a, b)
+    function cross_pullback(ΔΩ)
+        return (NO_FIELDS, @thunk(cross(b, ΔΩ)), @thunk(cross(ΔΩ, a)))
+    end
+    return Ω, cross_pullback
+end
+
+# cross product matrix, i.e. matrix vₓ such that vₓ * a = v × a
+_crossmat(v) = [0 -v[3] v[2]; v[3] 0 -v[1]; -v[2] v[1] 0]
+
+#####
 ##### `inv`
 #####
 

--- a/src/rulesets/LinearAlgebra/dense.jl
+++ b/src/rulesets/LinearAlgebra/dense.jl
@@ -36,9 +36,6 @@ function rrule(::typeof(cross), a::AbstractVector{<:Real}, b::AbstractVector{<:R
     return Ω, cross_pullback
 end
 
-# cross product matrix, i.e. matrix vₓ such that vₓ * a = v × a
-_crossmat(v) = [0 -v[3] v[2]; v[3] 0 -v[1]; -v[2] v[1] 0]
-
 #####
 ##### `inv`
 #####

--- a/test/rulesets/LinearAlgebra/dense.jl
+++ b/test/rulesets/LinearAlgebra/dense.jl
@@ -25,6 +25,34 @@
             rrule_test(dot, randn(), (x, x̄), (y, ȳ))
         end
     end
+    @testset "cross" begin
+        @testset "frule" begin
+            @testset "Vector{$T} tangent" for T in (Float64, ComplexF64)
+                n = 3
+                x, y = randn(T, n), randn(T, n)
+                ẋ, ẏ = randn(T, n), randn(T, n)
+                frule_test(cross, (x, ẋ), (y, ẏ))
+            end
+            @testset "Matrix{$T} tangent" for T in (Float64, ComplexF64)
+                m, n = 10, 3
+                x, y = randn(T, n), randn(T, n)
+                ẋ, ẏ = randn(T, m, n), randn(T, m, n)
+                Ω, ΔΩ = frule((Zero(), ẋ, ẏ), cross, x, y)
+                @test Ω == cross(x, y)
+                @test size(ΔΩ) == (m, n)
+                for i in 1:m # check chunks
+                    @test ΔΩ[i, :] ≈ frule((Zero(), ẋ[i, :], ẏ[i, :]), cross, x, y)[2]
+                end
+            end
+        end
+        @testset "rrule" begin
+            n = 3
+            x, y = randn(n), randn(n)
+            x̄, ȳ = randn(n), randn(n)
+            ΔΩ = randn(n)
+            rrule_test(cross, ΔΩ, (x, x̄), (y, ȳ))
+        end
+    end
     @testset "inv" begin
         N = 3
         B = generate_well_conditioned_matrix(N)

--- a/test/rulesets/LinearAlgebra/dense.jl
+++ b/test/rulesets/LinearAlgebra/dense.jl
@@ -38,7 +38,7 @@
                 x, y = randn(T, n), randn(T, n)
                 ẋ, ẏ = randn(T, m, n), randn(T, m, n)
                 Ω, ΔΩ = frule((Zero(), ẋ, ẏ), cross, x, y)
-                @test Ω == cross(x, y)
+                @test Ω ≈ cross(x, y)
                 @test size(ΔΩ) == (m, n)
                 for i in 1:m # check chunks
                     @test ΔΩ[i, :] ≈ frule((Zero(), ẋ[i, :], ẏ[i, :]), cross, x, y)[2]

--- a/test/rulesets/LinearAlgebra/dense.jl
+++ b/test/rulesets/LinearAlgebra/dense.jl
@@ -27,10 +27,12 @@
     end
     @testset "cross" begin
         @testset "frule" begin
-            n = 3
-            x, y = randn(T, n), randn(T, n)
-            ẋ, ẏ = randn(T, n), randn(T, n)
-            frule_test(cross, (x, ẋ), (y, ẏ))
+            @testset "$T" for T in (Float64, ComplexF64)
+                n = 3
+                x, y = randn(T, n), randn(T, n)
+                ẋ, ẏ = randn(T, n), randn(T, n)
+                frule_test(cross, (x, ẋ), (y, ẏ))
+            end
         end
         @testset "rrule" begin
             n = 3

--- a/test/rulesets/LinearAlgebra/dense.jl
+++ b/test/rulesets/LinearAlgebra/dense.jl
@@ -27,23 +27,10 @@
     end
     @testset "cross" begin
         @testset "frule" begin
-            @testset "Vector{$T} tangent" for T in (Float64, ComplexF64)
-                n = 3
-                x, y = randn(T, n), randn(T, n)
-                ẋ, ẏ = randn(T, n), randn(T, n)
-                frule_test(cross, (x, ẋ), (y, ẏ))
-            end
-            @testset "Matrix{$T} tangent" for T in (Float64, ComplexF64)
-                m, n = 10, 3
-                x, y = randn(T, n), randn(T, n)
-                ẋ, ẏ = randn(T, m, n), randn(T, m, n)
-                Ω, ΔΩ = frule((Zero(), ẋ, ẏ), cross, x, y)
-                @test Ω ≈ cross(x, y)
-                @test size(ΔΩ) == (m, n)
-                for i in 1:m # check chunks
-                    @test ΔΩ[i, :] ≈ frule((Zero(), ẋ[i, :], ẏ[i, :]), cross, x, y)[2]
-                end
-            end
+            n = 3
+            x, y = randn(T, n), randn(T, n)
+            ẋ, ẏ = randn(T, n), randn(T, n)
+            frule_test(cross, (x, ẋ), (y, ẏ))
         end
         @testset "rrule" begin
             n = 3


### PR DESCRIPTION
Adds rules for the cross product.
It includes a rule for chunked forward mode, following https://github.com/JuliaDiff/ChainRulesTestUtils.jl/issues/37, where the chunked tangent vector matrices are assumed to have the size `(m, n)`, where `n` is the length of the input vectors and `m` is the number of chunks. Does this look right, @oxinabox @YingboMa?

Pending clarification on complex conjugation conventions ( https://github.com/JuliaDiff/ChainRulesCore.jl/issues/159) the `rrule` is restricted to real input vectors.