### PR TITLE
Correct inplace for complex BLAS and fix some accumulation against nondifferentails

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "0.7.24"
+version = "0.7.25"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/Project.toml
+++ b/Project.toml
@@ -12,9 +12,9 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 ChainRulesCore = "0.9.12"
-ChainRulesTestUtils = "0.4.2, 0.5"
+ChainRulesTestUtils = "0.5"
 Compat = "3"
-FiniteDifferences = "0.10"
+FiniteDifferences = "0.11"
 Reexport = "0.2"
 Requires = "0.5.2, 1"
 julia = "1"

--- a/src/rulesets/LinearAlgebra/blas.jl
+++ b/src/rulesets/LinearAlgebra/blas.jl
@@ -129,7 +129,7 @@ function rrule(::typeof(gemv), tA::Char, α::T, A::AbstractMatrix{T},
         else  # uppercase(tA) === 'T'
             ∂A = InplaceableThunk(
                 @thunk(conj(α * x * ȳ')),
-                Ā -> conj!(ger!(α, x, ȳ, Ā))
+                Ā -> conj!(ger!(α, x, ȳ, conj!(Ā)))
             )
             ∂x = InplaceableThunk(
                 @thunk(gemv('N', α', conj(A), ȳ)),
@@ -188,7 +188,7 @@ function rrule(
                 )
                 ∂B = InplaceableThunk(
                     @thunk(conj(gemm('C', 'N', α, C̄, A))),
-                    B̄ -> conj!(gemm!('C', 'N', α, C̄, A, β, B̄))
+                    B̄ -> conj!(gemm!('C', 'N', α, C̄, A, β, conj!(B̄)))
                 )
             end
         elseif uppercase(tA) === 'C'
@@ -224,7 +224,7 @@ function rrule(
             if uppercase(tB) === 'N'
                 ∂A = InplaceableThunk(
                     @thunk(conj(gemm('N', 'C', α, B, C̄))),
-                    Ā -> conj!(gemm!('N', 'C', α, B, C̄, β, Ā))
+                    Ā -> conj!(gemm!('N', 'C', α, B, C̄, β, conj!(Ā)))
                 )
                 ∂B = InplaceableThunk(
                     @thunk(gemm('N', 'N', α', conj(A), C̄)),

--- a/test/rulesets/Base/base.jl
+++ b/test/rulesets/Base/base.jl
@@ -43,7 +43,7 @@
             test_scalar(acscd, 1/x)
             test_scalar(acotd, 1/x)
         end
-        
+
         @testset "sinc" for x = (0.0, 0.434, Complex(0.434, 0.25))
             test_scalar(sinc, x)
         end
@@ -126,14 +126,14 @@
         frule_test(identity, (randn(T, 4), randn(T, 4)))
         frule_test(
             identity,
-            (Composite{Tuple}(randn(T, 3)...), Composite{Tuple}(randn(T, 3)...))
+            (Tuple(randn(T, 3)), Composite{Tuple{T, T, T}}(randn(T, 3)...))
         )
 
         rrule_test(identity, randn(T), (randn(T), randn(T)))
         rrule_test(identity, randn(T, 4), (randn(T, 4), randn(T, 4)))
         rrule_test(
-            identity, Tuple(randn(T, 3)),
-            (Composite{Tuple}(randn(T, 3)...), Composite{Tuple}(randn(T, 3)...))
+            identity, Composite{Tuple{T, T, T}}(randn(T, 3)...),
+            (Tuple(randn(T, 3)), Composite{Tuple{T, T, T}}(randn(T, 3)...))
         )
     end
 

--- a/test/rulesets/Base/evalpoly.jl
+++ b/test/rulesets/Base/evalpoly.jl
@@ -27,9 +27,8 @@
             Ω = evalpoly(x, p)
             Ω̄ = randn(T, size(Ω)...)
             frule_test(evalpoly, (x, ẋ), (p, ṗ))
-            frule_test(evalpoly, (x, ẋ), (Tuple(p), Tuple(ṗ)))
+            frule_test(evalpoly, (x, ẋ), (Tuple(p), rand_tangent(Tuple(p))))
             rrule_test(evalpoly, Ω̄, (x, x̄), (p, p̄))
-            rrule_test(evalpoly, Ω̄, (x, x̄), (Tuple(p), Tuple(p̄)))
+            rrule_test(evalpoly, Ω̄, (x, x̄), (Tuple(p), rand_tangent(Tuple(p))))
         end
     end
-

--- a/test/rulesets/LinearAlgebra/blas.jl
+++ b/test/rulesets/LinearAlgebra/blas.jl
@@ -33,7 +33,7 @@
                 n = 10
                 x, ẋ, x̄ = randn(T, n), randn(T, n), randn(T, n)
                 frule_test(BLAS.nrm2, (x, ẋ))
-                rrule_test(BLAS.nrm2, randn(), (x, x̄))
+                rrule_test(BLAS.nrm2, randn(), (x, x̄); rtol=1e-7)
             end
         end
 

--- a/test/rulesets/LinearAlgebra/factorization.jl
+++ b/test/rulesets/LinearAlgebra/factorization.jl
@@ -89,10 +89,10 @@ using ChainRules: level2partition, level3partition, chol_blocked_rev, chol_unblo
                 ΔF = unthunk(dF)
                 _, dX = dX_pullback(ΔF)
                 X̄_ad = dot(unthunk(dX), V)
-                X̄_fd = _fdm() do ε
+                X̄_fd = central_fdm(5, 1)(0.000_001) do ε
                     dot(Ȳ, getproperty(cholesky(X .+ ε .* V), p))
                 end
-                @test X̄_ad ≈ X̄_fd rtol=1e-6 atol=1e-6
+                @test X̄_ad ≈ X̄_fd rtol=1e-4
             end
         end
         @testset "helper functions" begin

--- a/test/rulesets/packages/SpecialFunctions.jl
+++ b/test/rulesets/packages/SpecialFunctions.jl
@@ -50,7 +50,7 @@ end
             isreal(x) || continue
 
             Δx, x̄ = randn(2)
-            Δz = (randn(), randn())
+            Δz = Composite{Tuple{Float64, DoesNotExist}}(randn(), Zero())
 
             frule_test(SpecialFunctions.logabsgamma, (x, Δx))
             rrule_test(SpecialFunctions.logabsgamma, Δz, (x, x̄))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,7 @@ using ChainRulesTestUtils
 using ChainRulesTestUtils: _fdm
 using Compat: only
 using FiniteDifferences
+using FiniteDifferences: rand_tangent
 using LinearAlgebra
 using LinearAlgebra.BLAS
 using LinearAlgebra: dot


### PR DESCRIPTION
closes #278 

This PR is the follow up from the integration tests failing in
https://github.com/JuliaDiff/ChainRulesTestUtils.jl/pull/59

The core problem with the complex numbers was we were doing
`a = (b + a)' ` 
but we should have been doing
`a = b' + a`
but BLAS doesn;t have a shorthand for that
so what we actually do is:
`a = (b + a')'`

Other problem was us using some things were not differentials, and trying to acculate against them.

Requires
https://github.com/JuliaDiff/FiniteDifferences.jl/pull/111
for tests to pass, as needs to `to_vec` support for `AbstractZeros`
because its used in how ChainRulesTestUtil checks equality for `Composites`
which doesn't seem great, and seems like  in longer term to destructure the eqaulity checks is better
like in https://github.com/JuliaDiff/ChainRulesTestUtils.jl/pull/57