### PR TITLE
Fixup naming convention `*_rrule` -> `*_pullback`

### DIFF
--- a/src/rulesets/Random/random.jl
+++ b/src/rulesets/Random/random.jl
@@ -1,8 +1,8 @@
 frule(Δargs, ::Type{MersenneTwister}, args...) = MersenneTwister(args...), Zero()
 
 function rrule(::Type{MersenneTwister}, args...)
-    function MersenneTwister_rrule(ΔΩ)
+    function MersenneTwister_pullback(ΔΩ)
         return (NO_FIELDS, map(_ -> Zero(), args)...)
     end
-    return MersenneTwister(args...), MersenneTwister_rrule
+    return MersenneTwister(args...), MersenneTwister_pullback
 end


### PR DESCRIPTION
tiny style thing noticed in https://github.com/JuliaDiff/ChainRules.jl/pull/228 / https://github.com/JuliaDiff/ChainRules.jl/pull/223