### PR TITLE
Gradient for matrix `muladd`

### DIFF
--- a/src/rulesets/Base/arraymath.jl
+++ b/src/rulesets/Base/arraymath.jl
@@ -73,6 +73,83 @@ function rrule(
 end
 
 
+#####
+##### `muladd`
+#####
+
+function rrule(
+        ::typeof(muladd),
+        A::AbstractMatrix{<:CommutativeMulNumber},
+        B::AbstractVecOrMat{<:CommutativeMulNumber},
+        z::Union{CommutativeMulNumber, AbstractVecOrMat{<:CommutativeMulNumber}},
+    )
+    # The useful case, mul! fused with +
+    function muladd_pullback_1(Ȳ)
+        matmul = (
+            InplaceableThunk(
+                @thunk(Ȳ * B'),
+                dA -> mul!(dA, Ȳ, B', true, true)
+            ),
+            InplaceableThunk(
+                @thunk(A' * Ȳ),
+                dB -> mul!(dB, A', Ȳ, true, true)
+            )
+        )
+        addon = if z isa Bool
+            Zero()
+        elseif z isa Number
+            @thunk(sum(Ȳ))
+        else
+            T = eltype(Ȳ)
+            InplaceableThunk(
+                @thunk(sum!(similar(z, T), Ȳ)),
+                dz -> sum!(dz, Ȳ; init=false)
+            )
+        end
+        (NO_FIELDS, matmul..., addon)
+    end
+    return muladd(A, B, z), muladd_pullback_1
+end
+
+function rrule(
+        ::typeof(muladd),
+        ut::LinearAlgebra.AdjOrTransAbsVec{<:CommutativeMulNumber},
+        v::AbstractVector{<:CommutativeMulNumber},
+        z::CommutativeMulNumber,
+    )
+    # This case is dot(u,v)+z, but would also match signature above.
+    muladd_pullback_2(dy) = (NO_FIELDS, @thunk(v' .* dy), @thunk(ut' .* dy), dy)
+    return muladd(ut, v, z), muladd_pullback_2
+end
+
+function rrule(
+        ::typeof(muladd),
+        u::AbstractVector{<:CommutativeMulNumber},
+        vt::LinearAlgebra.AdjOrTransAbsVec{<:CommutativeMulNumber},
+        z::Union{CommutativeMulNumber, AbstractVecOrMat{<:CommutativeMulNumber}},
+    )
+    # Outer product, just broadcasting
+    function muladd_pullback_3(Ȳ)
+        proj = (
+            @thunk(vec(sum(Ȳ .* conj.(vt), dims=2))),
+            @thunk(vec(sum(u .* conj.(Ȳ), dims=1))'),
+        )
+        addon = if z isa Bool
+            Zero()
+        elseif z isa Number
+            @thunk(sum(Ȳ))
+        else
+            T = eltype(Ȳ)
+            InplaceableThunk(
+                @thunk(sum!(similar(z, T), Ȳ)),
+                dz -> sum!(dz, Ȳ; init=false)
+            )
+        end
+        (NO_FIELDS, proj..., addon)
+    end
+    return muladd(u, vt, z), muladd_pullback_3
+end
+
 
 #####
 ##### `/`

--- a/src/rulesets/Base/arraymath.jl
+++ b/src/rulesets/Base/arraymath.jl
@@ -122,35 +122,6 @@ function rrule(
     return muladd(ut, v, z), muladd_pullback_2
 end
 
-function rrule(
-        ::typeof(muladd),
-        u::AbstractVector{<:CommutativeMulNumber},
-        vt::LinearAlgebra.AdjOrTransAbsVec{<:CommutativeMulNumber},
-        z::Union{CommutativeMulNumber, AbstractVecOrMat{<:CommutativeMulNumber}},
-    )
-    # Outer product, just broadcasting
-    function muladd_pullback_3(Ȳ)
-        proj = (
-            @thunk(vec(sum(Ȳ .* conj.(vt), dims=2))),
-            @thunk(vec(sum(u .* conj.(Ȳ), dims=1))'),
-        )
-        addon = if z isa Bool
-            Zero()
-        elseif z isa Number
-            @thunk(sum(Ȳ))
-        else
-            T = eltype(Ȳ)
-            InplaceableThunk(
-                @thunk(sum!(similar(z, T), Ȳ)),
-                dz -> sum!(dz, Ȳ; init=false)
-            )
-        end
-        (NO_FIELDS, proj..., addon)
-    end
-    return muladd(u, vt, z), muladd_pullback_3
-end
-
-
 #####
 ##### `/`
 #####

--- a/test/rulesets/Base/arraymath.jl
+++ b/test/rulesets/Base/arraymath.jl
@@ -49,6 +49,52 @@
     end
 
 
+    VERSION >= v"1.6.0-DEV.1536" && @testset "muladd: $T" for T in (Float64, ComplexF64)
+        @testset "add $(typeof(z))" for z in [rand(T), rand(T,3), rand(T,3,3)] #, false]
+            dz = rand(T, fill(3, ndims(z))...)
+            @testset "matrix * matrix" begin
+                A, B = rand(T,3,3), rand(T,3,3)
+                dA, dB = rand(T,3,3), rand(T,3,3)
+                rrule_test(muladd, A*B.+z, (A, dA), (B, dB), (z, dz))
+                rrule_test(muladd, A'*B.+z, (A', dA'), (B, dB), (z, dz))
+                rrule_test(muladd, A*B'.+z, (A, dA), (B', dB'), (z, dz))
+            end
+            if ndims(z) <= 1
+                @testset "matrix * vector" begin
+                    A, B = rand(T,3,3), rand(T,3)
+                    dA, dB = rand(T,3,3), rand(T,3)
+                    rrule_test(muladd, A*B.+z, (A, dA), (B, dB), (z, dz))
+                    dA, dB = rand(T,3,3), rand(T,3,1)
+                    rrule_test(muladd, A*B.+z, (A, dA), (B, dB), (z, dz))
+                end
+                @testset "adjoint * matrix" begin
+                    At, B, zt = rand(T,3)', rand(T,3,3), z'
+                    dAt, dB, dzt = rand(T,3)', rand(T,3,3), z'
+                    rrule_test(muladd, At*B.+zt, (At, dAt), (B, dB), (zt, dzt))
+                    dAt, dB, dzt = rand(T,1,3), rand(T,3,3), z'
+                    rrule_test(muladd, At*B.+zt, (At, dAt), (B, dB), (zt, dzt))
+                end
+            end
+            if ndims(z) == 0
+                @testset "adjoint * vector" begin # like dot
+                    A, B = rand(T,3)', rand(T,3)
+                    dA, dB = rand(T,3)', rand(T,3)
+                    rrule_test(muladd, A*B.+z, (A, dA), (B, dB), (z, dz))
+                    dA, dB = rand(T,1,3), rand(T,3)
+                    rrule_test(muladd, A*B.+z, (A, dA), (B, dB), (z, dz))
+                end
+            end
+            if ndims(z) == 2
+                @testset "vector * adjoint" begin # outer product
+                    A, B = rand(T,3), rand(T,3)'
+                    dA, dB = rand(T,3), rand(T,3)'
+                    rrule_test(muladd, A*B.+z, (A, dA), (B, dB), (z, dz))
+                    dA, dB = rand(T,3), rand(T,1,3)
+                    rrule_test(muladd, A*B.+z, (A, dA), (B, dB), (z, dz))
+                end
+            end
+        end
+    end
     @testset "$f" for f in (/, \)
         @testset "Matrix" begin
             for n in 3:5, m in 3:5

--- a/test/rulesets/Base/arraymath.jl
+++ b/test/rulesets/Base/arraymath.jl
@@ -84,15 +84,6 @@
                     rrule_test(muladd, A*B.+z, (A, dA), (B, dB), (z, dz))
                 end
             end
-            if ndims(z) == 2
-                @testset "vector * adjoint" begin # outer product
-                    A, B = rand(T,3), rand(T,3)'
-                    dA, dB = rand(T,3), rand(T,3)'
-                    rrule_test(muladd, A*B.+z, (A, dA), (B, dB), (z, dz))
-                    dA, dB = rand(T,3), rand(T,1,3)
-                    rrule_test(muladd, A*B.+z, (A, dA), (B, dB), (z, dz))
-                end
-            end
         end
     end
     @testset "$f" for f in (/, \)


### PR DESCRIPTION
This adds a backward gradient definition for things like `muladd(::Matrix, ::Matrix, ::Vector)`, which are now fused into one `mul!` call.

Tests will only run on latest Julia, although later they could use Compat.jl.