### PR TITLE
fix division return type 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "0.7.7"
+version = "0.7.8"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/rulesets/Base/base.jl
+++ b/src/rulesets/Base/base.jl
@@ -138,7 +138,7 @@ end
     ),
     (!(islow | ishigh), islow, ishigh),
 )
-@scalar_rule x \ y (-((y / x) / x), inv(x))
+@scalar_rule x \ y (-(Ω / x), one(Ω) / x)
 
 function frule((_, ẏ), ::typeof(identity), x)
     return (x, ẏ)

--- a/src/rulesets/Base/base.jl
+++ b/src/rulesets/Base/base.jl
@@ -138,7 +138,7 @@ end
     ),
     (!(islow | ishigh), islow, ishigh),
 )
-@scalar_rule x \ y (-(Ω / x), one(Ω) / x)
+@scalar_rule x \ y (-(Ω / x), one(y) / x)
 
 function frule((_, ẏ), ::typeof(identity), x)
     return (x, ẏ)

--- a/src/rulesets/Base/fastmath_able.jl
+++ b/src/rulesets/Base/fastmath_able.jl
@@ -133,7 +133,7 @@ let
 
         @scalar_rule x + y (One(), One())
         @scalar_rule x - y (One(), -1)
-        @scalar_rule x / y (inv(y), -((x / y) / y))
+        @scalar_rule x / y (one(Ω) / y, -(Ω / y))
         #log(complex(x)) is required so it gives correct complex answer for x<0
         @scalar_rule(x ^ y,
             (ifelse(iszero(x), zero(Ω), y * Ω / x), Ω * log(complex(x))),

--- a/src/rulesets/Base/fastmath_able.jl
+++ b/src/rulesets/Base/fastmath_able.jl
@@ -133,7 +133,7 @@ let
 
         @scalar_rule x + y (One(), One())
         @scalar_rule x - y (One(), -1)
-        @scalar_rule x / y (one(Ω) / y, -(Ω / y))
+        @scalar_rule x / y (one(x) / y, -(Ω / y))
         #log(complex(x)) is required so it gives correct complex answer for x<0
         @scalar_rule(x ^ y,
             (ifelse(iszero(x), zero(Ω), y * Ω / x), Ω * log(complex(x))),
@@ -141,7 +141,7 @@ let
         # x^y for x < 0 errors when y is not an integer, but then derivative wrt y
         # is undefined, so we adopt subgradient convention and set derivative to 0.
         @scalar_rule(x::Real ^ y::Real,
-            (ifelse(iszero(x), zero(Ω), y * Ω / x), Ω * log(convert(typeof(Ω), ifelse(x ≤ 0, one(x), x)))),
+            (ifelse(iszero(x), zero(Ω), y * Ω / x), Ω * log(oftype(Ω, ifelse(x ≤ 0, one(x), x)))),
         )
         @scalar_rule(
             rem(x, y),

--- a/src/rulesets/Base/fastmath_able.jl
+++ b/src/rulesets/Base/fastmath_able.jl
@@ -113,16 +113,16 @@ let
         function frule(
             (_, Δx, Δy),
             ::typeof(hypot),
-            x::T1,
-            y::T2,
-        ) where {T1<:Union{Real,Complex}, T2<:Union{Real,Complex}}
+            x::T,
+            y::T,
+        ) where {T<:Union{Real,Complex}}
             Ω = hypot(x, y)
             n = ifelse(iszero(Ω), one(Ω), Ω)
             ∂Ω = (_realconjtimes(x, Δx) + _realconjtimes(y, Δy)) / n
             return Ω, ∂Ω
         end
 
-        function rrule(::typeof(hypot), x::T1, y::T2) where {T1<:Union{Real,Complex}, T2<:Union{Real,Complex}}
+        function rrule(::typeof(hypot), x::T, y::T) where {T<:Union{Real,Complex}}
             Ω = hypot(x, y)
             function hypot_pullback(ΔΩ)
                 c = real(ΔΩ) / ifelse(iszero(Ω), one(Ω), Ω)
@@ -141,7 +141,7 @@ let
         # x^y for x < 0 errors when y is not an integer, but then derivative wrt y
         # is undefined, so we adopt subgradient convention and set derivative to 0.
         @scalar_rule(x::Real ^ y::Real,
-            (ifelse(iszero(x), zero(Ω), y * Ω / x), Ω * log(ifelse(x ≤ 0, one(x), x))),
+            (ifelse(iszero(x), zero(Ω), y * Ω / x), Ω * log(convert(typeof(Ω), ifelse(x ≤ 0, one(x), x)))),
         )
         @scalar_rule(
             rem(x, y),

--- a/src/rulesets/Base/fastmath_able.jl
+++ b/src/rulesets/Base/fastmath_able.jl
@@ -113,16 +113,16 @@ let
         function frule(
             (_, Δx, Δy),
             ::typeof(hypot),
-            x::T,
-            y::T,
-        ) where {T<:Union{Real,Complex}}
+            x::T1,
+            y::T2,
+        ) where {T1<:Union{Real,Complex}, T2<:Union{Real,Complex}}
             Ω = hypot(x, y)
             n = ifelse(iszero(Ω), one(Ω), Ω)
             ∂Ω = (_realconjtimes(x, Δx) + _realconjtimes(y, Δy)) / n
             return Ω, ∂Ω
         end
 
-        function rrule(::typeof(hypot), x::T, y::T) where {T<:Union{Real,Complex}}
+        function rrule(::typeof(hypot), x::T1, y::T2) where {T1<:Union{Real,Complex}, T2<:Union{Real,Complex}}
             Ω = hypot(x, y)
             function hypot_pullback(ΔΩ)
                 c = real(ΔΩ) / ifelse(iszero(Ω), one(Ω), Ω)

--- a/test/rulesets/Base/fastmath_able.jl
+++ b/test/rulesets/Base/fastmath_able.jl
@@ -136,18 +136,28 @@ const FASTABLE_AST = quote
             y, Δy, ȳ = rand(T, 3)
             Δz = randn(typeof(f(x, y)))
 
-            if T != Float32
-                frule_test(f, (x, Δx), (y, Δy))
-                rrule_test(f, Δz, (x, x̄), (y, ȳ))    
-            end   
+            frule_test(f, (x, Δx), (y, Δy))
+            rrule_test(f, Δz, (x, x̄), (y, ȳ))    
+        end
 
-            # issue #233
-            if T <: Real
-                @test frule((Zero(), Δx, Δy), f, x, y) isa Tuple{T, T}
-                _, ∂x, ∂y = rrule(f, x, y)[2](Δz)
+        @testset "$f(x::$T, y::$T) type check" for f in (/, +, -,\, hypot, ^), T in (Float32, Float64)
+            x, Δx, x̄ = 10rand(T, 3)
+            y, Δy, ȳ = rand(T, 3)
+            @assert T == typeof(f(x, y))
+            Δz = randn(typeof(f(x, y)))
+
+            @test frule((Zero(), Δx, Δy), f, x, y) isa Tuple{T, T}
+            _, ∂x, ∂y = rrule(f, x, y)[2](Δz)
+            @test extern.((∂x, ∂y)) isa Tuple{T, T}
+
+            if f != hypot
+                # Issue #233                
+                @test frule((Zero(), Δx, Δy), f, x, 2) isa Tuple{T, T}
+                _, ∂x, ∂y = rrule(f, x, 2)[2](Δz)
                 @test extern.((∂x, ∂y)) isa Tuple{T, T}
-                @test frule((Zero(), Δx, Δy), f, x, 1) isa Tuple{T, T}
-                _, ∂x, ∂y = rrule(f, x, 1)[2](Δz)
+                
+                @test frule((Zero(), Δx, Δy), f, 2, y) isa Tuple{T, T}
+                _, ∂x, ∂y = rrule(f, 2, y)[2](Δz)
                 @test extern.((∂x, ∂y)) isa Tuple{T, T}
             end
         end

--- a/test/rulesets/Base/fastmath_able.jl
+++ b/test/rulesets/Base/fastmath_able.jl
@@ -131,7 +131,7 @@ const FASTABLE_AST = quote
             rrule_test(f, Δz, (x, x̄), (y, ȳ))
         end
 
-        @testset "$f(x::$T, y::$T)" for f in (/, +, -, hypot), T in (Float32, Float64, ComplexF64)
+        @testset "$f(x::$T, y::$T)" for f in (/, +, -, hypot), T in (Float64, ComplexF64)
             x, Δx, x̄ = 10rand(T, 3)
             y, Δy, ȳ = rand(T, 3)
             Δz = randn(typeof(f(x, y)))

--- a/test/rulesets/Base/fastmath_able.jl
+++ b/test/rulesets/Base/fastmath_able.jl
@@ -140,10 +140,14 @@ const FASTABLE_AST = quote
                 frule_test(f, (x, Δx), (y, Δy))
                 rrule_test(f, Δz, (x, x̄), (y, ȳ))    
             end   
+
             # issue #233
             if T <: Real
                 @test frule((Zero(), Δx, Δy), f, x, y) isa Tuple{T, T}
                 _, ∂x, ∂y = rrule(f, x, y)[2](Δz)
+                @test extern.((∂x, ∂y)) isa Tuple{T, T}
+                @test frule((Zero(), Δx, Δy), f, x, 1) isa Tuple{T, T}
+                _, ∂x, ∂y = rrule(f, x, 1)[2](Δz)
                 @test extern.((∂x, ∂y)) isa Tuple{T, T}
             end
         end


### PR DESCRIPTION
Fix https://github.com/FluxML/Zygote.jl/issues/727. 

Still have to add tests. Where are `rrule_test`, `frule_test` and `scalar_test` defined? Do they check types?