### PR TITLE
Restrict types in logdet

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "0.7.12"
+version = "0.7.13"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/rulesets/LinearAlgebra/dense.jl
+++ b/src/rulesets/LinearAlgebra/dense.jl
@@ -78,12 +78,12 @@ end
 ##### `logdet`
 #####
 
-function frule((_, Δx), ::typeof(logdet), x::Union{Number, AbstractMatrix})
+function frule((_, Δx), ::typeof(logdet), x::Union{Number, StridedMatrix{<:Number}})
     Ω = logdet(x)
     return Ω, tr(x \ Δx)
 end
 
-function rrule(::typeof(logdet), x::Union{Number, AbstractMatrix})
+function rrule(::typeof(logdet), x::Union{Number, StridedMatrix{<:Number}})
     Ω = logdet(x)
     function logdet_pullback(ΔΩ)
         ∂x = x isa Number ? ΔΩ / x' : ΔΩ * inv(x)'


### PR DESCRIPTION
Fixing this makes e.g.`Zygote` "just work" with`MvNormal` and `GenericMvT` in `Distributions` by preventing `ChainRules` from taking control of the way that `AbstractPDMats` compute `logdet`.