### PR TITLE
Add complex tests and fix rules for BLAS functions

### DIFF
--- a/src/rulesets/LinearAlgebra/blas.jl
+++ b/src/rulesets/LinearAlgebra/blas.jl
@@ -37,8 +37,12 @@ end
 
 function frule((_, Δx), ::typeof(BLAS.nrm2), x)
     Ω = BLAS.nrm2(x)
-    # use dot here because BLAS.dot can't take complex arrays
-    return Ω, real(dot(x, Δx)) / ifelse(iszero(Ω), one(Ω), Ω)
+    ∂Ω = ifelse(
+        eltype(x) <: Real,
+        BLAS.dot(x, Δx),
+        real(BLAS.dotc(x, Δx)),
+    ) / ifelse(iszero(Ω), one(Ω), Ω)
+    return Ω, ∂Ω
 end
 
 function rrule(::typeof(BLAS.nrm2), x)

--- a/src/rulesets/LinearAlgebra/blas.jl
+++ b/src/rulesets/LinearAlgebra/blas.jl
@@ -86,7 +86,7 @@ function rrule(::typeof(BLAS.asum), x)
     return BLAS.asum(x), asum_pullback
 end
 
-function ChainRules.rrule(::typeof(BLAS.asum), n, X, incx)
+function rrule(::typeof(BLAS.asum), n, X, incx)
     Ω = BLAS.asum(n, X, incx)
     asum_pullback(::Zero) = (NO_FIELDS, DoesNotExist(), Zero(), DoesNotExist())
     function asum_pullback(ΔΩ)

