### PR TITLE
Make sum of bool arrays nondiffernetiable

### DIFF
--- a/src/rulesets/Base/nondiff.jl
+++ b/src/rulesets/Base/nondiff.jl
@@ -340,6 +340,8 @@ VERSION >= v"1.1" && @non_differentiable splitpath(::AbstractString)
 @non_differentiable success(::Array{Base.Process,1})
 @non_differentiable success(::Base.Process)
 @non_differentiable success(::Base.ProcessChain)
+@non_differentiable sum(::AbstractArray{Bool})
+@non_differentiable sum(::NTuple{<:Any, Bool})
 @non_differentiable supertype(::Any)
 @non_differentiable symlink(::AbstractString, ::AbstractString)
 

--- a/test/rulesets/Base/nondiff.jl
+++ b/test/rulesets/Base/nondiff.jl
@@ -1,0 +1,7 @@
+@testset "Base/nondiff.jl" begin
+    @testset "Sum boolean arrays" begin
+        rrule_test(sum, 12, (falses(5, 3), nothing))
+        rrule_test(sum, 2, ([true, false, true], nothing))
+        rrule_test(sum, 2, ((true, false, true), nothing))
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,6 +18,7 @@ println("Testing ChainRules.jl")
 @testset "ChainRules" begin
     @testset "rulesets" begin
         @testset "Base" begin
+            include(joinpath("rulesets", "Base", "nondiff.jl"))
             include(joinpath("rulesets", "Base", "base.jl"))
             include(joinpath("rulesets", "Base", "fastmath_able.jl"))
             include(joinpath("rulesets", "Base", "evalpoly.jl"))


### PR DESCRIPTION
This matches to https://github.com/FluxML/Zygote.jl/pull/794

Fixing this in chainrules won't actually fix it in Zygote becuase 
Zygote defines `sum(::AbstractArray)` with a better definition than what ChainRules has right now, that will always take precidence.