### PR TITLE
add derivatives for exponential integral

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,6 @@ Compat = "3"
 FiniteDifferences = "0.11"
 Reexport = "0.2"
 Requires = "0.5.2, 1"
-SpecialFunctions = "0.10.3"
 julia = "1"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -19,6 +19,7 @@ Compat = "3"
 FiniteDifferences = "0.11"
 Reexport = "0.2"
 Requires = "0.5.2, 1"
+SpecialFunctions = "0.10.3"
 julia = "1"
 
 [extras]

--- a/src/rulesets/packages/SpecialFunctions.jl
+++ b/src/rulesets/packages/SpecialFunctions.jl
@@ -67,9 +67,11 @@
     (SpecialFunctions.digamma(a) - SpecialFunctions.digamma(a + b),
      SpecialFunctions.digamma(b) - SpecialFunctions.digamma(a + b),)
 )
-@scalar_rule(
-    SpecialFunctions.expint(ν, z), (NaN, -SpecialFunctions.expint(ν - 1, z)),
-)
+if isdefined(SpecialFunctions, :expint)
+    @scalar_rule(
+        SpecialFunctions.expint(ν, z), (NaN, -SpecialFunctions.expint(ν - 1, z)),
+    )
+end
 # Changes between SpecialFunctions 0.7 and 0.8
 if isdefined(SpecialFunctions, :lgamma)
     # actually is the absolute value of the logorithm of gamma

--- a/src/rulesets/packages/SpecialFunctions.jl
+++ b/src/rulesets/packages/SpecialFunctions.jl
@@ -67,6 +67,9 @@
     (SpecialFunctions.digamma(a) - SpecialFunctions.digamma(a + b),
      SpecialFunctions.digamma(b) - SpecialFunctions.digamma(a + b),)
 )
+@scalar_rule(
+    SpecialFunctions.expint(ν, z), (NaN, -SpecialFunctions.expint(ν - 1, z)),
+)
 # Changes between SpecialFunctions 0.7 and 0.8
 if isdefined(SpecialFunctions, :lgamma)
     # actually is the absolute value of the logorithm of gamma


### PR DESCRIPTION
Fixes #292 .

We probably need a test case right? Currently we don't have test cases for `polygamma(m, x)`, and probably for other "binary" functions either.

And one of the forms of derivative of `expint(\nu, z)` with respect `\nu` is actually:
`-z ^ (nu - 1) * meijerg(((), (1, 1)), ((0, 0, -nu + 1), ()), z)`.

Though I couldn't find in `SpecialFunctions` an implementation of `meijerg`.