### PR TITLE
Remove uses of similar to generate test inputs

### DIFF
--- a/test/rulesets/LinearAlgebra/dense.jl
+++ b/test/rulesets/LinearAlgebra/dense.jl
@@ -28,7 +28,7 @@
             M, N = 3, 4
             x, A, y = randn(T, M), randn(T, M, N), randn(T, N)
             ẋ, Adot, ẏ = randn(T, M), randn(T, M, N), randn(T, N)
-            x̄, Abar, ȳ = similar(x), similar(A), similar(y)
+            x̄, Abar, ȳ = randn(T, M), randn(T, M, N), randn(T, N)
             frule_test(dot, (x, ẋ), (A, Adot), (y, ẏ))
             rrule_test(dot, randn(T), (x, x̄), (A, Abar), (y, ȳ))
         end
@@ -37,7 +37,7 @@
             M, N = 3, 4
             x, A, y = rand(T, M), F(rand(T, N, M)), rand(T, N)
             ẋ, Adot, ẏ = rand(T, M), F(rand(T, N, M)), rand(T, N)
-            x̄, Abar, ȳ = similar(x), F(rand(T, N, M)), similar(y)
+            x̄, Abar, ȳ = rand(T, M), F(rand(T, N, M)), rand(T, N)
             frule_test(dot, (x, ẋ), (A, Adot), (y, ẏ); rtol=1f-3)
             rrule_test(dot, float(rand(T)), (x, x̄), (A, Abar), (y, ȳ); rtol=1f-3)
         end

--- a/test/rulesets/LinearAlgebra/structured.jl
+++ b/test/rulesets/LinearAlgebra/structured.jl
@@ -36,8 +36,10 @@
     @testset "dot(x, ::Diagonal, y)" begin
         N = 4
         x, d, y = randn(ComplexF64, N), randn(ComplexF64, N), randn(ComplexF64, N)
+        x̄, d̄, ȳ = randn(ComplexF64, N), randn(ComplexF64, N), randn(ComplexF64, N)
         D = Diagonal(d)
-        rrule_test(dot, rand(ComplexF64), (x,similar(x)), (D,similar(D)), (y,similar(y)))
+        D̄ = Diagonal(d̄)
+        rrule_test(dot, rand(ComplexF64), (x, x̄), (D, D̄), (y, ȳ))
     end
     @testset "::Diagonal * ::AbstractVector" begin
         N = 3


### PR DESCRIPTION
This is why we have been getting non-determinstic failures, even thouh the RNG seed was set.
`similar` just has whatever values was in RAM.
Which could well be NaN.

Turns out it was not FiniteDifferences.jl v0.11 at all.