--- a/src/rulesets/LinearAlgebra/blas.jl
+++ b/src/rulesets/LinearAlgebra/blas.jl
@@ -167,45 +167,92 @@ function rrule(
         if uppercase(tA) === 'N'
             if uppercase(tB) === 'N'
                 ∂A = InplaceableThunk(
-                    @thunk(gemm('N', 'T', α, C̄, B)),
-                    Ā -> gemm!('N', 'T', α, C̄, B, β, Ā)
+                    @thunk(gemm('N', 'C', α', C̄, B)),
+                    Ā -> gemm!('N', 'C', α', C̄, B, β, Ā)
                 )
                 ∂B = InplaceableThunk(
-                    @thunk(gemm('T', 'N', α, A, C̄)),
-                    B̄ -> gemm!('T', 'N', α, A, C̄, β, B̄)
+                    @thunk(gemm('C', 'N', α', A, C̄)),
+                    B̄ -> gemm!('C', 'N', α', A, C̄, β, B̄)
                 )
-            else
+            elseif uppercase(tB) === 'C'
                 ∂A = InplaceableThunk(
-                    @thunk(gemm('N', 'N', α, C̄, B)),
-                    Ā -> gemm!('N', 'N', α, C̄, B, β, Ā)
+                    @thunk(gemm('N', 'N', α', C̄, B)),
+                    Ā -> gemm!('N', 'N', α', C̄, B, β, Ā)
                 )
                 ∂B = InplaceableThunk(
-                    @thunk(gemm('T', 'N', α, C̄, A)),
-                    B̄ -> gemm!('T', 'N', α, C̄, A, β, B̄)
+                    @thunk(gemm('C', 'N', α, C̄, A)),
+                    B̄ -> gemm!('C', 'N', α, C̄, A, β, B̄)
+                )
+            else  # uppercase(tB) === 'T'
+                ∂A = InplaceableThunk(
+                    @thunk(gemm('N', 'N', α', C̄, conj(B))),
+                    Ā -> gemm!('N', 'N', α', C̄, conj(B), β, Ā)
+                )
+                ∂B = InplaceableThunk(
+                    @thunk(conj(gemm('C', 'N', α, C̄, A))),
+                    B̄ -> conj!(gemm!('C', 'N', α, C̄, A, β, B̄))
                 )
             end
-        else
+        elseif uppercase(tA) === 'C'
             if uppercase(tB) === 'N'
                 ∂A = InplaceableThunk(
-                    @thunk(gemm('N', 'T', α, B, C̄)),
-                    Ā -> gemm!('N', 'T', α, B, C̄, β, Ā)
+                    @thunk(gemm('N', 'C', α, B, C̄)),
+                    Ā -> gemm!('N', 'C', α, B, C̄, β, Ā)
                 )
                 ∂B = InplaceableThunk(
-                    @thunk(gemm('N', 'N', α, A, C̄)),
-                    B̄ -> gemm!('N', 'N', α, A, C̄, β, B̄)
+                    @thunk(gemm('N', 'N', α', A, C̄)),
+                    B̄ -> gemm!('N', 'N', α', A, C̄, β, B̄)
                 )
-            else
+            elseif uppercase(tB) === 'C'
                 ∂A = InplaceableThunk(
-                    @thunk(gemm('T', 'T', α, B, C̄)),
-                    Ā -> gemm!('T', 'T', α, B, C̄, β, Ā)
+                    @thunk(gemm('C', 'C', α, B, C̄)),
+                    Ā -> gemm!('C', 'C', α, B, C̄, β, Ā)
                 )
                 ∂B = InplaceableThunk(
-                    @thunk(gemm('T', 'T', α, C̄, A)),
-                    B̄ -> gemm!('T', 'T', α, C̄, A, β, B̄)
+                    @thunk(gemm('C', 'C', α, C̄, A)),
+                    B̄ -> gemm!('C', 'C', α, C̄, A, β, B̄)
+                )
+            else  # uppercase(tB) === 'T'
+                ∂A = InplaceableThunk(
+                    @thunk(gemm('T', 'C', α, B, C̄)),
+                    Ā -> gemm!('T', 'C', α, B, C̄, β, Ā)
+                )
+                ∂B = InplaceableThunk(
+                    @thunk(gemm('T', 'T', α', C̄, A)),
+                    B̄ -> gemm!('T', 'T', α', C̄, A, β, B̄)
+                )
+            end
+        else  # uppercase(tA) === 'T'
+            if uppercase(tB) === 'N'
+                ∂A = InplaceableThunk(
+                    @thunk(conj(gemm('N', 'C', α, B, C̄))),
+                    Ā -> conj!(gemm!('N', 'C', α, B, C̄, β, Ā))
+                )
+                ∂B = InplaceableThunk(
+                    @thunk(gemm('N', 'N', α', conj(A), C̄)),
+                    B̄ -> gemm!('N', 'N', α', conj(A), C̄, β, B̄)
+                )
+            elseif uppercase(tB) === 'C'
+                ∂A = InplaceableThunk(
+                    @thunk(gemm('T', 'T', α', B, C̄)),
+                    Ā -> gemm!('T', 'T', α', B, C̄, β, Ā)
+                )
+                ∂B = InplaceableThunk(
+                    @thunk(gemm('C', 'T', α, C̄, A)),
+                    B̄ -> gemm!('C', 'T', α, C̄, A, β, B̄)
+                )
+            else  # uppercase(tB) === 'T'
+                ∂A = InplaceableThunk(
+                    @thunk(gemm('C', 'T', α', B, C̄)),
+                    Ā -> gemm!('C', 'T', α', B, C̄, β, Ā)
+                )
+                ∂B = InplaceableThunk(
+                    @thunk(gemm('T', 'C', α', C̄, A)),
+                    B̄ -> gemm!('T', 'C', α', C̄, A, β, B̄)
                 )
             end
         end
-        return (NO_FIELDS, DoesNotExist(), DoesNotExist(), @thunk(dot(C̄, C) / α), ∂A, ∂B)
+        return (NO_FIELDS, DoesNotExist(), DoesNotExist(), @thunk(dot(C, C̄) / α'), ∂A, ∂B)
     end
     return C, gemv_pullback
 end

--- a/src/rulesets/LinearAlgebra/blas.jl
+++ b/src/rulesets/LinearAlgebra/blas.jl
@@ -37,11 +37,12 @@ end
 
 function frule((_, Δx), ::typeof(BLAS.nrm2), x)
     Ω = BLAS.nrm2(x)
-    ∂Ω = ifelse(
-        eltype(x) <: Real,
-        BLAS.dot(x, Δx),
-        real(BLAS.dotc(x, Δx)),
-    ) / ifelse(iszero(Ω), one(Ω), Ω)
+    s = ifelse(iszero(Ω), one(Ω), Ω)
+    ∂Ω = if eltype(x) <: Real
+        BLAS.dot(x, Δx) / s
+    else
+        real(BLAS.dotc(x, Δx)) / s
+    end
     return Ω, ∂Ω
 end
 

--- a/src/rulesets/LinearAlgebra/blas.jl
+++ b/src/rulesets/LinearAlgebra/blas.jl
@@ -41,7 +41,9 @@ function frule((_, Δx), ::typeof(BLAS.nrm2), x)
     ∂Ω = if eltype(x) <: Real
         BLAS.dot(x, Δx) / s
     else
-        real(BLAS.dotc(x, Δx)) / s
+        sum(zip(x, Δx)) do (xi, Δxi)
+            return _realconjtimes(xi, Δxi)
+        end / s
     end
     return Ω, ∂Ω
 end

--- a/src/rulesets/LinearAlgebra/blas.jl
+++ b/src/rulesets/LinearAlgebra/blas.jl
@@ -38,12 +38,10 @@ end
 function frule((_, Δx), ::typeof(BLAS.nrm2), x)
     Ω = BLAS.nrm2(x)
     s = ifelse(iszero(Ω), one(Ω), Ω)
-    ∂Ω = if eltype(x) <: Real
+    ∂Ω = if x isa Real
         BLAS.dot(x, Δx) / s
     else
-        sum(zip(x, Δx)) do (xi, Δxi)
-            return _realconjtimes(xi, Δxi)
-        end / s
+        sum(y -> _realconjtimes(y...), zip(x, Δx)) / s
     end
     return Ω, ∂Ω
 end

--- a/test/rulesets/LinearAlgebra/blas.jl
+++ b/test/rulesets/LinearAlgebra/blas.jl
@@ -11,18 +11,18 @@
 
         @testset "over strides" begin
             n = 10
-            stride1 = 2
-            stride2 = 3
-            x, y = randn(n * stride1), randn(n * stride2)
-            x̄, ȳ = randn(n * stride1), randn(n * stride2)
+            incx = 2
+            incy = 3
+            x, y = randn(n * incx), randn(n * incy)
+            x̄, ȳ = randn(n * incx), randn(n * incy)
             rrule_test(
                 BLAS.dot,
                 randn(),
                 (n, nothing),
                 (x, x̄),
-                (stride1, nothing),
+                (incx, nothing),
                 (y, ȳ),
-                (stride2, nothing),
+                (incy, nothing),
             )
         end
     end
@@ -38,20 +38,20 @@
         end
 
         @testset "over strides" begin
-            dims = (5, 2, 3)
-            stride = 2
-            @testset "Array{$T,$N}" for N in 1:length(dims), T in (Float64,)
-                s = (dims[1] * stride, dims[2:N]...)
-                n = prod(s)
-                x, x̄ = randn(T, s), randn(T, s)
+            dims = (3, 2, 1)
+            incx = 2
+            @testset "Array{$T,$N}" for N in 1:length(dims), T in (Float64,ComplexF64)
+                s = (dims[1] * incx, dims[2:N]...)
+                n = div(prod(s), incx)
+                x, x̄ = randn(T, s...), randn(T, s...)
                 rrule_test(
                     BLAS.nrm2,
                     randn(),
                     (n, nothing),
                     (x, x̄),
-                    (stride, nothing);
+                    (incx, nothing);
                     atol=0,
-                    rtol=sqrt(eps(T)),
+                    rtol=1e-5,
                 )
             end
         end

--- a/test/rulesets/LinearAlgebra/blas.jl
+++ b/test/rulesets/LinearAlgebra/blas.jl
@@ -1,4 +1,32 @@
 @testset "BLAS" begin
+    @testset "dot" begin
+        @testset "all entries" begin
+            n = 10
+            x, y = randn(n), randn(n)
+            ẋ, ẏ = randn(n), randn(n)
+            x̄, ȳ = randn(n), randn(n)
+            frule_test(BLAS.dot, (x, ẋ), (y, ẏ))
+            rrule_test(BLAS.dot, randn(), (x, x̄), (y, ȳ))
+        end
+
+        @testset "over strides" begin
+            n = 10
+            stride1 = 2
+            stride2 = 3
+            x, y = randn(n * stride1), randn(n * stride2)
+            x̄, ȳ = randn(n * stride1), randn(n * stride2)
+            rrule_test(
+                BLAS.dot,
+                randn(),
+                (n, nothing),
+                (x, x̄),
+                (stride1, nothing),
+                (y, ȳ),
+                (stride2, nothing),
+            )
+        end
+    end
+
     @testset "gemm" begin
         dims = 3:5
         for m in dims, n in dims, p in dims, tA in ('N', 'T'), tB in ('N', 'T')

--- a/test/rulesets/LinearAlgebra/blas.jl
+++ b/test/rulesets/LinearAlgebra/blas.jl
@@ -106,19 +106,19 @@
         end
     end
     @testset "gemv" begin
-        for n in 3:5, m in 3:5, t in ('N', 'T')
-            α = randn()
-            A = randn(m, n)
-            x = randn(t === 'N' ? n : m)
-            y = α * (t === 'N' ? A : A') * x
-            ȳ = randn(size(y)...)
+        for n in 3:5, m in 3:5, t in ('N', 'C', 'T'), T in (Float64, ComplexF64)
+            α = randn(T)
+            A = randn(T, m, n)
+            x = randn(T, t === 'N' ? n : m)
+            y = gemv(t, α, A, x)
+            ȳ = randn(T, size(y)...)
             rrule_test(
                 gemv,
                 ȳ,
                 (t, nothing),
-                (α, randn()),
-                (A, randn(size(A))),
-                (x, randn(size(x))),
+                (α, randn(T)),
+                (A, randn(T, size(A))),
+                (x, randn(T, size(x))),
             )
         end
     end

--- a/test/rulesets/LinearAlgebra/blas.jl
+++ b/test/rulesets/LinearAlgebra/blas.jl
@@ -27,6 +27,36 @@
         end
     end
 
+    @testset "nrm2" begin
+        @testset "all entires" begin
+            @testset "$T" for T in (Float64,ComplexF64)
+                n = 10
+                x, ẋ, x̄ = randn(T, n), randn(T, n), randn(T, n)
+                frule_test(BLAS.nrm2, (x, ẋ))
+                rrule_test(BLAS.nrm2, randn(), (x, x̄))
+            end
+        end
+
+        @testset "over strides" begin
+            dims = (5, 2, 3)
+            stride = 2
+            @testset "Array{$T,$N}" for N in 1:length(dims), T in (Float64,)
+                s = (dims[1] * stride, dims[2:N]...)
+                n = prod(s)
+                x, x̄ = randn(T, s), randn(T, s)
+                rrule_test(
+                    BLAS.nrm2,
+                    randn(),
+                    (n, nothing),
+                    (x, x̄),
+                    (stride, nothing);
+                    atol=0,
+                    rtol=sqrt(eps(T)),
+                )
+            end
+        end
+    end
+
     @testset "gemm" begin
         dims = 3:5
         for m in dims, n in dims, p in dims, tA in ('N', 'T'), tB in ('N', 'T')

--- a/test/rulesets/LinearAlgebra/blas.jl
+++ b/test/rulesets/LinearAlgebra/blas.jl
@@ -43,7 +43,7 @@
             @testset "Array{$T,$N}" for N in 1:length(dims), T in (Float64,ComplexF64)
                 s = (dims[1] * incx, dims[2:N]...)
                 n = div(prod(s), incx)
-                x, x̄ = randn(T, s...), randn(T, s...)
+                x, x̄ = randn(T, s), randn(T, s)
                 rrule_test(
                     BLAS.nrm2,
                     randn(),
@@ -52,6 +52,35 @@
                     (incx, nothing);
                     atol=0,
                     rtol=1e-5,
+                )
+            end
+        end
+    end
+
+    @testset "asum" begin
+        @testset "all entries" begin
+            @testset "$T" for T in (Float64,ComplexF64)
+                n = 10
+                x, ẋ, x̄ = randn(T, n), randn(T, n), randn(T, n)
+                frule_test(BLAS.asum, (x, ẋ))
+                rrule_test(BLAS.asum, randn(), (x, x̄))
+            end
+        end
+
+        @testset "over strides" begin
+            dims = (3, 2, 1)
+            incx = 2
+            @testset "Array{$T,$N}" for N in 1:length(dims), T in (Float64,ComplexF64)
+                s = (dims[1] * incx, dims[2:N]...)
+                n = div(prod(s), incx)
+                x, x̄ = randn(T, s), randn(T, s)
+                rrule_test(
+                    BLAS.asum,
+                    randn(),
+                    (n, nothing),
+                    (x, x̄),
+                    (incx, nothing);
+                    fdm = central_fdm(5, 1; adapt=4),
                 )
             end
         end

--- a/test/rulesets/LinearAlgebra/blas.jl
+++ b/test/rulesets/LinearAlgebra/blas.jl
@@ -60,7 +60,7 @@
     @testset "asum" begin
         @testset "all entries" begin
             @testset "$T" for T in (Float64,ComplexF64)
-                n = 10
+                n = 6
                 x, ẋ, x̄ = randn(T, n), randn(T, n), randn(T, n)
                 frule_test(BLAS.asum, (x, ẋ))
                 rrule_test(BLAS.asum, randn(), (x, x̄))
@@ -68,20 +68,13 @@
         end
 
         @testset "over strides" begin
-            dims = (3, 2, 1)
+            dims = (2, 2, 1)
             incx = 2
             @testset "Array{$T,$N}" for N in 1:length(dims), T in (Float64,ComplexF64)
                 s = (dims[1] * incx, dims[2:N]...)
                 n = div(prod(s), incx)
                 x, x̄ = randn(T, s), randn(T, s)
-                rrule_test(
-                    BLAS.asum,
-                    randn(),
-                    (n, nothing),
-                    (x, x̄),
-                    (incx, nothing);
-                    fdm = central_fdm(5, 1; adapt=4),
-                )
+                rrule_test( BLAS.asum, randn(), (n, nothing), (x, x̄), (incx, nothing))
             end
         end
     end

--- a/test/rulesets/LinearAlgebra/blas.jl
+++ b/test/rulesets/LinearAlgebra/blas.jl
@@ -88,23 +88,24 @@
 
     @testset "gemm" begin
         dims = 3:5
-        for m in dims, n in dims, p in dims, tA in ('N', 'T'), tB in ('N', 'T')
-            α = randn()
-            A = randn(tA === 'N' ? (m, n) : (n, m))
-            B = randn(tB === 'N' ? (n, p) : (p, n))
+        for m in dims, n in dims, p in dims, tA in ('N', 'C', 'T'), tB in ('N', 'C', 'T'), T in (Float64, ComplexF64)
+            α = randn(T)
+            A = randn(T, tA === 'N' ? (m, n) : (n, m))
+            B = randn(T, tB === 'N' ? (n, p) : (p, n))
             C = gemm(tA, tB, α, A, B)
-            ȳ = randn(size(C)...)
+            ȳ = randn(T, size(C)...)
             rrule_test(
                 gemm,
                 ȳ,
                 (tA, nothing),
                 (tB, nothing),
-                (α, randn()),
-                (A, randn(size(A))),
-                (B, randn(size(B))),
+                (α, randn(T)),
+                (A, randn(T, size(A))),
+                (B, randn(T, size(B))),
             )
         end
     end
+
     @testset "gemv" begin
         for n in 3:5, m in 3:5, t in ('N', 'C', 'T'), T in (Float64, ComplexF64)
             α = randn(T)

--- a/test/rulesets/LinearAlgebra/blas.jl
+++ b/test/rulesets/LinearAlgebra/blas.jl
@@ -28,7 +28,7 @@
     end
 
     @testset "nrm2" begin
-        @testset "all entires" begin
+        @testset "all entries" begin
             @testset "$T" for T in (Float64,ComplexF64)
                 n = 10
                 x, ẋ, x̄ = randn(T, n), randn(T, n), randn(T, n)


### PR DESCRIPTION
As part of #210, this PR fixes #214 by adding missing complex tests for all rules for `BLAS` functions and fixing the rules where necessary. This should be the last piece of v0.7.0.

This PR uses the utility functions from #216, so it is blocked by that PR. Locally all tests pass.