### PR TITLE
add adjoint for reduce hvcat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "0.7.10"
+version = "0.7.11"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/rulesets/Base/array.jl
+++ b/src/rulesets/Base/array.jl
@@ -40,12 +40,12 @@ function rrule(::typeof(hcat), A::AbstractArray, Bs::AbstractArray...)
 end
 
 function rrule(::typeof(reduce), ::typeof(hcat), As::AbstractVector{<:AbstractVecOrMat})
-    function reduce_hcat_pullback(Ȳ)
+    function reduce_hcat_pullback(ΔY)
         sizes = size.(As, 2)
         cumsizes = cumsum(sizes)
         ∂As = map(cumsizes, sizes) do post, diff
             pre = post - diff + 1
-            Ȳ[:, pre:post]
+            return ΔY[:, pre:post]
         end
         return (NO_FIELDS, NO_FIELDS, ∂As)
     end
@@ -71,12 +71,12 @@ function rrule(::typeof(vcat), A::AbstractArray, Bs::AbstractArray...)
 end
 
 function rrule(::typeof(reduce), ::typeof(vcat), As::AbstractVector{<:AbstractVecOrMat})
-    function reduce_vcat_pullback(Ȳ)
+    function reduce_vcat_pullback(ΔY)
         sizes = size.(As, 1)
         cumsizes = cumsum(sizes)
         ∂As = map(cumsizes, sizes) do post, diff
             pre = post - diff + 1
-            Ȳ[pre:post, :]
+            return ΔY[pre:post, :]
         end
         return (NO_FIELDS, NO_FIELDS, ∂As)
     end

