### PR TITLE
Add logabsdet and test det and logdet on numbers

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "0.7.9"
+version = "0.7.10"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "0.7.11"
+version = "0.7.12"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "0.7.8"
+version = "0.7.9"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/rulesets/LinearAlgebra/dense.jl
+++ b/src/rulesets/LinearAlgebra/dense.jl
@@ -100,7 +100,7 @@ function frule((_, Δx), ::typeof(logabsdet), x::AbstractMatrix)
     Ω = logabsdet(x)
     (y, signy) = Ω
     b = tr(x \ Δx)
-    ∂y = real(∂detx)
+    ∂y = real(b)
     ∂signy = eltype(x) <: Real ? Zero() : im * imag(b) * signy
     ∂Ω = Composite{typeof(Ω)}(∂y, ∂signy)
     return Ω, ∂Ω

--- a/src/rulesets/LinearAlgebra/dense.jl
+++ b/src/rulesets/LinearAlgebra/dense.jl
@@ -67,7 +67,8 @@ end
 function rrule(::typeof(det), x::Union{Number, AbstractMatrix})
     Ω = det(x)
     function det_pullback(ΔΩ)
-        return NO_FIELDS, Ω * ΔΩ * inv(x)'
+        ∂x = x isa Number ? ΔΩ : Ω * ΔΩ * inv(x)'
+        return (NO_FIELDS, ∂x)
     end
     return Ω, det_pullback
 end

--- a/src/rulesets/LinearAlgebra/dense.jl
+++ b/src/rulesets/LinearAlgebra/dense.jl
@@ -63,6 +63,7 @@ function frule((_, Δx), ::typeof(det), x::AbstractMatrix)
     # way to compute this trace without during the full compution within
     return Ω, Ω * tr(x \ Δx)
 end
+frule((_, Δx), ::typeof(det), x::Number) = (det(x), Δx)
 
 function rrule(::typeof(det), x::Union{Number, AbstractMatrix})
     Ω = det(x)

--- a/src/rulesets/LinearAlgebra/dense.jl
+++ b/src/rulesets/LinearAlgebra/dense.jl
@@ -80,13 +80,14 @@ end
 
 function frule((_, Δx), ::typeof(logdet), x::Union{Number, AbstractMatrix})
     Ω = logdet(x)
-    return Ω, tr(inv(x) * Δx)
+    return Ω, tr(x \ Δx)
 end
 
 function rrule(::typeof(logdet), x::Union{Number, AbstractMatrix})
     Ω = logdet(x)
     function logdet_pullback(ΔΩ)
-        return (NO_FIELDS, ΔΩ * inv(x)')
+        ∂x = x isa Number ? ΔΩ / x' : ΔΩ * inv(x)'
+        return (NO_FIELDS, ∂x)
     end
     return Ω, logdet_pullback
 end

--- a/src/rulesets/LinearAlgebra/dense.jl
+++ b/src/rulesets/LinearAlgebra/dense.jl
@@ -57,11 +57,11 @@ end
 ##### `det`
 #####
 
-function frule((_, ẋ), ::typeof(det), x::Union{Number, AbstractMatrix})
+function frule((_, Δx), ::typeof(det), x::AbstractMatrix)
     Ω = det(x)
     # TODO Performance optimization: probably there is an efficent
     # way to compute this trace without during the full compution within
-    return Ω, Ω * tr(inv(x) * ẋ)
+    return Ω, Ω * tr(x \ Δx)
 end
 
 function rrule(::typeof(det), x::Union{Number, AbstractMatrix})

--- a/test/rulesets/LinearAlgebra/dense.jl
+++ b/test/rulesets/LinearAlgebra/dense.jl
@@ -88,11 +88,17 @@
             rrule_test(pinv, ΔY, (X, X̄))
         end
     end
-    @testset "det(::Matrix{$T})" for T in (Float64, ComplexF64)
-        N = 3
-        B = generate_well_conditioned_matrix(T, N)
-        frule_test(det, (B, randn(T, N, N)))
-        rrule_test(det, randn(T), (B, randn(T, N, N)))
+    @testset "$f" for f in (det, logdet)
+        @testset "$f(::$T)" for T in (Float64, ComplexF64)
+            b = (f === logdet && T <: Real) ? abs(randn(T)) : randn(T)
+            test_scalar(f, b)
+        end
+        @testset "$f(::Matrix{$T})" for T in (Float64, ComplexF64)
+            N = 3
+            B = generate_well_conditioned_matrix(T, N)
+            frule_test(f, (B, randn(T, N, N)))
+            rrule_test(f, randn(T), (B, randn(T, N, N)))
+        end
     end
     @testset "logdet(::Matrix{$T})" for T in (Float64, ComplexF64)
         N = 3

--- a/test/rulesets/LinearAlgebra/dense.jl
+++ b/test/rulesets/LinearAlgebra/dense.jl
@@ -100,11 +100,14 @@
             rrule_test(f, randn(T), (B, randn(T, N, N)))
         end
     end
-    @testset "logdet(::Matrix{$T})" for T in (Float64, ComplexF64)
+    @testset "logabsdet(::Matrix{$T})" for T in (Float64, ComplexF64)
         N = 3
-        B = generate_well_conditioned_matrix(T, N)
-        frule_test(logdet, (B, randn(T, N, N)))
-        rrule_test(logdet, randn(T), (B, randn(T, N, N)))
+        B = randn(T, N, N)
+        frule_test(logabsdet, (B, randn(T, N, N)))
+        rrule_test(logabsdet, (randn(), randn(T)), (B, randn(T, N, N)))
+        # test for opposite sign of determinant
+        frule_test(logabsdet, (-B, randn(T, N, N)))
+        rrule_test(logabsdet, (randn(), randn(T)), (-B, randn(T, N, N)))
     end
     @testset "tr" begin
         N = 4


### PR DESCRIPTION
`det` and `logdet` were implemented for numbers but were untested. This PR adds number tests and removes the dangerous `inv` in their rules for number inputs. (see https://github.com/FluxML/Zygote.jl/issues/727#issuecomment-655361588).

It also adds rules for `logabsdet`.