### PR TITLE
Pin the Integration Test for Zygote to Julia 1.4

### DIFF
--- a/.github/workflows/IntegrationTestZygote.yml
+++ b/.github/workflows/IntegrationTestZygote.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        julia-version: [1]
+        julia-version: [1.4]
         os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Because Zygote's tests are broken in Juliia 1.5 (https://github.com/FluxML/Zygote.jl/issues/775)
we haven't had integration tests usable.
and #257  happened.
Our downstream Integration tests would have caught that.

cc @ChrisRackauckas 