### PR TITLE
Fix rules for sign with complex input

### DIFF
--- a/src/rulesets/Base/fastmath_able.jl
+++ b/src/rulesets/Base/fastmath_able.jl
@@ -113,6 +113,8 @@ let
     # we do this second so it overwrites anything we included by mistake in the fastable
 end
 
+# the jacobian for `sign` is symmetric; `_sign_jvp` gives both J * Δz and Jᵀ * ΔΩ for
+# output Ω, (co)tangent Δ, and real input x or the absolute value of complex input z
 _sign_jvp(Ω, absz, Δ) = Ω * ((imag(Δ) * real(Ω) - real(Δ) * imag(Ω)) / absz)im
 _sign_jvp(Ω::Real, x::Real, Δ) = (imag(Δ) * Ω / ifelse(iszero(x), one(x), x)) * im
 _sign_jvp(Ω::Real, x::Real, Δ::Real) = Zero()

--- a/src/rulesets/Base/fastmath_able.jl
+++ b/src/rulesets/Base/fastmath_able.jl
@@ -62,9 +62,33 @@ let
         @scalar_rule +x One()
         @scalar_rule -x -1
 
+        function frule((_, Δx), ::typeof(sign), x::Real)
+            Ω = sign(x)
+            ∂Ω = _sign_jvp(Ω, x, Δx)
+            return Ω, ∂Ω
+        end
+        function frule((_, Δz), ::typeof(sign), z::Complex)
+            absz = abs(ifelse(iszero(z), one(z), z))
+            Ω = z / absz
+            ∂Ω = _sign_jvp(Ω, absz, Δz)
+            return Ω, ∂Ω
+        end
 
-        @scalar_rule sign(x) Zero()
-
+        function rrule(::typeof(sign), x::Real)
+            Ω = sign(x)
+            function sign_pullback(ΔΩ)
+                return (NO_FIELDS, @thunk(_sign_jvp(Ω, x, ΔΩ)))
+            end
+            return Ω, sign_pullback
+        end
+        function rrule(::typeof(sign), z::Complex)
+            absz = abs(ifelse(iszero(z), one(z), z))
+            Ω = z / absz
+            function sign_pullback(ΔΩ)
+                return (NO_FIELDS, @thunk(_sign_jvp(Ω, absz, ΔΩ)))
+            end
+            return Ω, sign_pullback
+        end
 
         # product rule requires special care for arguments where `mul` is non-commutative
         function frule((_, Δx, Δy), ::typeof(*), x::Number, y::Number)
@@ -88,3 +112,7 @@ let
     eval(fastable_ast)  # Get original definitions
     # we do this second so it overwrites anything we included by mistake in the fastable
 end
+
+_sign_jvp(Ω, absz, Δ) = Ω * ((imag(Δ) * real(Ω) - real(Δ) * imag(Ω)) / absz)im
+_sign_jvp(Ω::Real, x::Real, Δ) = (imag(Δ) * Ω / ifelse(iszero(x), one(x), x)) * im
+_sign_jvp(Ω::Real, x::Real, Δ::Real) = Zero()

--- a/src/rulesets/Base/fastmath_able.jl
+++ b/src/rulesets/Base/fastmath_able.jl
@@ -77,7 +77,7 @@ let
         function rrule(::typeof(sign), x::Real)
             Ω = sign(x)
             function sign_pullback(ΔΩ)
-                return (NO_FIELDS, @thunk(_sign_jvp(Ω, x, ΔΩ)))
+                return (NO_FIELDS, _sign_jvp(Ω, x, ΔΩ))
             end
             return Ω, sign_pullback
         end
@@ -85,7 +85,7 @@ let
             absz = abs(ifelse(iszero(z), one(z), z))
             Ω = z / absz
             function sign_pullback(ΔΩ)
-                return (NO_FIELDS, @thunk(_sign_jvp(Ω, absz, ΔΩ)))
+                return (NO_FIELDS, _sign_jvp(Ω, absz, ΔΩ))
             end
             return Ω, sign_pullback
         end

--- a/test/rulesets/Base/fastmath_able.jl
+++ b/test/rulesets/Base/fastmath_able.jl
@@ -97,6 +97,9 @@ const FASTABLE_AST = quote
                 frule_test(sign, (z, ż))
                 rrule_test(sign, ΔΩ, (z, z̄))
 
+                # test that complex (co)tangents with real primal gives same result as
+                # complex primal with zero imaginary part
+
                 Ω, ∂Ω = frule((Zero(), ż), sign, real(z))
                 @test Ω == sign(real(z))
                 @test ∂Ω ≈ frule((Zero(), ż), sign, real(z) + 0im)[2]
@@ -107,6 +110,9 @@ const FASTABLE_AST = quote
             end
 
             @testset "zero over the point discontinuity" begin
+                # Can't do finite differencing because we are lying
+                # following the subgradient convention.
+
                 _, pb = rrule(sign, 0.0 + 0.0im)
                 _, z̄ = pb(randn(ComplexF64))
                 @test extern(z̄) == 0.0 + 0.0im

--- a/test/rulesets/Base/fastmath_able.jl
+++ b/test/rulesets/Base/fastmath_able.jl
@@ -138,13 +138,12 @@ const FASTABLE_AST = quote
         end
         @testset "complex" begin
             @testset "at $z" for z in (-1.1 + randn() * im, 0.5 + randn() * im)
-                ż, z̄, ΔΩ = randn(ComplexF64, 3)
-                frule_test(sign, (z, ż))
-                rrule_test(sign, ΔΩ, (z, z̄))
+                test_scalar(sign, z)
 
                 # test that complex (co)tangents with real primal gives same result as
                 # complex primal with zero imaginary part
 
+                ż, ΔΩ = randn(ComplexF64, 2)
                 Ω, ∂Ω = frule((Zero(), ż), sign, real(z))
                 @test Ω == sign(real(z))
                 @test ∂Ω ≈ frule((Zero(), ż), sign, real(z) + 0im)[2]

--- a/test/rulesets/Base/fastmath_able.jl
+++ b/test/rulesets/Base/fastmath_able.jl
@@ -150,7 +150,7 @@ const FASTABLE_AST = quote
 
                 Ω, pb = rrule(sign, real(z))
                 @test Ω == sign(real(z))
-                @test extern(pb(ΔΩ)[2]) ≈ extern(rrule(sign, real(z) + 0im)[2](ΔΩ)[2])
+                @test pb(ΔΩ)[2] ≈ rrule(sign, real(z) + 0im)[2](ΔΩ)[2]
             end
 
             @testset "zero over the point discontinuity" begin


### PR DESCRIPTION
The current rule for `sign(z::Complex)` is incorrect, as `sign(z::Complex) = z / abs(z)`. This PR adds rules for the complex `sign`. It also reimplements the rules for real inputs, to ensure that they do the right thing if passed complex (co)tangents (following https://github.com/JuliaDiff/ChainRules.jl/pull/196#discussion_r444566361).

The tests in this PR require #198 to pass.