### PR TITLE
Add rules for pinv

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "0.7.2"
+version = "0.7.3"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/rulesets/LinearAlgebra/dense.jl
+++ b/src/rulesets/LinearAlgebra/dense.jl
@@ -127,10 +127,10 @@ end
 function frule(
     (_, Δx),
     ::typeof(pinv),
-    x::AbstractVector{T};
-    kwargs...,
+    x::AbstractVector{T},
+    tol::Real = 0,
 ) where {T<:Union{Real,Complex}}
-    y = pinv(x; kwargs...)
+    y = pinv(x, tol)
     # make sure ∂y is the same type as y
     fdual = y isa Transpose ? transpose : adjoint
     ∂y = fdual(sum(abs2, y') .* Δx .- 2real(y * Δx) .* y')
@@ -155,13 +155,13 @@ end
 
 function rrule(
     ::typeof(pinv),
-    x::AbstractVector{T};
-    kwargs...,
+    x::AbstractVector{T},
+    tol::Real = 0,
 ) where {T<:Union{Real,Complex}}
-    y = pinv(x; kwargs...)
+    y = pinv(x, tol)
     function pinv_pullback(Δy)
         ∂x = sum(abs2, y') .* vec(Δy') .- 2real(y * Δy') .* y'
-        return (NO_FIELDS, ∂x)
+        return (NO_FIELDS, ∂x, Zero())
     end
     return y, pinv_pullback
 end

--- a/src/rulesets/LinearAlgebra/dense.jl
+++ b/src/rulesets/LinearAlgebra/dense.jl
@@ -133,7 +133,7 @@ function frule(
     y = pinv(x, tol)
     # make sure ∂y is the same type as y
     fdual = y isa Transpose ? transpose : adjoint
-    ∂y = fdual(sum(abs2, y') .* Δx .- 2real(y * Δx) .* y')
+    ∂y = fdual(sum(abs2, parent(y)) .* Δx .- 2real(y * Δx) .* parent(y))
     return y, ∂y
 end
 
@@ -160,7 +160,7 @@ function rrule(
 ) where {T<:Union{Real,Complex}}
     y = pinv(x, tol)
     function pinv_pullback(Δy)
-        ∂x = sum(abs2, y') .* vec(Δy') .- 2real(y * Δy') .* y'
+        ∂x = sum(abs2, parent(y)) .* vec(Δy') .- 2real(y * Δy') .* parent(y)
         return (NO_FIELDS, ∂x, Zero())
     end
     return y, pinv_pullback

--- a/src/rulesets/LinearAlgebra/dense.jl
+++ b/src/rulesets/LinearAlgebra/dense.jl
@@ -153,6 +153,10 @@ function frule(
     return y, ∂y
 end
 
+# Formula for derivative adapted from Eq 4.12 of
+# Golub, Gene H., and Victor Pereyra. "The Differentiation of Pseudo-Inverses and Nonlinear
+# Least Squares Problems Whose Variables Separate."
+# SIAM Journal on Numerical Analysis 10(2). (1973). 413-432. doi: 10.1137/0710036
 function frule((_, ΔA), ::typeof(pinv), A::AbstractMatrix{T}; kwargs...) where {T}
     Y = pinv(A; kwargs...)
     m, n = size(A)

--- a/src/rulesets/LinearAlgebra/dense.jl
+++ b/src/rulesets/LinearAlgebra/dense.jl
@@ -122,7 +122,7 @@ end
 ##### `pinv`
 #####
 
-@scalar_rule pinv(x::Number) -(Ω ^ 2)
+@scalar_rule pinv(x) -(Ω ^ 2)
 
 function frule(
     (_, Δx),

--- a/src/rulesets/LinearAlgebra/dense.jl
+++ b/src/rulesets/LinearAlgebra/dense.jl
@@ -131,9 +131,8 @@ function frule(
     tol::Real = 0,
 ) where {T<:Union{Real,Complex}}
     y = pinv(x, tol)
-    # make sure ∂y is the same type as y
-    fdual = y isa Transpose ? transpose : adjoint
-    ∂y = fdual(sum(abs2, parent(y)) .* Δx .- 2real(y * Δx) .* parent(y))
+    ∂y′ = sum(abs2, parent(y)) .* Δx .- 2real(y * Δx) .* parent(y)
+    ∂y = y isa Transpose ? transpose(∂y′) : adjoint(∂y′)
     return y, ∂y
 end
 

--- a/src/rulesets/LinearAlgebra/utils.jl
+++ b/src/rulesets/LinearAlgebra/utils.jl
@@ -27,7 +27,7 @@ function _eyesubx!(X::AbstractMatrix)
 end
 
 # X + Y, overwrites X if possible
-function _add!(X::AbstractVecOrMat{T}, Y::AbstractVecOrMat{T}) where T<:Real
+function _add!(X::AbstractVecOrMat, Y::AbstractVecOrMat)
     @inbounds for i = eachindex(X, Y)
         X[i] += Y[i]
     end

--- a/test/rulesets/LinearAlgebra/dense.jl
+++ b/test/rulesets/LinearAlgebra/dense.jl
@@ -57,11 +57,12 @@
         @testset "Vector{$T}" for T in (Float64, ComplexF64)
             n = 3
             x, ẋ, x̄ = randn(T, n), randn(T, n), randn(T, n)
+            tol, ṫol, t̄ol = 0.0, randn(), randn()
             Δy = copyto!(similar(pinv(x)), randn(T, n))
-            frule_test(pinv, (x, ẋ))
-            @test frule((Zero(),  ẋ), pinv, x)[2] isa typeof(pinv(x))
-            rrule_test(pinv, Δy, (x, x̄))
-            @test rrule(pinv, x)[2](Δy)[2] isa Vector{T}
+            frule_test(pinv, (x, ẋ), (tol, ṫol))
+            @test frule((Zero(), ẋ), pinv, x)[2] isa typeof(pinv(x))
+            rrule_test(pinv, Δy, (x, x̄), (tol, t̄ol))
+            @test rrule(pinv, x)[2](Δy)[2] isa typeof(x)
         end
         @testset "Matrix{$T} with size ($m,$n)" for T in (Float64, ComplexF64),
             m in 1:3,

--- a/test/rulesets/LinearAlgebra/dense.jl
+++ b/test/rulesets/LinearAlgebra/dense.jl
@@ -48,6 +48,30 @@
         frule_test(inv, (B, randn(T, N, N)))
         rrule_test(inv, randn(T, N, N), (B, randn(T, N, N)))
     end
+    @testset "pinv" begin
+        @testset "$T" for T in (Float64, ComplexF64)
+            test_scalar(pinv, randn(T))
+            @test frule((Zero(), randn(T)), pinv, zero(T))[2] ≈ zero(T)
+            @test rrule(pinv, zero(T))[2](randn(T))[2] ≈ zero(T)
+        end
+        @testset "Vector{$T}" for T in (Float64, ComplexF64)
+            n = 3
+            x, ẋ, x̄ = randn(T, n), randn(T, n), randn(T, n)
+            Δy = copyto!(similar(pinv(x)), randn(T, n))
+            frule_test(pinv, (x, ẋ))
+            @test frule((Zero(),  ẋ), pinv, x)[2] isa typeof(pinv(x))
+            rrule_test(pinv, Δy, (x, x̄))
+        end
+        @testset "Matrix{$T} with size ($m,$n)" for T in (Float64, ComplexF64),
+            m in 1:3,
+            n in 1:3
+
+            X, Ẋ, X̄ = randn(T, m, n), randn(T, m, n), randn(T, m, n)
+            ΔY = randn(T, size(pinv(X))...)
+            frule_test(pinv, (X, Ẋ))
+            rrule_test(pinv, ΔY, (X, X̄))
+        end
+    end
     @testset "det(::Matrix{$T})" for T in (Float64, ComplexF64)
         N = 3
         B = generate_well_conditioned_matrix(T, N)

--- a/test/rulesets/LinearAlgebra/dense.jl
+++ b/test/rulesets/LinearAlgebra/dense.jl
@@ -64,6 +64,20 @@
             rrule_test(pinv, Δy, (x, x̄), (tol, t̄ol))
             @test rrule(pinv, x)[2](Δy)[2] isa typeof(x)
         end
+        @testset "$F{Vector{$T}}" for T in (Float64, ComplexF64), F in (Transpose, Adjoint)
+            n = 3
+            x, ẋ, x̄ = F(randn(T, n)), F(randn(T, n)), F(randn(T, n))
+            y = pinv(x)
+            Δy = copyto!(similar(y), randn(T, n))
+            frule_test(pinv, (x, ẋ))
+            y_fwd, ∂y_fwd = frule((Zero(),  ẋ), pinv, x)
+            @test y_fwd isa typeof(y)
+            @test ∂y_fwd isa typeof(y)
+            rrule_test(pinv, Δy, (x, x̄))
+            y_rev, back = rrule(pinv, x)
+            @test y_rev isa typeof(y)
+            @test back(Δy)[2] isa typeof(x)
+        end
         @testset "Matrix{$T} with size ($m,$n)" for T in (Float64, ComplexF64),
             m in 1:3,
             n in 1:3

--- a/test/rulesets/LinearAlgebra/dense.jl
+++ b/test/rulesets/LinearAlgebra/dense.jl
@@ -61,6 +61,7 @@
             frule_test(pinv, (x, ẋ))
             @test frule((Zero(),  ẋ), pinv, x)[2] isa typeof(pinv(x))
             rrule_test(pinv, Δy, (x, x̄))
+            @test rrule(pinv, x)[2](Δy)[2] isa Vector{T}
         end
         @testset "Matrix{$T} with size ($m,$n)" for T in (Float64, ComplexF64),
             m in 1:3,


### PR DESCRIPTION
This adds forward and reverse rules for `pinv` for the following inputs:
- `Number`
- `AbstractVector{T} where T<:Union{Real,Complex}`
- `Transpose{AbstractVector{T}} where T<:Union{Real,Complex}`
- `Adjoint{AbstractVector{T}} where T<:Union{Real,Complex}`
- `AbstractMatrix`

For the latter case, the `rrule` is equivalent to Zygote's `pinv` adjoint, but this is a little more efficient because it retracts over the largest dimension.