### PR TITLE
reuse factorization in rule for \

### DIFF
--- a/src/rulesets/Base/arraymath.jl
+++ b/src/rulesets/Base/arraymath.jl
@@ -101,16 +101,16 @@ end
 #####
 
 function rrule(::typeof(\), A::AbstractVecOrMat{<:Real}, B::AbstractVecOrMat{<:Real})
-    Y = A \ B
+    Af = factorize(A)  # precompute factorized form, to reused in pullback
+    Y = Af \ B  # factorized form is much faster to run \ on
     function backslash_pullback(Ȳ)
+        ∂B = Af' \ Ȳ
         ∂A = @thunk begin
-            B̄ = A' \ Ȳ
-            Ā = -B̄ * Y'
-            Ā = add!!(Ā, (B - A * Y) * B̄' / A')
-            Ā = add!!(Ā, A' \ Y * (Ȳ' - B̄'A))
+            Ā = -∂B * Y'
+            Ā = add!!(Ā, (B - A * Y) * ∂B' / Af')
+            Ā = add!!(Ā, Af' \ Y * (Ȳ' - ∂B'A))
             Ā
         end
-        ∂B = @thunk A' \ Ȳ
         return NO_FIELDS, ∂A, ∂B
     end
     return Y, backslash_pullback


### PR DESCRIPTION
Closes #250 
Its pretty cute
I am not 100% sure this is correct, but CI will tell me

Also stops thunking `∂B` since we want to use that for `∂A`
which means if we need `∂B` then we need to compute it, and if we need `∂A` we needed to compute it,
so either way we need it.


```julia
julia> @btime $(x)\$y
  1.032 μs (3 allocations: 1.19 KiB)
10-element Vector{Float64}:
  0.49018802032025616
 -0.33578706090563665
 -0.4615411572036624
  0.24664997800385907
 -0.5310612794797791
  0.3537748064584685
  1.470168551590106
 -0.4108242996218167
  0.11217305102151084
 -0.4276420520809933

julia> @btime $(factorize(x))\$y
  252.892 ns (1 allocation: 160 bytes)
10-element Vector{Float64}:
  0.49018802032025616
 -0.33578706090563665
 -0.4615411572036624
  0.24664997800385907
 -0.5310612794797791
  0.3537748064584685
  1.470168551590106
 -0.4108242996218167
  0.11217305102151084
 -0.4276420520809933
```