### PR TITLE
Run Travis on latest stable release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ julia:
   - nightly
 jobs:
   allow_failures:
-    - julia: 1.3
     - julia: nightly
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,7 @@ os:
   - linux
 julia:
   - 1.0
-  - 1.1
-  - 1.2
-  - 1.3
+  - 1
   - nightly
 jobs:
   allow_failures:


### PR DESCRIPTION
Implements @oxinabox's suggestion in https://github.com/JuliaDiff/ChainRules.jl/issues/202. Also no longer allows failures on 1.3, but they shouldn't be necessary with this anyways.