### PR TITLE
Remove thunks on scalars

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "0.7.13"
+version = "0.7.14"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/rulesets/Base/fastmath_able.jl
+++ b/src/rulesets/Base/fastmath_able.jl
@@ -126,7 +126,7 @@ let
             Ω = hypot(x, y)
             function hypot_pullback(ΔΩ)
                 c = real(ΔΩ) / ifelse(iszero(Ω), one(Ω), Ω)
-                return (NO_FIELDS, @thunk(c * x), @thunk(c * y))
+                return (NO_FIELDS, c * x, c * y)
             end
             return (Ω, hypot_pullback)
         end
@@ -185,7 +185,7 @@ let
 
         function rrule(::typeof(*), x::Number, y::Number)
             function times_pullback(ΔΩ)
-                return (NO_FIELDS,  @thunk(ΔΩ * y'), @thunk(x' * ΔΩ))
+                return (NO_FIELDS,  ΔΩ * y', x' * ΔΩ)
             end
             return x * y, times_pullback
         end


### PR DESCRIPTION
@dpsanders pointed out that our scalar multiplication implementation returns thunks. As a policy we don't thunk scalar operations for simple operations as the tradeoff isn't typically worth it -- these appeared to creep through.

I'll add a separate don't-thunk-by-default test to `ChainRulesTestUtils` to make sure that this doesn't creep back in, but still lets rule-implementers use thunk if they _really_ want to.