### PR TITLE
add rules for round, floor, ceil

### DIFF
--- a/src/rulesets/Base/fastmath_able.jl
+++ b/src/rulesets/Base/fastmath_able.jl
@@ -33,6 +33,11 @@ let
         @scalar_rule log10(x) inv(x) / log(oftype(x, 10))
         @scalar_rule log1p(x) inv(x + 1)
         @scalar_rule log2(x) inv(x) / log(oftype(x, 2))
+        
+        # rouding related
+        @scalar_rule round(x) zero(x)
+        @scalar_rule floor(x) zero(x)
+        @scalar_rule ceil(x) zero(x)
 
 
         # Unary complex functions

--- a/src/rulesets/Base/fastmath_able.jl
+++ b/src/rulesets/Base/fastmath_able.jl
@@ -34,7 +34,8 @@ let
         @scalar_rule log1p(x) inv(x + 1)
         @scalar_rule log2(x) inv(x) / log(oftype(x, 2))
         
-        # rouding related
+        # rouding related, 
+        # we use `zero` rather than `Zero()` for scalar, and avoids issues with map etc
         @scalar_rule round(x) zero(x)
         @scalar_rule floor(x) zero(x)
         @scalar_rule ceil(x) zero(x)

--- a/test/rulesets/Base/fastmath_able.jl
+++ b/test/rulesets/Base/fastmath_able.jl
@@ -90,6 +90,16 @@ const FASTABLE_AST = quote
         end
     end
 
+    @testset "rounding" begin
+        for x in (-0.1, 6.4, 0.5 + 0.25im)
+            test_scalar(round, x)
+            if x isa Real
+                test_scalar(floor, x)
+                test_scalar(ceil, x)
+            end
+        end
+    end
+
     @testset "Unary complex functions" begin
         for f ∈ (abs, abs2, conj), z ∈ (-4.1-0.02im, 6.4, 3 + im)
             @testset "Unary complex functions f = $f, z = $z" begin

--- a/test/rulesets/Base/fastmath_able.jl
+++ b/test/rulesets/Base/fastmath_able.jl
@@ -91,9 +91,15 @@ const FASTABLE_AST = quote
     end
 
     @testset "rounding" begin
-        for x in (-0.6, -0.2, -0.1, 0.1, 0.2, 0.6, 6.4)
-            test_scalar(floor, x, fdm = backward_fdm(5, 1))
-            test_scalar(ceil, x, fdm = forward_fdm(5, 1))
+        for x in (-0.6, -0.2, 0.1, 0.6)
+            # thanks to RoundNearest
+            if 0 > x % 1 > 0.5 || -1 < x % 1 <= 0.5
+                test_scalar(round, x; fdm=backward_fdm(5,1))
+            else
+                test_scalar(round, x; fdm=forward_fdm(5,1))
+            end
+            test_scalar(floor, x; fdm=backward_fdm(5, 1))
+            test_scalar(ceil, x; fdm=forward_fdm(5, 1))
         end
     end
 

--- a/test/rulesets/Base/fastmath_able.jl
+++ b/test/rulesets/Base/fastmath_able.jl
@@ -91,12 +91,9 @@ const FASTABLE_AST = quote
     end
 
     @testset "rounding" begin
-        for x in (-0.1, 6.4, 0.5 + 0.25im)
-            test_scalar(round, x)
-            if x isa Real
-                test_scalar(floor, x)
-                test_scalar(ceil, x)
-            end
+        for x in (-0.6, -0.2, -0.1, 0.1, 0.2, 0.6, 6.4)
+            test_scalar(floor, x, fdm = backward_fdm(5, 1))
+            test_scalar(ceil, x, fdm = forward_fdm(5, 1))
         end
     end
 


### PR DESCRIPTION
close #100

tests don't fully pass because `fdm` doesn't work for all of them:
https://github.com/JuliaDiff/ChainRulesTestUtils.jl/blob/85739e41653de0e0026776116b62f2bcf2a7ba82/src/testers.jl#L94
```
julia> _fdm = ChainRulesTestUtils._fdm;

julia> ChainRulesTestUtils.jvp(_fdm, xs->ceil(xs...), (0.1, 1.0))
5.833333333333332
```
should we "manually test" it and/or use `complex_jacobian_test` (like for `abs`)?
