### PR TITLE
Improvements to numeric exponent rules

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "0.7.6"
+version = "0.7.7"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/rulesets/Base/fastmath_able.jl
+++ b/src/rulesets/Base/fastmath_able.jl
@@ -143,6 +143,15 @@ let
             ),
         )
         @scalar_rule(
+            x::Real ^ y::Real,
+            (
+                ifelse(iszero(x), zero(Ω), ifelse(iszero(y), zero(Ω), y * Ω / x)),
+                # x^y for x < 0 errors when y is not an integer, but then derivative wrt y
+                # is undefined, so we adopt subgradient convention and set derivative to 0.
+                x ≤ 0 ? zero(Ω) : Ω * log(x),
+            ),
+        )
+        @scalar_rule(
             rem(x, y),
             @setup((u, nan) = promote(x / y, NaN16), isint = isinteger(x / y)),
             (ifelse(isint, nan, one(u)), ifelse(isint, nan, -trunc(u))),

--- a/src/rulesets/Base/fastmath_able.jl
+++ b/src/rulesets/Base/fastmath_able.jl
@@ -134,22 +134,14 @@ let
         @scalar_rule x + y (One(), One())
         @scalar_rule x - y (One(), -1)
         @scalar_rule x / y (inv(y), -((x / y) / y))
-        @scalar_rule(
-            x ^ y,
-            (
-                ifelse(iszero(x), zero(Ω), ifelse(iszero(y), zero(Ω), y * Ω / x)),
-                #log(complex(x)) is required so it gives correct complex answer for x<0
-                Ω * log(complex(x)),
-            ),
+        #log(complex(x)) is required so it gives correct complex answer for x<0
+        @scalar_rule(x ^ y,
+            (ifelse(iszero(x), zero(Ω), y * Ω / x), Ω * log(complex(x))),
         )
-        @scalar_rule(
-            x::Real ^ y::Real,
-            (
-                ifelse(iszero(x), zero(Ω), ifelse(iszero(y), zero(Ω), y * Ω / x)),
-                # x^y for x < 0 errors when y is not an integer, but then derivative wrt y
-                # is undefined, so we adopt subgradient convention and set derivative to 0.
-                x ≤ 0 ? zero(Ω) : Ω * log(x),
-            ),
+        # x^y for x < 0 errors when y is not an integer, but then derivative wrt y
+        # is undefined, so we adopt subgradient convention and set derivative to 0.
+        @scalar_rule(x::Real ^ y::Real,
+            (ifelse(iszero(x), zero(Ω), y * Ω / x), Ω * log(ifelse(x ≤ 0, one(x), x))),
         )
         @scalar_rule(
             rem(x, y),

--- a/src/rulesets/Base/fastmath_able.jl
+++ b/src/rulesets/Base/fastmath_able.jl
@@ -134,9 +134,13 @@ let
         @scalar_rule x + y (One(), One())
         @scalar_rule x - y (One(), -1)
         @scalar_rule x / y (inv(y), -((x / y) / y))
-        #log(complex(x)) is require so it give correct complex answer for x<0
-        @scalar_rule(x ^ y,
-            (ifelse(iszero(y), zero(Ω), y * x ^ (y - 1)), Ω * log(complex(x))),
+        @scalar_rule(
+            x ^ y,
+            (
+                ifelse(iszero(x), zero(Ω), ifelse(iszero(y), zero(Ω), y * Ω / x)),
+                #log(complex(x)) is required so it gives correct complex answer for x<0
+                Ω * log(complex(x)),
+            ),
         )
         @scalar_rule(
             rem(x, y),

--- a/test/rulesets/Base/base.jl
+++ b/test/rulesets/Base/base.jl
@@ -117,17 +117,6 @@
         rrule_test(mod, Δz, (x, x̄), (y, ȳ))
     end
 
-    @testset "^(x::$T, n::$T)" for T in (Float64, ComplexF64)
-        # for real x and n, x must be >0
-        x = T <: Real ? 15rand() : 15randn(ComplexF64)
-        Δx, x̄ = 10rand(T, 2)
-        y, Δy, ȳ = rand(T, 3)
-        Δz = rand(T)
-
-        frule_test(^, (x, Δx), (y, Δy))
-        rrule_test(^, Δz, (x, x̄), (y, ȳ))
-    end
-
     @testset "identity" for T in (Float64, ComplexF64)
         frule_test(identity, (randn(T), randn(T)))
         frule_test(identity, (randn(T, 4), randn(T, 4)))

--- a/test/rulesets/Base/fastmath_able.jl
+++ b/test/rulesets/Base/fastmath_able.jl
@@ -149,6 +149,23 @@ const FASTABLE_AST = quote
 
             frule_test(^, (x, Δx), (y, Δy))
             rrule_test(^, Δz, (x, x̄), (y, ȳ))
+
+            T <: Real && @testset "discontinuity for ^(x::Real, n::Int) when x ≤ 0" begin
+                # finite differences doesn't work for x < 0, so we check manually
+                x, y = -10rand(T), 3
+                Δx = randn(T)
+                Δy = randn(T)
+                Δz = randn(T)
+
+                @test frule((Zero(), Δx, Δy), ^, x, y)[2] ≈ Δx * y * x^(y - 1)
+                @test frule((Zero(), Δx, Δy), ^, zero(x), y)[2] ≈ 0
+                _, ∂x, ∂y = rrule(^, x, y)[2](Δz)
+                @test ∂x ≈ Δz * y * x^(y - 1)
+                @test ∂y ≈ 0
+                _, ∂x, ∂y = rrule(^, zero(x), y)[2](Δz)
+                @test ∂x ≈ 0
+                @test ∂y ≈ 0
+            end
         end
     end
 

--- a/test/rulesets/Base/fastmath_able.jl
+++ b/test/rulesets/Base/fastmath_able.jl
@@ -139,6 +139,17 @@ const FASTABLE_AST = quote
             frule_test(f, (x, Δx), (y, Δy))
             rrule_test(f, Δz, (x, x̄), (y, ȳ))
         end
+
+        @testset "^(x::$T, n::$T)" for T in (Float64, ComplexF64)
+            # for real x and n, x must be >0
+            x = T <: Real ? 15rand() : 15randn(ComplexF64)
+            Δx, x̄ = 10rand(T, 2)
+            y, Δy, ȳ = rand(T, 3)
+            Δz = rand(T)
+
+            frule_test(^, (x, Δx), (y, Δy))
+            rrule_test(^, Δz, (x, x̄), (y, ȳ))
+        end
     end
 
     @testset "sign" begin


### PR DESCRIPTION
This PR makes a few improvements to the rules for `^(::Number, ::Number)`.

For the general rule, it slightly improves the efficiency by removing the second `^` call.

It also adds a new real rule that avoids unnecessarily complexifying the tangents and cotangents. The general rule embeds the numbers in the complex plane for complex differentiation. However, for real negative base, exponentiation is undefined (literally throws an error) unless the exponent is exactly an integer. So for negative base, the derivative wrt the exponent is actually undefined (hence we can't even call FD on it). The new rule adopts the subgradient convention when the base is negative.

Oh, and since the rules are defined in `fastmath.jl`, I moved the test to the corresponding test file.

Here are are a few examples:

## Example 1: `frule` with positive real base, real exponent

Only the type has changed. Instead of getting a purely real complex tangent, we just get the equivalent real tangent. The `rrule` has the same behavior.

```julia
using ChainRules
x, p = 2.5, 1.5
Δx, Δp = 0.33, -0.47
frule((Zero(), Δx, Δp), ^, x, p)
```

### on master:
```julia
(3.952847075210474, -0.9196561346879987 - 0.0im)
```

### this pr:
```julia
(3.952847075210474, -0.9196561346879987)
```

## Example 2: `frule` with negative real base, integer exponent

We get the same tangent as we would have gotten had the input tangent on `p` been `Zero()`

```julia
x, p = -2.5, 3
frule((Zero(), Δx, Zero()), ^, x, p) # (-15.625, 6.1875)
frule((Zero(), Δx, Δp), ^, x, p)
```

### on master:
```julia
(-15.625, 12.916510062200826 + 23.07107104980004im)
```

### this pr:
```julia
(-15.625, 6.1875)
```

## Example 3: `rrule` with negative real base, integer exponent

The cotangent on `p` is 0.

```julia
x, p = -2.5, 3
ΔΩ = 2.3
rrule(^, x, p)[2](ΔΩ)
```

### on master:
```julia
(Zero(), 43.125, -32.929198176727446 - 112.90098598838317im)
```

### this pr:
```julia
(Zero(), 43.125, -0.0)
```