### PR TITLE
Fix complex array rules

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 ChainRulesCore = "0.9"
-ChainRulesTestUtils = "0.4"
+ChainRulesTestUtils = "0.4.1"
 Compat = "3"
 FiniteDifferences = "0.10"
 Reexport = "0.2"

--- a/src/rulesets/LinearAlgebra/dense.jl
+++ b/src/rulesets/LinearAlgebra/dense.jl
@@ -67,7 +67,7 @@ end
 function rrule(::typeof(det), x::Union{Number, AbstractMatrix})
     Ω = det(x)
     function det_pullback(ΔΩ)
-        return NO_FIELDS, Ω * ΔΩ * transpose(inv(x))
+        return NO_FIELDS, Ω * ΔΩ * inv(x)'
     end
     return Ω, det_pullback
 end
@@ -84,7 +84,7 @@ end
 function rrule(::typeof(logdet), x::Union{Number, AbstractMatrix})
     Ω = logdet(x)
     function logdet_pullback(ΔΩ)
-        return (NO_FIELDS, ΔΩ * transpose(inv(x)))
+        return (NO_FIELDS, ΔΩ * inv(x)')
     end
     return Ω, logdet_pullback
 end

--- a/src/rulesets/LinearAlgebra/dense.jl
+++ b/src/rulesets/LinearAlgebra/dense.jl
@@ -9,12 +9,12 @@ const SquareMatrix{T} = Union{Diagonal{T},AbstractTriangular{T}}
 #####
 
 function frule((_, Δx, Δy), ::typeof(dot), x, y)
-    return dot(x, y), sum(Δx .* y) + sum(x .* Δy)
+    return dot(x, y), dot(Δx, y) + dot(x, Δy)
 end
 
 function rrule(::typeof(dot), x, y)
     function dot_pullback(ΔΩ)
-        return (NO_FIELDS, @thunk(ΔΩ .* y), @thunk(x .* ΔΩ))
+        return (NO_FIELDS, @thunk(y .* ΔΩ'), @thunk(x .* ΔΩ))
     end
     return dot(x, y), dot_pullback
 end

--- a/src/rulesets/LinearAlgebra/structured.jl
+++ b/src/rulesets/LinearAlgebra/structured.jl
@@ -32,7 +32,7 @@ if VERSION ≥ v"1.3"
         end
         return diag(A, k), diag_pullback
     end
-    
+
     function rrule(::typeof(diagm), m::Integer, n::Integer, kv::Pair{<:Integer,<:AbstractVector}...)
         function diagm_pullback(ȳ)
             return (NO_FIELDS, DoesNotExist(), DoesNotExist(), _diagm_back.(kv, Ref(ȳ))...)
@@ -48,7 +48,7 @@ function rrule(::typeof(diagm), kv::Pair{<:Integer,<:AbstractVector}...)
 end
 
 function _diagm_back(p, ȳ)
-    return Thunk() do 
+    return Thunk() do
         k, v = p
         d = diag(ȳ, k)[1:length(v)] # handle if diagonal was smaller than matrix
         return Composite{typeof(p)}(second = d)
@@ -73,7 +73,7 @@ function rrule(::Type{<:Symmetric}, A::AbstractMatrix)
     return Symmetric(A), Symmetric_pullback
 end
 
-_symmetric_back(ΔΩ) = UpperTriangular(ΔΩ) + LowerTriangular(ΔΩ)' - Diagonal(ΔΩ)
+_symmetric_back(ΔΩ) = UpperTriangular(ΔΩ) + transpose(LowerTriangular(ΔΩ)) - Diagonal(ΔΩ)
 _symmetric_back(ΔΩ::Union{Diagonal,UpperTriangular}) = ΔΩ
 
 #####

--- a/test/rulesets/Base/base.jl
+++ b/test/rulesets/Base/base.jl
@@ -80,21 +80,6 @@
         end
     end
 
-    @testset "matmul *(x, y)" begin
-        x, y = rand(3, 2), rand(2, 5)
-        z, pullback = rrule(*, x, y)
-
-        @test z == x * y
-
-        z̄ = rand(3, 5)
-        (ds, dx, dy) = pullback(z̄)
-
-        @test ds === NO_FIELDS
-
-        @test extern(dx) == extern(zeros(3, 2) .+ dx)
-        @test extern(dy) == extern(zeros(2, 5) .+ dy)
-    end
-
      @testset "ldexp" begin
             x, Δx, x̄ = 10rand(3)
             Δz = rand()

--- a/test/rulesets/LinearAlgebra/dense.jl
+++ b/test/rulesets/LinearAlgebra/dense.jl
@@ -1,28 +1,28 @@
 @testset "linalg" begin
     @testset "dot" begin
-        @testset "Vector" begin
+        @testset "Vector{$T}" for T in (Float64, ComplexF64)
             M = 3
-            x, y = randn(M), randn(M)
-            ẋ, ẏ = randn(M), randn(M)
-            x̄, ȳ = randn(M), randn(M)
+            x, y = randn(T, M), randn(T, M)
+            ẋ, ẏ = randn(T, M), randn(T, M)
+            x̄, ȳ = randn(T, M), randn(T, M)
             frule_test(dot, (x, ẋ), (y, ẏ))
-            rrule_test(dot, randn(), (x, x̄), (y, ȳ))
+            rrule_test(dot, randn(T), (x, x̄), (y, ȳ))
         end
-        @testset "Matrix" begin
+        @testset "Matrix{$T}" for T in (Float64, ComplexF64)
             M, N = 3, 4
-            x, y = randn(M, N), randn(M, N)
-            ẋ, ẏ = randn(M, N), randn(M, N)
-            x̄, ȳ = randn(M, N), randn(M, N)
+            x, y = randn(T, M, N), randn(T, M, N)
+            ẋ, ẏ = randn(T, M, N), randn(T, M, N)
+            x̄, ȳ = randn(T, M, N), randn(T, M, N)
             frule_test(dot, (x, ẋ), (y, ẏ))
-            rrule_test(dot, randn(), (x, x̄), (y, ȳ))
+            rrule_test(dot, randn(T), (x, x̄), (y, ȳ))
         end
-        @testset "Array{T, 3}" begin
+        @testset "Array{$T, 3}" for T in (Float64, ComplexF64)
             M, N, P = 3, 4, 5
-            x, y = randn(M, N, P), randn(M, N, P)
-            ẋ, ẏ = randn(M, N, P), randn(M, N, P)
-            x̄, ȳ = randn(M, N, P), randn(M, N, P)
+            x, y = randn(T, M, N, P), randn(T, M, N, P)
+            ẋ, ẏ = randn(T, M, N, P), randn(T, M, N, P)
+            x̄, ȳ = randn(T, M, N, P), randn(T, M, N, P)
             frule_test(dot, (x, ẋ), (y, ẏ))
-            rrule_test(dot, randn(), (x, x̄), (y, ȳ))
+            rrule_test(dot, randn(T), (x, x̄), (y, ȳ))
         end
     end
     @testset "cross" begin

--- a/test/rulesets/LinearAlgebra/dense.jl
+++ b/test/rulesets/LinearAlgebra/dense.jl
@@ -42,23 +42,23 @@
             rrule_test(cross, ΔΩ, (x, x̄), (y, ȳ))
         end
     end
-    @testset "inv" begin
+    @testset "inv(::Matrix{$T})" for T in (Float64, ComplexF64)
         N = 3
-        B = generate_well_conditioned_matrix(N)
-        frule_test(inv, (B, randn(N, N)))
-        rrule_test(inv, randn(N, N), (B, randn(N, N)))
+        B = generate_well_conditioned_matrix(T, N)
+        frule_test(inv, (B, randn(T, N, N)))
+        rrule_test(inv, randn(T, N, N), (B, randn(T, N, N)))
     end
-    @testset "det" begin
+    @testset "det(::Matrix{$T})" for T in (Float64, ComplexF64)
         N = 3
-        B = generate_well_conditioned_matrix(N)
-        frule_test(det, (B, randn(N, N)))
-        rrule_test(det, randn(), (B, randn(N, N)))
+        B = generate_well_conditioned_matrix(T, N)
+        frule_test(det, (B, randn(T, N, N)))
+        rrule_test(det, randn(T), (B, randn(T, N, N)))
     end
-    @testset "logdet" begin
+    @testset "logdet(::Matrix{$T})" for T in (Float64, ComplexF64)
         N = 3
-        B = generate_well_conditioned_matrix(N)
-        frule_test(logdet, (B, randn(N, N)))
-        rrule_test(logdet, randn(), (B, randn(N, N)))
+        B = generate_well_conditioned_matrix(T, N)
+        frule_test(logdet, (B, randn(T, N, N)))
+        rrule_test(logdet, randn(T), (B, randn(T, N, N)))
     end
     @testset "tr" begin
         N = 4

--- a/test/rulesets/LinearAlgebra/structured.jl
+++ b/test/rulesets/LinearAlgebra/structured.jl
@@ -14,7 +14,7 @@
         comp = Composite{typeof(res)}(; diag=10*res.diag)  # this is the structure of Diagonal
         @test pb(comp) == (NO_FIELDS, [10, 40])
     end
-    
+
     @testset "::Diagonal * ::AbstractVector" begin
         N = 3
         rrule_test(
@@ -78,9 +78,9 @@
             end
         end
     end
-    @testset "Symmetric" begin
+    @testset "Symmetric(::AbstractMatrix{$T})" for T in (Float64, ComplexF64)
         N = 3
-        rrule_test(Symmetric, randn(N, N), (randn(N, N), randn(N, N)))
+        rrule_test(Symmetric, randn(T, N, N), (randn(T, N, N), randn(T, N, N)))
     end
     @testset "$f" for f in (Adjoint, adjoint, Transpose, transpose)
         n = 5


### PR DESCRIPTION
As part of #210, PR adds missing complex tests and fixes where necessary for the array rules of the following functions, which lack type constraints:
- `dot`
- `det`
- `logdet`
- `Symmetric`

 It does not release any type constraints. It also does not handle the BLAS rules (#214). This PR requires https://github.com/JuliaDiff/ChainRulesTestUtils.jl/pull/47.
