### PR TITLE
add Base.sinc rule

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "0.7.14"
+version = "0.7.15"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/rulesets/Base/base.jl
+++ b/src/rulesets/Base/base.jl
@@ -130,6 +130,8 @@ end
 @scalar_rule sinpi(x) π * cospi(x)
 @scalar_rule tand(x) (π / oftype(x, 180)) * (1 + Ω ^ 2)
 
+@scalar_rule sinc(x) cosc(x)
+
 @scalar_rule(
     clamp(x, low, high),
     @setup(

--- a/test/rulesets/Base/base.jl
+++ b/test/rulesets/Base/base.jl
@@ -44,7 +44,7 @@
             test_scalar(acotd, 1/x)
         end
         
-        @testset "sinc" for x = (0.434, Complex(0.434, 0.25))
+        @testset "sinc" for x = (0.0, 0.434, Complex(0.434, 0.25))
             test_scalar(sinc, x)
         end
     end  # Trig

--- a/test/rulesets/Base/base.jl
+++ b/test/rulesets/Base/base.jl
@@ -43,6 +43,10 @@
             test_scalar(acscd, 1/x)
             test_scalar(acotd, 1/x)
         end
+        
+        @testset "sinc" for x = (0.434, Complex(0.434, 0.25))
+            test_scalar(sinc, x)
+        end
     end  # Trig
 
     @testset "Angles" begin


### PR DESCRIPTION
I recently became aware that Julia `Base` defines a `cosc` function to be the derivative of `sinc`, so it seems worth adding this rule (especially since naive differentiation of `sinc` leads to an implementation that is numerically unstable: https://github.com/JuliaLang/julia/issues/37227).