### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -38,5 +38,5 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       # fixes for coveralls pushed since last release v1.1.1
-      - run: julia --color=yes -e 'using Pkg; Pkg.add("Coverage#master"); using Coverage; Coveralls.submit(process_folder())'
+      - run: julia --color=yes -e 'using Pkg; Pkg.add(name="Coverage", rev="master"); using Coverage; Coveralls.submit(process_folder())'
         shell: bash

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,8 +19,8 @@ jobs:
           - '1'
         os:
           - ubuntu-latest
+          - macOS-latest
           - windows-latest
-          - macos-latest
         arch:
           - x86
           - x64

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -40,3 +40,5 @@ jobs:
       # fixes for coveralls pushed since last release v1.1.1
       - run: julia --color=yes -e 'using Pkg; Pkg.add(PackageSpec(name="Coverage", rev="master")); using Coverage; Coveralls.submit(process_folder())'
         shell: bash
+        env:
+          COVERALLS_TOKEN: ${{ secrets.COVERALLS_TOKEN }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -37,8 +37,7 @@ jobs:
             ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
-      # fixes for coveralls pushed since last release v1.1.1
-      - run: julia --color=yes -e 'using Pkg; Pkg.add(PackageSpec(name="Coverage", rev="master")); using Coverage; Coveralls.submit(process_folder())'
-        shell: bash
-        env:
-          COVERALLS_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v1
+        with:
+          file: lcov.info

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,40 @@
+name: CI
+on:
+  push:
+    branches: [master]
+    tags: [v*]
+  pull_request:
+
+jobs:
+  test:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1.0'
+          - '1'
+        os:
+          - ubuntu-latest
+        arch:
+          - x64
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: actions/cache@v1
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-test-
+            ${{ runner.os }}-
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+      - uses: julia-actions/julia-uploadcoveralls@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -45,5 +45,5 @@ jobs:
           file: lcov.info
       - uses: coverallsapp/github-action@master
         with:
-          github-token: ${{ secrets.COVERALLS_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: lcov.info

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,6 +24,10 @@ jobs:
         arch:
           - x86
           - x64
+        # 32-bit Julia binaries are not available on macOS
+        exclude:
+          - os: macOS-latest
+            julia-arch: x86
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -43,3 +43,7 @@ jobs:
       - uses: codecov/codecov-action@v1
         with:
           file: lcov.info
+      - uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.COVERALLS_TOKEN }}
+          path-to-lcov: lcov.info

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,6 +4,8 @@ on:
     branches: [master]
     tags: [v*]
   pull_request:
+  schedule:
+    - cron: "0 0 * * *"
 
 jobs:
   test:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -37,4 +37,6 @@ jobs:
             ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
-      - uses: julia-actions/julia-uploadcoveralls@v1
+      # fixes for coveralls pushed since last release v1.1.1
+      - run: julia --color=yes -e 'using Pkg; Pkg.add("Coverage#master"); using Coverage; Coveralls.submit(process_folder())'
+        shell: bash

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,7 +5,7 @@ on:
     tags: [v*]
   pull_request:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 0 * * *" # run on default branch every night at midnight UTC
 
 jobs:
   test:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -51,12 +51,11 @@ jobs:
           path-to-lcov: lcov.info
 
   finish:
+    name: Coveralls Finished
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - name: Coveralls Finished
-        uses: coverallsapp/github-action@master
+      - uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel-finished: true
-

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -46,4 +46,17 @@ jobs:
       - uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          flag-name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
+          parallel: true
           path-to-lcov: lcov.info
+
+  finish:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Coveralls Finished
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          parallel-finished: true
+

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,7 +27,7 @@ jobs:
         # 32-bit Julia binaries are not available on macOS
         exclude:
           - os: macOS-latest
-            julia-arch: x86
+            arch: x86
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -38,5 +38,5 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       # fixes for coveralls pushed since last release v1.1.1
-      - run: julia --color=yes -e 'using Pkg; Pkg.add(name="Coverage", rev="master"); using Coverage; Coveralls.submit(process_folder())'
+      - run: julia --color=yes -e 'using Pkg; Pkg.add(PackageSpec(name="Coverage", rev="master")); using Coverage; Coveralls.submit(process_folder())'
         shell: bash

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,7 +19,10 @@ jobs:
           - '1'
         os:
           - ubuntu-latest
+          - windows-latest
+          - macos-latest
         arch:
+          - x86
           - x64
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/JuliaNightly.yml
+++ b/.github/workflows/JuliaNightly.yml
@@ -1,5 +1,5 @@
 # CI for Julia nightly, separate workflow to avoid failing CI badge on nightly fail
-name: Nightly
+name: JuliaNightly
 on:
   push:
     branches: [master]
@@ -10,7 +10,7 @@ on:
 
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
+    name: ${{ matrix.os }} - ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/Nightly.yml
+++ b/.github/workflows/Nightly.yml
@@ -1,0 +1,48 @@
+# CI for Julia nightly, separate workflow to avoid failing CI badge on nightly fail
+name: Nightly
+on:
+  push:
+    branches: [master]
+    tags: [v*]
+  pull_request:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  test:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - 'nightly'
+        os:
+          - ubuntu-latest
+          - macOS-latest
+          - windows-latest
+        arch:
+          - x86
+          - x64
+        # 32-bit Julia binaries are not available on macOS
+        exclude:
+          - os: macOS-latest
+            arch: x86
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: actions/cache@v1
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-test-
+            ${{ runner.os }}-
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 # ChainRules
 
+[![CI](https://github.com/JuliaDiff/ChainRules.jl/workflows/CI/badge.svg?branch=master)](https://github.com/JuliaDiff/ChainRules.jl/actions?query=workflow%3ACI)
 [![Travis](https://travis-ci.org/JuliaDiff/ChainRules.jl.svg?branch=master)](https://travis-ci.org/JuliaDiff/ChainRules.jl)
 [![Coveralls](https://coveralls.io/repos/github/JuliaDiff/ChainRules.jl/badge.svg?branch=master)](https://coveralls.io/github/JuliaDiff/ChainRules.jl?branch=master)
 [![PkgEval](https://juliaci.github.io/NanosoldierReports/pkgeval_badges/C/ChainRules.svg)](https://juliaci.github.io/NanosoldierReports/pkgeval_badges/report.html)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 [![CI](https://github.com/JuliaDiff/ChainRules.jl/workflows/CI/badge.svg?branch=master)](https://github.com/JuliaDiff/ChainRules.jl/actions?query=workflow%3ACI)
 [![Travis](https://travis-ci.org/JuliaDiff/ChainRules.jl.svg?branch=master)](https://travis-ci.org/JuliaDiff/ChainRules.jl)
+[![Codecov](https://codecov.io/gh/JuliaDiff/ChainRules.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/JuliaDiff/ChainRules.jl)
 [![Coveralls](https://coveralls.io/repos/github/JuliaDiff/ChainRules.jl/badge.svg?branch=master)](https://coveralls.io/github/JuliaDiff/ChainRules.jl?branch=master)
 [![PkgEval](https://juliaci.github.io/NanosoldierReports/pkgeval_badges/C/ChainRules.svg)](https://juliaci.github.io/NanosoldierReports/pkgeval_badges/report.html)
 [![Code Style: Blue](https://img.shields.io/badge/code%20style-blue-4495d1.svg)](https://github.com/invenia/BlueStyle)

--- a/test/rulesets/LinearAlgebra/dense.jl
+++ b/test/rulesets/LinearAlgebra/dense.jl
@@ -105,10 +105,15 @@
             test_scalar(f, b)
         end
         @testset "$f(::Matrix{$T})" for T in (Float64, ComplexF64)
+            if f === logdet && float(T) <: Float32
+                kwargs = (atol=1e-5, rtol=1e-5)
+            else
+                kwargs = NamedTuple()
+            end
             N = 3
             B = generate_well_conditioned_matrix(T, N)
-            frule_test(f, (B, randn(T, N, N)))
-            rrule_test(f, randn(T), (B, randn(T, N, N)))
+            frule_test(f, (B, randn(T, N, N)); kwargs...)
+            rrule_test(f, randn(T), (B, randn(T, N, N)); kwargs...)
         end
     end
     @testset "logabsdet(::Matrix{$T})" for T in (Float64, ComplexF64)

--- a/test/rulesets/packages/SpecialFunctions.jl
+++ b/test/rulesets/packages/SpecialFunctions.jl
@@ -50,7 +50,7 @@ end
             isreal(x) || continue
 
             Δx, x̄ = randn(2)
-            Δz = Composite{Tuple{Float64, DoesNotExist}}(randn(), Zero())
+            Δz = Composite{Tuple{Float64, DoesNotExist}}(randn(), randn())
 
             frule_test(SpecialFunctions.logabsgamma, (x, Δx))
             rrule_test(SpecialFunctions.logabsgamma, Δz, (x, x̄))


### PR DESCRIPTION
This PR adds a GitHub Actions for CI. The goal is ultimately to replace Travis, though I recommend keeping both in parallel for a little while until we are sure we are happy with this.

cc @simeonschaub 