### PR TITLE
Bump version number for release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "0.7.0-DEV"
+version = "0.7.0"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"


### PR DESCRIPTION
Following https://github.com/JuliaDiff/ChainRules.jl/issues/210, the rules that support complex inputs (and aren't as simple as summation or copying) now have complex tests. It should be safe to make a release. This PR removes the `DEV` tag from the version number.