### PR TITLE
Delete ChainRulesTestUtils submodule, and ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ Manifest.toml
 docs/build
 docs/site
 .idea/*
+dev/*


### PR DESCRIPTION
fixes the mistakenly added submodule pointed out in https://github.com/JuliaDiff/ChainRules.jl/pull/304#issuecomment-728930890
adds `/dev` to gitignore to hopefully prevent it from happening again