### PR TITLE
fix typo in 4 arg gemm rrule

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "0.7.21"
+version = "0.7.22"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/rulesets/LinearAlgebra/blas.jl
+++ b/src/rulesets/LinearAlgebra/blas.jl
@@ -263,5 +263,5 @@ function rrule(
         (_, dtA, dtB, _, dA, dB) = inner_pullback(Ȳ)
         return (NO_FIELDS, dtA, dtB, dA, dB)
     end
-    return C, gemm_pullback
+    return C, gemv_pullback
 end

--- a/src/rulesets/LinearAlgebra/blas.jl
+++ b/src/rulesets/LinearAlgebra/blas.jl
@@ -259,9 +259,9 @@ function rrule(
     ::typeof(gemm), tA::Char, tB::Char, A::AbstractMatrix{T}, B::AbstractMatrix{T}
 ) where T<:BlasFloat
     C, inner_pullback = rrule(gemm, tA, tB, one(T), A, B)
-    function gemv_pullback(Ȳ)
+    function gemm_pullback(Ȳ)
         (_, dtA, dtB, _, dA, dB) = inner_pullback(Ȳ)
         return (NO_FIELDS, dtA, dtB, dA, dB)
     end
-    return C, gemv_pullback
+    return C, gemm_pullback
 end

--- a/test/rulesets/LinearAlgebra/blas.jl
+++ b/test/rulesets/LinearAlgebra/blas.jl
@@ -96,6 +96,15 @@
                 (A, randn(T, size(A))),
                 (B, randn(T, size(B))),
             )
+
+            rrule_test(
+                gemm,
+                ȳ,
+                (tA, nothing),
+                (tB, nothing),
+                (A, randn(T, size(A))),
+                (B, randn(T, size(B))),
+            )
         end
     end
 


### PR DESCRIPTION
This is a simple typo.
Clearly we have no tests for this rule.

This is blocking for https://github.com/invenia/Nabla.jl/pull/189