### PR TITLE
Adds some missing unthunks

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "0.7.23"
+version = "0.7.24"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/rulesets/LinearAlgebra/factorization.jl
+++ b/src/rulesets/LinearAlgebra/factorization.jl
@@ -8,7 +8,7 @@ using LinearAlgebra.BLAS: gemv, gemv!, gemm!, trsm!, axpy!, ger!
 function rrule(::typeof(svd), X::AbstractMatrix{<:Real})
     F = svd(X)
     function svd_pullback(Ȳ::Composite)
-        # svd_rev does a lot of linear algebra, it it is efficient to unthunk before
+        # svd_rev does a lot of linear algebra, it is is efficient to unthunk before
         ∂X = svd_rev(F, unthunk(Ȳ.U), unthunk(Ȳ.S), unthunk(Ȳ.V))
         return (NO_FIELDS, ∂X)
     end

--- a/src/rulesets/LinearAlgebra/factorization.jl
+++ b/src/rulesets/LinearAlgebra/factorization.jl
@@ -8,7 +8,8 @@ using LinearAlgebra.BLAS: gemv, gemv!, gemm!, trsm!, axpy!, ger!
 function rrule(::typeof(svd), X::AbstractMatrix{<:Real})
     F = svd(X)
     function svd_pullback(Ȳ::Composite)
-        ∂X = svd_rev(F, Ȳ.U, Ȳ.S, Ȳ.V)
+        # svd_rev does a lot of linear algebra, it it is efficient to unthunk before
+        ∂X = svd_rev(F, unthunk(Ȳ.U), unthunk(Ȳ.S), unthunk(Ȳ.V))
         return (NO_FIELDS, ∂X)
     end
     return F, svd_pullback

--- a/src/rulesets/LinearAlgebra/structured.jl
+++ b/src/rulesets/LinearAlgebra/structured.jl
@@ -32,6 +32,9 @@ end
 #####
 
 function rrule(::Type{<:Diagonal}, d::AbstractVector)
+    function Diagonal_pullback(x::AbstractThunk)
+        return Diagonal_pullback(unthunk(x))
+    end
     function Diagonal_pullback(ȳ::AbstractMatrix)
         return (NO_FIELDS, diag(ȳ))
     end

--- a/src/rulesets/LinearAlgebra/structured.jl
+++ b/src/rulesets/LinearAlgebra/structured.jl
@@ -32,9 +32,6 @@ end
 #####
 
 function rrule(::Type{<:Diagonal}, d::AbstractVector)
-    function Diagonal_pullback(x::AbstractThunk)
-        return Diagonal_pullback(unthunk(x))
-    end
     function Diagonal_pullback(ȳ::AbstractMatrix)
         return (NO_FIELDS, diag(ȳ))
     end

--- a/test/rulesets/LinearAlgebra/factorization.jl
+++ b/test/rulesets/LinearAlgebra/factorization.jl
@@ -13,17 +13,37 @@ using ChainRules: level2partition, level3partition, chol_blocked_rev, chol_unblo
                 @test dself1 === NO_FIELDS
                 @test dp === DoesNotExist()
 
-                ΔF = unthunk(dF)
-                dself2, dX = dX_pullback(ΔF)
+                dself2, dX = dX_pullback(dF)
                 @test dself2 === NO_FIELDS
                 X̄_ad = unthunk(dX)
                 X̄_fd = only(j′vp(central_fdm(5, 1), X->getproperty(svd(X), p), Ȳ, X))
                 @test all(isapprox.(X̄_ad, X̄_fd; rtol=1e-6, atol=1e-6))
+
             end
             @testset "Vt" begin
                 Y, dF_pullback = rrule(getproperty, F, :Vt)
                 Ȳ = randn(size(Y)...)
                 @test_throws ArgumentError dF_pullback(Ȳ)
+            end
+        end
+
+        @testset "Thunked inputs" begin
+            X = randn(4, 3)
+            F, dX_pullback = rrule(svd, X)
+            for p in [:U, :S, :V]
+                Y, dF_pullback = rrule(getproperty, F, p)
+                Ȳ = randn(size(Y)...)
+
+                _, dF_unthunked, _ = dF_pullback(Ȳ)
+
+                @assert !(getproperty(dF_unthunked, p) isa AbstractThunk)
+                dF_thunked = map(f->Thunk(()->f), dF_unthunked)
+                @assert getproperty(dF_thunked, p) isa AbstractThunk
+
+                dself_thunked, dX_thunked = dX_pullback(dF_thunked)
+                dself_unthunked, dX_unthunked = dX_pullback(dF_unthunked)
+                @test dself_thunked == dself_unthunked
+                @test dX_thunked == dX_unthunked
             end
         end
 

--- a/test/rulesets/LinearAlgebra/factorization.jl
+++ b/test/rulesets/LinearAlgebra/factorization.jl
@@ -18,7 +18,6 @@ using ChainRules: level2partition, level3partition, chol_blocked_rev, chol_unblo
                 X̄_ad = unthunk(dX)
                 X̄_fd = only(j′vp(central_fdm(5, 1), X->getproperty(svd(X), p), Ȳ, X))
                 @test all(isapprox.(X̄_ad, X̄_fd; rtol=1e-6, atol=1e-6))
-
             end
             @testset "Vt" begin
                 Y, dF_pullback = rrule(getproperty, F, :Vt)


### PR DESCRIPTION
I am not 100% sure how i feel about this.
Maybe we should actually overload some more linear operators in ChainRulesCore.
Including in particular: the `Diagonal` constructor,
and `\` with a `Vector`

But for `svd_rev` because we use some of the inputs multiple times, it is actually faster to unthunk them at the start anyway.
I feel like we shouldn't actually have to use any input more than once, but that is another issue.

The testset in Nabla that revealed this was:
```julia
    @testset "Tape updating from multiple components" begin
        ∇f = ∇() do X
            U, S, V = svd(X)
            Y = U * Diagonal(S) * V'
            sum(Y)
        end
        X = [1.0 2.0; 3.0 4.0; 5.0 6.0]
        @test ∇f(X)[1] ≈ ones(3, 2) atol=1e-5
    end
```

I am not sure what is a good way to test this PR.
Do we want to add something to ChainRulesTestUtils that redoes all tests passing in Thunk's of the inputs in as well?
That wouldn't trivially catch Composites.

This is needed for https://github.com/invenia/Nabla.jl/pull/189