### PR TITLE
Fix signature for MersenneTwister

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "0.7.5"
+version = "0.7.6"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/rulesets/Random/random.jl
+++ b/src/rulesets/Random/random.jl
@@ -1,6 +1,6 @@
-frule(Δargs, ::typeof(MersenneTwister), args...) = MersenneTwister(args...), Zero()
+frule(Δargs, ::Type{MersenneTwister}, args...) = MersenneTwister(args...), Zero()
 
-function rrule(::typeof(MersenneTwister), args...)
+function rrule(::Type{MersenneTwister}, args...)
     function MersenneTwister_rrule(ΔΩ)
         return (NO_FIELDS, map(_ -> Zero(), args)...)
     end


### PR DESCRIPTION
This PR (probably) fixes #227. `typeof(MersenneTwister)` is `DataType`, so the rules introduced in #223 will be applied to many function calls.

@baggepinnen can you confirm this resolves the issue for you?