--- a/src/rulesets/Base/array.jl
+++ b/src/rulesets/Base/array.jl
@@ -47,7 +47,7 @@ function rrule(::typeof(reduce), ::typeof(hcat), As::AbstractVector{<:AbstractVe
             pre = post - diff + 1
             return ΔY[:, pre:post]
         end
-        return (NO_FIELDS, NO_FIELDS, ∂As)
+        return (NO_FIELDS, DoesNotExist(), ∂As)
     end
     return reduce(hcat, As), reduce_hcat_pullback
 end
@@ -78,7 +78,7 @@ function rrule(::typeof(reduce), ::typeof(vcat), As::AbstractVector{<:AbstractVe
             pre = post - diff + 1
             return ΔY[pre:post, :]
         end
-        return (NO_FIELDS, NO_FIELDS, ∂As)
+        return (NO_FIELDS, DoesNotExist(), ∂As)
     end
     return reduce(vcat, As), reduce_vcat_pullback
 end

--- a/src/rulesets/Base/array.jl
+++ b/src/rulesets/Base/array.jl
@@ -39,6 +39,19 @@ function rrule(::typeof(hcat), A::AbstractArray, Bs::AbstractArray...)
     return hcat(A, Bs...), hcat_pullback
 end
 
+function rrule(::typeof(reduce), ::typeof(hcat), As::AbstractVector{<:AbstractVecOrMat})
+    function reduce_hcat_pullback(Ȳ)
+        sizes = size.(As, 2)
+        cumsizes = cumsum(sizes)
+        ∂As = map(cumsizes, sizes) do post, diff
+            pre = post - diff + 1
+            Ȳ[:, pre:post]
+        end
+        return (NO_FIELDS, NO_FIELDS, ∂As)
+    end
+    return reduce(hcat, As), reduce_hcat_pullback
+end
+
 #####
 ##### `vcat`
 #####
@@ -55,6 +68,19 @@ function rrule(::typeof(vcat), A::AbstractArray, Bs::AbstractArray...)
         return (NO_FIELDS, ∂A, ∂Bs...)
     end
     return vcat(A, Bs...), vcat_pullback
+end
+
+function rrule(::typeof(reduce), ::typeof(vcat), As::AbstractVector{<:AbstractVecOrMat})
+    function reduce_vcat_pullback(Ȳ)
+        sizes = size.(As, 1)
+        cumsizes = cumsum(sizes)
+        ∂As = map(cumsizes, sizes) do post, diff
+            pre = post - diff + 1
+            Ȳ[pre:post, :]
+        end
+        return (NO_FIELDS, NO_FIELDS, ∂As)
+    end
+    return reduce(vcat, As), reduce_vcat_pullback
 end
 
 #####

--- a/test/rulesets/Base/array.jl
+++ b/test/rulesets/Base/array.jl
@@ -42,7 +42,7 @@ end
     H, pullback = rrule(reduce, hcat, x)
     @test H == reduce(hcat, x)
     H̄ = randn(3, 6)
-    x̄ = [rand(size(m)...) for m in x]
+    x̄ = randn.(size.(x))
     rrule_test(reduce, H̄, (hcat, nothing), (x, x̄))
 end
 
@@ -68,7 +68,7 @@ end
     V, pullback = rrule(reduce, vcat, x)
     @test V == reduce(vcat, x)
     V̄ = randn(6, 4)
-    x̄ = [rand(size(m)...) for m in x]
+    x̄ = randn.(size.(x))
     rrule_test(reduce, V̄, (vcat, nothing), (x, x̄))
 end
 

--- a/test/rulesets/Base/array.jl
+++ b/test/rulesets/Base/array.jl
@@ -34,6 +34,21 @@ end
     @test dC ≈ view(H̄, :, 4:6)
 end
 
+@testset "reduce hcat" begin
+    A = randn(3, 2)
+    B = randn(3, 1)
+    C = randn(3, 3)
+    H, pullback = rrule(reduce, hcat, [A, B, C])
+    @test H == reduce(hcat, [A, B, C])
+    H̄ = randn(3, 6)
+    (ds, dh, (dA, dB, dC)) = pullback(H̄)
+    @test ds == NO_FIELDS
+    @test dh == NO_FIELDS
+    @test dA ≈ view(H̄, :, 1:2)
+    @test dB ≈ view(H̄, :, 3:3)
+    @test dC ≈ view(H̄, :, 4:6)
+end
+
 @testset "vcat" begin
     A = randn(2, 4)
     B = randn(1, 4)
@@ -43,6 +58,21 @@ end
     V̄ = randn(6, 4)
     (ds, dA, dB, dC) = pullback(V̄)
     @test ds == NO_FIELDS
+    @test dA ≈ view(V̄, 1:2, :)
+    @test dB ≈ view(V̄, 3:3, :)
+    @test dC ≈ view(V̄, 4:6, :)
+end
+
+@testset "reduce vcat" begin
+    A = randn(2, 4)
+    B = randn(1, 4)
+    C = randn(3, 4)
+    V, pullback = rrule(reduce, vcat, [A, B, C])
+    @test V == reduce(vcat, [A, B, C])
+    V̄ = randn(6, 4)
+    (ds, dv, (dA, dB, dC)) = pullback(V̄)
+    @test ds == NO_FIELDS
+    @test dv == NO_FIELDS
     @test dA ≈ view(V̄, 1:2, :)
     @test dB ≈ view(V̄, 3:3, :)
     @test dC ≈ view(V̄, 4:6, :)

--- a/test/rulesets/Base/array.jl
+++ b/test/rulesets/Base/array.jl
@@ -38,15 +38,12 @@ end
     A = randn(3, 2)
     B = randn(3, 1)
     C = randn(3, 3)
-    H, pullback = rrule(reduce, hcat, [A, B, C])
-    @test H == reduce(hcat, [A, B, C])
+    x = [A, B, C]
+    H, pullback = rrule(reduce, hcat, x)
+    @test H == reduce(hcat, x)
     H̄ = randn(3, 6)
-    (ds, dh, (dA, dB, dC)) = pullback(H̄)
-    @test ds == NO_FIELDS
-    @test dh == NO_FIELDS
-    @test dA ≈ view(H̄, :, 1:2)
-    @test dB ≈ view(H̄, :, 3:3)
-    @test dC ≈ view(H̄, :, 4:6)
+    x̄ = [rand(size(m)...) for m in x]
+    rrule_test(reduce, H̄, (hcat, nothing), (x, x̄))
 end
 
 @testset "vcat" begin
@@ -67,15 +64,12 @@ end
     A = randn(2, 4)
     B = randn(1, 4)
     C = randn(3, 4)
-    V, pullback = rrule(reduce, vcat, [A, B, C])
-    @test V == reduce(vcat, [A, B, C])
+    x = [A, B, C]
+    V, pullback = rrule(reduce, vcat, x)
+    @test V == reduce(vcat, x)
     V̄ = randn(6, 4)
-    (ds, dv, (dA, dB, dC)) = pullback(V̄)
-    @test ds == NO_FIELDS
-    @test dv == NO_FIELDS
-    @test dA ≈ view(V̄, 1:2, :)
-    @test dB ≈ view(V̄, 3:3, :)
-    @test dC ≈ view(V̄, 4:6, :)
+    x̄ = [rand(size(m)...) for m in x]
+    rrule_test(reduce, V̄, (vcat, nothing), (x, x̄))
 end
 
 @testset "fill" begin


### PR DESCRIPTION
Code is basically the same as @AzamatB's https://github.com/FluxML/Zygote.jl/pull/501 (plus tests), but I think now it makes more sense to have this here.

This fixes `reduce(hcat, As)` and `reduce(vcat, As)` for Zygote, as otherwise you'd get the mutation error.