### PR TITLE
use `sincos` in rules for `sin` and `cos`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "0.7.31"
+version = "0.7.32"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/rulesets/Base/base.jl
+++ b/src/rulesets/Base/base.jl
@@ -75,32 +75,6 @@ function rrule(::typeof(hypot), z::Complex)
     return (Ω, hypot_pullback)
 end
 
-# `sin`
-
-function rrule(::typeof(sin), x::Number)
-    sinx, cosx = sincos(x)
-    sin_pullback(dy) = (NO_FIELDS, cosx * dy)
-    return (sinx, sin_pullback)
-end
-
-function frule((_, dy), ::typeof(sin), x::Number)
-    sinx, cosx = sincos(x)
-    return (sinx, cosx)
-end
-
-# `cos`
-
-function rrule(::typeof(cos), x::Number)
-    sinx, cosx = sincos(x)
-    cos_pullback(dy) = (NO_FIELDS, -sinx * dy)
-    return (cosx, cos_pullback)
-end
-
-function frule((_, dy), ::typeof(cos), x::Number)
-    sinx, cosx = sincos(x)
-    return (cosx, -sinx)
-end
-
 @scalar_rule fma(x, y, z) (y, x, One())
 @scalar_rule muladd(x, y, z) (y, x, One())
 @scalar_rule rem2pi(x, r::RoundingMode) (One(), DoesNotExist())

--- a/src/rulesets/Base/base.jl
+++ b/src/rulesets/Base/base.jl
@@ -75,6 +75,32 @@ function rrule(::typeof(hypot), z::Complex)
     return (Ω, hypot_pullback)
 end
 
+# `sin`
+
+function rrule(::typeof(sin), x::Number)
+    sinx, cosx = sincos(x)
+    sin_pullback(dy) = (NO_FIELDS, cosx * dy)
+    return (sinx, sin_pullback)
+end
+
+function frule((_, dy), ::typeof(sin), x::Number)
+    sinx, cosx = sincos(x)
+    return (sinx, cosx)
+end
+
+# `cos`
+
+function rrule(::typeof(cos), x::Number)
+    sinx, cosx = sincos(x)
+    cos_pullback(dy) = (NO_FIELDS, -sinx * dy)
+    return (cosx, cos_pullback)
+end
+
+function frule((_, dy), ::typeof(cos), x::Number)
+    sinx, cosx = sincos(x)
+    return (cosx, -sinx)
+end
+
 @scalar_rule fma(x, y, z) (y, x, One())
 @scalar_rule muladd(x, y, z) (y, x, One())
 @scalar_rule rem2pi(x, r::RoundingMode) (One(), DoesNotExist())

--- a/src/rulesets/Base/fastmath_able.jl
+++ b/src/rulesets/Base/fastmath_able.jl
@@ -5,8 +5,6 @@ let
     # e.g. do not add `foo` unless `Base.FastMath.foo_fast` exists.
     fastable_ast = quote
         #  Trig-Basics
-        @scalar_rule cos(x) -(sin(x))
-        @scalar_rule sin(x) cos(x)
         @scalar_rule tan(x) 1 + Ω ^ 2
 
 

--- a/src/rulesets/Base/fastmath_able.jl
+++ b/src/rulesets/Base/fastmath_able.jl
@@ -5,13 +5,13 @@ let
     # e.g. do not add `foo` unless `Base.FastMath.foo_fast` exists.
     fastable_ast = quote
         #  Trig-Basics
-        ## use `sincos` to comput sin and cos at the same time
-        ## for the rules for sin and cos
-        ## See issue: https://github.com/JuliaDiff/ChainRules.jl/issues/291s
+        ## use `sincos` to compute `sin` and `cos` at the same time
+        ## for the rules for `sin` and `cos`
+        ## See issue: https://github.com/JuliaDiff/ChainRules.jl/issues/291
         ## sin
         function rrule(::typeof(sin), x::Number)
             sinx, cosx = sincos(x)
-            sin_pullback(Δy) = (NO_FIELDS, cosx * Δy)
+            sin_pullback(Δy) = (NO_FIELDS, cosx' * Δy)
             return (sinx, sin_pullback)
         end
 
@@ -23,7 +23,7 @@ let
         ## cos
         function rrule(::typeof(cos), x::Number)
             sinx, cosx = sincos(x)
-            cos_pullback(Δy) = (NO_FIELDS, -sinx * Δy)
+            cos_pullback(Δy) = (NO_FIELDS, -sinx' * Δy)
             return (cosx, cos_pullback)
         end
         

--- a/src/rulesets/Base/fastmath_able.jl
+++ b/src/rulesets/Base/fastmath_able.jl
@@ -5,6 +5,33 @@ let
     # e.g. do not add `foo` unless `Base.FastMath.foo_fast` exists.
     fastable_ast = quote
         #  Trig-Basics
+        ## use `sincos` to comput sin and cos at the same time
+        ## for the rules for sin and cos
+        ## See issue: https://github.com/JuliaDiff/ChainRules.jl/issues/291s
+        ## sin
+        function rrule(::typeof(sin), x::Number)
+            sinx, cosx = sincos(x)
+            sin_pullback(Δy) = (NO_FIELDS, cosx * Δy)
+            return (sinx, sin_pullback)
+        end
+
+        function frule((_, Δx), ::typeof(sin), x::Number)
+            sinx, cosx = sincos(x)
+            return (sinx, cosx * Δx)
+        end
+
+        ## cos
+        function rrule(::typeof(cos), x::Number)
+            sinx, cosx = sincos(x)
+            cos_pullback(Δy) = (NO_FIELDS, -sinx * Δy)
+            return (cosx, cos_pullback)
+        end
+        
+        function frule((_, Δx), ::typeof(cos), x::Number)
+            sinx, cosx = sincos(x)
+            return (cosx, -sinx * Δx)
+        end
+        
         @scalar_rule tan(x) 1 + Ω ^ 2
 
 


### PR DESCRIPTION
Fixes #291 

Currently tests fail though.