### PR TITLE
det and logdet for structured matrixes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "0.7.25"
+version = "0.7.26"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/rulesets/LinearAlgebra/structured.jl
+++ b/src/rulesets/LinearAlgebra/structured.jl
@@ -280,7 +280,7 @@ _diag_view(X::Diagonal) = parent(X)  #Diagonal wraps a Vector of just Diagonal e
 
 function rrule(::typeof(det), X::Union{Diagonal, AbstractTriangular})
     y = det(X)
-    s = y ./ _diag_view(X)
+    s = conj!(y ./ _diag_view(X))
     function det_pullback(ȳ)
         return (NO_FIELDS, Diagonal(ȳ .* s))
     end
@@ -289,7 +289,7 @@ end
 
 function rrule(::typeof(logdet), X::Union{Diagonal, AbstractTriangular})
     y = logdet(X)
-    s = one(eltype(X)) ./ _diag_view(X)
+    s = conj!(one(eltype(X)) ./ _diag_view(X))
     function logdet_pullback(ȳ)
         return (NO_FIELDS, Diagonal(ȳ .* s))
     end

--- a/src/rulesets/LinearAlgebra/structured.jl
+++ b/src/rulesets/LinearAlgebra/structured.jl
@@ -274,3 +274,24 @@ function rrule(::typeof(tril), A::AbstractMatrix)
     end
     return tril(A), tril_pullback
 end
+
+_diag_view(X) = view(X, diagind(X))
+_diag_view(X::Diagonal) = parent(X)  #Diagonal wraps a Vector of just Diagonal elements
+
+function rrule(::typeof(det), X::Union{Diagonal, AbstractTriangular})
+    y = det(X)
+    s = y ./ _diag_view(X)
+    function det_pullback(ȳ)
+        return (NO_FIELDS, Diagonal(ȳ .* s))
+    end
+    return y, det_pullback
+end
+
+function rrule(::typeof(logdet), X::Union{Diagonal, AbstractTriangular})
+    y = logdet(X)
+    s = one(eltype(X)) ./ _diag_view(X)
+    function logdet_pullback(ȳ)
+        return (NO_FIELDS, Diagonal(ȳ .* s))
+    end
+    return y, logdet_pullback
+end

--- a/test/rulesets/LinearAlgebra/structured.jl
+++ b/test/rulesets/LinearAlgebra/structured.jl
@@ -160,7 +160,7 @@
     @testset "det and logdet $T" for T in (Diagonal, UpperTriangular, LowerTriangular)
         n = 5
         # rand (not randn) so det will be postive, so logdet will be defined
-        X = T(rand(n, n))
+        X = T(3*rand(n, n) .+ 1)
         X̄_acc = Diagonal(rand(n, n))  # sensitivity is always a diagonal for these types
         @testset "$op" for op in (det, logdet)
             rrule_test(op, 2.7, (X, X̄_acc))

--- a/test/rulesets/LinearAlgebra/structured.jl
+++ b/test/rulesets/LinearAlgebra/structured.jl
@@ -157,15 +157,17 @@
         end
     end
 
-    @testset "det and logdet $T" for T in (Diagonal, UpperTriangular, LowerTriangular)
-        n = 5
-        # rand (not randn) so det will be postive, so logdet will be defined
-        X = T(3*rand(n, n) .+ 1)
-        X̄_acc = Diagonal(rand(n, n))  # sensitivity is always a diagonal for these types
+    @testset "det and logdet $S" for S in (Diagonal, UpperTriangular, LowerTriangular)
         @testset "$op" for op in (det, logdet)
-            rrule_test(op, 2.7, (X, X̄_acc))
-
+            @testset "$T" for T in (Float64, ComplexF64)
+                n = 5
+                # rand (not randn) so det will be postive, so logdet will be defined
+                X = S(3*rand(T, (n, n)) .+ 1)
+                X̄_acc = Diagonal(rand(T, (n, n)))  # sensitivity is always a diagonal for these types
+                rrule_test(op, rand(T), (X, X̄_acc))
+            end
             @testset "return type" begin
+                X = S(3*rand(6, 6) .+ 1)
                 _, op_pullback = rrule(op, X)
                 X̄ = op_pullback(2.7)[2]
                 @test X̄ isa Diagonal

--- a/test/rulesets/LinearAlgebra/structured.jl
+++ b/test/rulesets/LinearAlgebra/structured.jl
@@ -156,4 +156,20 @@
             rrule_test(Op, randn(n, n), (randn(n, n), randn(n, n)), (k, nothing))
         end
     end
+
+    @testset "det and logdet $T" for T in (Diagonal, UpperTriangular, LowerTriangular)
+        n = 5
+        # rand (not randn) so det will be postive, so logdet will be defined
+        X = T(rand(n, n))
+        X̄_acc = Diagonal(rand(n, n))  # sensitivity is always a diagonal for these types
+        @testset "$op" for op in (det, logdet)
+            rrule_test(op, 2.7, (X, X̄_acc))
+
+            @testset "return type" begin
+                _, op_pullback = rrule(op, X)
+                X̄ = op_pullback(2.7)[2]
+                @test X̄ isa Diagonal
+            end
+        end
+    end
 end


### PR DESCRIPTION
This is based on https://github.com/invenia/Nabla.jl/blob/4cadc87677fb1187354999dcf93bd528f45f85d0/src/sensitivities/linalg/triangular.jl

Differences:
 - It generalizes it somewhat to apply `Diagonal` as well as `AbstractTriangular` matrixes
 - It doesn't currently implement the inplace rules, because I am not sure they are worth it. 
    - On the one hard it lets the `/` be fused with the accumulation, and avoids allocating the vector `s`
    - On the other hand it it means carrying a reference to `X` rather than just a vector `s` of the same size as the diagonal of `x`
   - @willtebbutt  what do you think? Should I add the inplace rules?