### PR TITLE
Some Adjoint and Transpose stuff

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "0.7.38"
+version = "0.7.39"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/rulesets/LinearAlgebra/structured.jl
+++ b/src/rulesets/LinearAlgebra/structured.jl
@@ -92,35 +92,31 @@ end
 
 # ✖️✖️✖️TODO: Deal with complex-valued arrays as well
 function rrule(::Type{<:Adjoint}, A::AbstractMatrix{<:Union{Real, Complex}})
-    function Adjoint_pullback(ȳ)
-        return (NO_FIELDS, adjoint(ȳ))
-    end
+    Adjoint_pullback(ȳ::Composite) = (NO_FIELDS, ȳ.parent)
+    Adjoint_pullback(ȳ::AbstractMatrix) = (NO_FIELDS, adjoint(ȳ))
     return Adjoint(A), Adjoint_pullback
 end
 
 function rrule(::Type{<:Adjoint}, A::AbstractVector{<:Union{Real, Complex}})
-    function Adjoint_pullback(ȳ)
-        return (NO_FIELDS, vec(adjoint(ȳ)))
-    end
+    Adjoint_pullback(ȳ::Composite) = (NO_FIELDS, vec(ȳ.parent))
+    Adjoint_pullback(ȳ::AbstractMatrix) = (NO_FIELDS, vec(adjoint(ȳ)))
     return Adjoint(A), Adjoint_pullback
 end
 
 function rrule(::typeof(adjoint), A::AbstractMatrix{<:Union{Real, Complex}})
-    function adjoint_pullback(ȳ)
-        return (NO_FIELDS, adjoint(ȳ))
-    end
+    adjoint_pullback(ȳ::Composite) = (NO_FIELDS, ȳ.parent)
+    adjoint_pullback(ȳ::AbstractMatrix) = (NO_FIELDS, adjoint(ȳ))
     return adjoint(A), adjoint_pullback
 end
 
 function rrule(::typeof(adjoint), A::AbstractVector{<:Union{Real, Complex}})
-    function adjoint_pullback(ȳ)
-        return (NO_FIELDS, vec(adjoint(ȳ)))
-    end
+    adjoint_pullback(ȳ::Composite) = (NO_FIELDS, vec(ȳ.parent))
+    adjoint_pullback(ȳ) = (NO_FIELDS, vec(adjoint(ȳ)))
     return adjoint(A), adjoint_pullback
 end
 
 function rrule(::typeof(parent), A::Adjoint)
-    parent_pullback(ȳ::AbstractMatrix) = (NO_FIELDS, Adjoint(ȳ))
+    parent_pullback(ȳ::AbstractMatrix) = (NO_FIELDS, Composite{typeof(A)}(parent=ȳ))
     return parent(A), parent_pullback
 end
 
@@ -129,30 +125,26 @@ end
 #####
 
 function rrule(::Type{<:Transpose}, A::AbstractMatrix{<:Union{Real, Complex}})
-    function Transpose_pullback(ȳ)
-        return (NO_FIELDS, transpose(ȳ))
-    end
+    Transpose_pullback(ȳ::Composite) = (NO_FIELDS, ȳ.parent)
+    Transpose_pullback(ȳ::AbstractMatrix) = (NO_FIELDS, Transpose(ȳ))
     return Transpose(A), Transpose_pullback
 end
 
 function rrule(::Type{<:Transpose}, A::AbstractVector{<:Union{Real, Complex}})
-    function Transpose_pullback(ȳ)
-        return (NO_FIELDS, vec(transpose(ȳ)))
-    end
+    Transpose_pullback(ȳ::Composite) = (NO_FIELDS, vec(ȳ.parent))
+    Transpose_pullback(ȳ::AbstractMatrix) = (NO_FIELDS, vec(Transpose(ȳ)))
     return Transpose(A), Transpose_pullback
 end
 
 function rrule(::typeof(transpose), A::AbstractMatrix{<:Union{Real, Complex}})
-    function transpose_pullback(ȳ)
-        return (NO_FIELDS, transpose(ȳ))
-    end
+    transpose_pullback(ȳ::Composite) = (NO_FIELDS, ȳ.parent)
+    transpose_pullback(ȳ::AbstractMatrix) = (NO_FIELDS, transpose(ȳ))
     return transpose(A), transpose_pullback
 end
 
 function rrule(::typeof(transpose), A::AbstractVector{<:Union{Real, Complex}})
-    function transpose_pullback(ȳ)
-        return (NO_FIELDS, vec(transpose(ȳ)))
-    end
+    transpose_pullback(ȳ::Composite) = (NO_FIELDS, vec(ȳ.parent))
+    transpose_pullback(ȳ::AbstractMatrix) = (NO_FIELDS, vec(transpose(ȳ)))
     return transpose(A), transpose_pullback
 end
 

--- a/src/rulesets/LinearAlgebra/structured.jl
+++ b/src/rulesets/LinearAlgebra/structured.jl
@@ -115,11 +115,6 @@ function rrule(::typeof(adjoint), A::AbstractVector{<:Union{Real, Complex}})
     return adjoint(A), adjoint_pullback
 end
 
-function rrule(::typeof(parent), A::Adjoint)
-    parent_pullback(ȳ::AbstractMatrix) = (NO_FIELDS, Composite{typeof(A)}(parent=ȳ))
-    return parent(A), parent_pullback
-end
-
 #####
 ##### `Transpose`
 #####
@@ -146,11 +141,6 @@ function rrule(::typeof(transpose), A::AbstractVector{<:Union{Real, Complex}})
     transpose_pullback(ȳ::Composite) = (NO_FIELDS, vec(ȳ.parent))
     transpose_pullback(ȳ::AbstractMatrix) = (NO_FIELDS, vec(transpose(ȳ)))
     return transpose(A), transpose_pullback
-end
-
-function rrule(::typeof(parent), A::Transpose)
-    parent_pullback(ȳ::AbstractMatrix) = (NO_FIELDS, Transpose(ȳ))
-    return parent(A), parent_pullback
 end
 
 #####

--- a/src/rulesets/LinearAlgebra/structured.jl
+++ b/src/rulesets/LinearAlgebra/structured.jl
@@ -90,25 +90,25 @@ end
 ##### `Adjoint`
 #####
 
-function rrule(::Type{<:Adjoint}, A::AbstractMatrix{<:Union{Real, Complex}})
+function rrule(::Type{<:Adjoint}, A::AbstractMatrix{<:Number})
     Adjoint_pullback(ȳ::Composite) = (NO_FIELDS, ȳ.parent)
     Adjoint_pullback(ȳ::AbstractVecOrMat) = (NO_FIELDS, adjoint(ȳ))
     return Adjoint(A), Adjoint_pullback
 end
 
-function rrule(::Type{<:Adjoint}, A::AbstractVector{<:Union{Real, Complex}})
+function rrule(::Type{<:Adjoint}, A::AbstractVector{<:Number})
     Adjoint_pullback(ȳ::Composite) = (NO_FIELDS, vec(ȳ.parent))
     Adjoint_pullback(ȳ::AbstractMatrix) = (NO_FIELDS, vec(adjoint(ȳ)))
     return Adjoint(A), Adjoint_pullback
 end
 
-function rrule(::typeof(adjoint), A::AbstractMatrix{<:Union{Real, Complex}})
+function rrule(::typeof(adjoint), A::AbstractMatrix{<:Number})
     adjoint_pullback(ȳ::Composite) = (NO_FIELDS, ȳ.parent)
     adjoint_pullback(ȳ::AbstractVecOrMat) = (NO_FIELDS, adjoint(ȳ))
     return adjoint(A), adjoint_pullback
 end
 
-function rrule(::typeof(adjoint), A::AbstractVector{<:Union{Real, Complex}})
+function rrule(::typeof(adjoint), A::AbstractVector{<:Number})
     adjoint_pullback(ȳ::Composite) = (NO_FIELDS, vec(ȳ.parent))
     adjoint_pullback(ȳ::AbstractMatrix) = (NO_FIELDS, vec(adjoint(ȳ)))
     return adjoint(A), adjoint_pullback
@@ -118,25 +118,25 @@ end
 ##### `Transpose`
 #####
 
-function rrule(::Type{<:Transpose}, A::AbstractMatrix{<:Union{Real, Complex}})
+function rrule(::Type{<:Transpose}, A::AbstractMatrix{<:Number})
     Transpose_pullback(ȳ::Composite) = (NO_FIELDS, ȳ.parent)
     Transpose_pullback(ȳ::AbstractVecOrMat) = (NO_FIELDS, Transpose(ȳ))
     return Transpose(A), Transpose_pullback
 end
 
-function rrule(::Type{<:Transpose}, A::AbstractVector{<:Union{Real, Complex}})
+function rrule(::Type{<:Transpose}, A::AbstractVector{<:Number})
     Transpose_pullback(ȳ::Composite) = (NO_FIELDS, vec(ȳ.parent))
     Transpose_pullback(ȳ::AbstractMatrix) = (NO_FIELDS, vec(Transpose(ȳ)))
     return Transpose(A), Transpose_pullback
 end
 
-function rrule(::typeof(transpose), A::AbstractMatrix{<:Union{Real, Complex}})
+function rrule(::typeof(transpose), A::AbstractMatrix{<:Number})
     transpose_pullback(ȳ::Composite) = (NO_FIELDS, ȳ.parent)
     transpose_pullback(ȳ::AbstractVecOrMat) = (NO_FIELDS, transpose(ȳ))
     return transpose(A), transpose_pullback
 end
 
-function rrule(::typeof(transpose), A::AbstractVector{<:Union{Real, Complex}})
+function rrule(::typeof(transpose), A::AbstractVector{<:Number})
     transpose_pullback(ȳ::Composite) = (NO_FIELDS, vec(ȳ.parent))
     transpose_pullback(ȳ::AbstractMatrix) = (NO_FIELDS, vec(transpose(ȳ)))
     return transpose(A), transpose_pullback

--- a/src/rulesets/LinearAlgebra/structured.jl
+++ b/src/rulesets/LinearAlgebra/structured.jl
@@ -91,64 +91,74 @@ end
 #####
 
 # ✖️✖️✖️TODO: Deal with complex-valued arrays as well
-function rrule(::Type{<:Adjoint}, A::AbstractMatrix{<:Real})
+function rrule(::Type{<:Adjoint}, A::AbstractMatrix{<:Union{Real, Complex}})
     function Adjoint_pullback(ȳ)
         return (NO_FIELDS, adjoint(ȳ))
     end
     return Adjoint(A), Adjoint_pullback
 end
 
-function rrule(::Type{<:Adjoint}, A::AbstractVector{<:Real})
+function rrule(::Type{<:Adjoint}, A::AbstractVector{<:Union{Real, Complex}})
     function Adjoint_pullback(ȳ)
         return (NO_FIELDS, vec(adjoint(ȳ)))
     end
     return Adjoint(A), Adjoint_pullback
 end
 
-function rrule(::typeof(adjoint), A::AbstractMatrix{<:Real})
+function rrule(::typeof(adjoint), A::AbstractMatrix{<:Union{Real, Complex}})
     function adjoint_pullback(ȳ)
         return (NO_FIELDS, adjoint(ȳ))
     end
     return adjoint(A), adjoint_pullback
 end
 
-function rrule(::typeof(adjoint), A::AbstractVector{<:Real})
+function rrule(::typeof(adjoint), A::AbstractVector{<:Union{Real, Complex}})
     function adjoint_pullback(ȳ)
         return (NO_FIELDS, vec(adjoint(ȳ)))
     end
     return adjoint(A), adjoint_pullback
+end
+
+function rrule(::typeof(parent), A::Adjoint)
+    parent_pullback(ȳ::AbstractMatrix) = (NO_FIELDS, Adjoint(ȳ))
+    return parent(A), parent_pullback
 end
 
 #####
 ##### `Transpose`
 #####
 
-function rrule(::Type{<:Transpose}, A::AbstractMatrix)
+function rrule(::Type{<:Transpose}, A::AbstractMatrix{<:Union{Real, Complex}})
     function Transpose_pullback(ȳ)
         return (NO_FIELDS, transpose(ȳ))
     end
     return Transpose(A), Transpose_pullback
 end
 
-function rrule(::Type{<:Transpose}, A::AbstractVector)
+function rrule(::Type{<:Transpose}, A::AbstractVector{<:Union{Real, Complex}})
     function Transpose_pullback(ȳ)
         return (NO_FIELDS, vec(transpose(ȳ)))
     end
     return Transpose(A), Transpose_pullback
 end
 
-function rrule(::typeof(transpose), A::AbstractMatrix)
+function rrule(::typeof(transpose), A::AbstractMatrix{<:Union{Real, Complex}})
     function transpose_pullback(ȳ)
         return (NO_FIELDS, transpose(ȳ))
     end
     return transpose(A), transpose_pullback
 end
 
-function rrule(::typeof(transpose), A::AbstractVector)
+function rrule(::typeof(transpose), A::AbstractVector{<:Union{Real, Complex}})
     function transpose_pullback(ȳ)
         return (NO_FIELDS, vec(transpose(ȳ)))
     end
     return transpose(A), transpose_pullback
+end
+
+function rrule(::typeof(parent), A::Transpose)
+    parent_pullback(ȳ::AbstractMatrix) = (NO_FIELDS, Transpose(ȳ))
+    return parent(A), parent_pullback
 end
 
 #####

--- a/src/rulesets/LinearAlgebra/structured.jl
+++ b/src/rulesets/LinearAlgebra/structured.jl
@@ -90,7 +90,6 @@ end
 ##### `Adjoint`
 #####
 
-# ✖️✖️✖️TODO: Deal with complex-valued arrays as well
 function rrule(::Type{<:Adjoint}, A::AbstractMatrix{<:Union{Real, Complex}})
     Adjoint_pullback(ȳ::Composite) = (NO_FIELDS, ȳ.parent)
     Adjoint_pullback(ȳ::AbstractMatrix) = (NO_FIELDS, adjoint(ȳ))

--- a/src/rulesets/LinearAlgebra/structured.jl
+++ b/src/rulesets/LinearAlgebra/structured.jl
@@ -92,7 +92,7 @@ end
 
 function rrule(::Type{<:Adjoint}, A::AbstractMatrix{<:Union{Real, Complex}})
     Adjoint_pullback(ȳ::Composite) = (NO_FIELDS, ȳ.parent)
-    Adjoint_pullback(ȳ::AbstractMatrix) = (NO_FIELDS, adjoint(ȳ))
+    Adjoint_pullback(ȳ::AbstractVecOrMat) = (NO_FIELDS, adjoint(ȳ))
     return Adjoint(A), Adjoint_pullback
 end
 
@@ -104,13 +104,13 @@ end
 
 function rrule(::typeof(adjoint), A::AbstractMatrix{<:Union{Real, Complex}})
     adjoint_pullback(ȳ::Composite) = (NO_FIELDS, ȳ.parent)
-    adjoint_pullback(ȳ::AbstractMatrix) = (NO_FIELDS, adjoint(ȳ))
+    adjoint_pullback(ȳ::AbstractVecOrMat) = (NO_FIELDS, adjoint(ȳ))
     return adjoint(A), adjoint_pullback
 end
 
 function rrule(::typeof(adjoint), A::AbstractVector{<:Union{Real, Complex}})
     adjoint_pullback(ȳ::Composite) = (NO_FIELDS, vec(ȳ.parent))
-    adjoint_pullback(ȳ) = (NO_FIELDS, vec(adjoint(ȳ)))
+    adjoint_pullback(ȳ::AbstractMatrix) = (NO_FIELDS, vec(adjoint(ȳ)))
     return adjoint(A), adjoint_pullback
 end
 
@@ -120,7 +120,7 @@ end
 
 function rrule(::Type{<:Transpose}, A::AbstractMatrix{<:Union{Real, Complex}})
     Transpose_pullback(ȳ::Composite) = (NO_FIELDS, ȳ.parent)
-    Transpose_pullback(ȳ::AbstractMatrix) = (NO_FIELDS, Transpose(ȳ))
+    Transpose_pullback(ȳ::AbstractVecOrMat) = (NO_FIELDS, Transpose(ȳ))
     return Transpose(A), Transpose_pullback
 end
 
@@ -132,7 +132,7 @@ end
 
 function rrule(::typeof(transpose), A::AbstractMatrix{<:Union{Real, Complex}})
     transpose_pullback(ȳ::Composite) = (NO_FIELDS, ȳ.parent)
-    transpose_pullback(ȳ::AbstractMatrix) = (NO_FIELDS, transpose(ȳ))
+    transpose_pullback(ȳ::AbstractVecOrMat) = (NO_FIELDS, transpose(ȳ))
     return transpose(A), transpose_pullback
 end
 

--- a/test/rulesets/LinearAlgebra/structured.jl
+++ b/test/rulesets/LinearAlgebra/structured.jl
@@ -104,11 +104,14 @@
             end
         end
     end
-    @testset "$f" for f in (Adjoint, adjoint, Transpose, transpose)
+    @testset "$f, $T" for
+        f in (Adjoint, adjoint, Transpose, transpose),
+        T in (Float64, ComplexF64)
+
         n = 5
         m = 3
-        rrule_test(f, randn(m, n), (randn(n, m), randn(n, m)))
-        rrule_test(f, randn(1, n), (randn(n), randn(n)))
+        rrule_test(f, randn(T, m, n), (randn(T, n, m), randn(T, n, m)))
+        rrule_test(f, randn(T, 1, n), (randn(T, n), randn(T, n)))
     end
     @testset "$T" for T in (UpperTriangular, LowerTriangular)
         n = 5

--- a/test/rulesets/LinearAlgebra/structured.jl
+++ b/test/rulesets/LinearAlgebra/structured.jl
@@ -144,6 +144,15 @@
 
             rrule_test(f, ȳ, (a, ā))
         end
+
+        @testset "$f(::Transpose{$T, Vector{$T})" begin
+            a = transpose(randn(T, n))
+            ā = transpose(randn(T, n))
+            y = f(a)
+            ȳ = randn(T, n)
+
+            rrule_test(f, ȳ, (a, ā))
+        end
     end
     @testset "$T" for T in (UpperTriangular, LowerTriangular)
         n = 5

--- a/test/rulesets/LinearAlgebra/structured.jl
+++ b/test/rulesets/LinearAlgebra/structured.jl
@@ -135,6 +135,15 @@
             _, pb = rrule(f, a)
             @test pb(ȳ_mat) == pb(ȳ_composite)
         end
+
+        @testset "$f(::Adjoint{$T, Vector{$T})" begin
+            a = randn(T, n)'
+            ā = randn(T, n)'
+            y = f(a)
+            ȳ = randn(T, n)
+
+            rrule_test(f, ȳ, (a, ā))
+        end
     end
     @testset "$T" for T in (UpperTriangular, LowerTriangular)
         n = 5

--- a/test/rulesets/LinearAlgebra/structured.jl
+++ b/test/rulesets/LinearAlgebra/structured.jl
@@ -110,8 +110,31 @@
 
         n = 5
         m = 3
-        rrule_test(f, randn(T, m, n), (randn(T, n, m), randn(T, n, m)))
-        rrule_test(f, randn(T, 1, n), (randn(T, n), randn(T, n)))
+        @testset "$f(::Matrix{$T})" begin
+            A = randn(T, n, m)
+            Ā = randn(T, n, m)
+            Y = f(A)
+            Ȳ_mat = randn(T, m, n)
+            Ȳ_composite = Composite{typeof(Y)}(parent=collect(f(Ȳ_mat)))
+
+            rrule_test(f, Ȳ_mat, (A, Ā))
+
+            _, pb = rrule(f, A)
+            @test pb(Ȳ_mat) == pb(Ȳ_composite)
+        end
+
+        @testset "$f(::Vector{$T})" begin
+            a = randn(T, n)
+            ā = randn(T, n)
+            y = f(a)
+            ȳ_mat = randn(T, 1, n)
+            ȳ_composite = Composite{typeof(y)}(parent=collect(f(ȳ_mat)))
+
+            rrule_test(f, ȳ_mat, (a, ā))
+
+            _, pb = rrule(f, a)
+            @test pb(ȳ_mat) == pb(ȳ_composite)
+        end
     end
     @testset "$T" for T in (UpperTriangular, LowerTriangular)
         n = 5


### PR DESCRIPTION
This PR pretty much brings us up to feature-parity with Zygote on the rules for `Adjoint` and `Transpose`.

TODO:
- [x] Enable the use of `Composite`s in the reverse-pass
- [x] Make the various transpose-like functions play nicely with  complex numbers.
- [ ] ~~Make `parent` return a `Composite`, rather than the transposition of `ȳ`, since `ȳ` might itself be e.g. a `Composite`.~~
- [ ] ~~Test `parent`.~~

edit: the second and third points weren't achievable in this PR because our testing infrastructure isn't up to scratch at the minute. Opened [this issue](https://github.com/JuliaDiff/ChainRulesTestUtils.jl/issues/80) regarding the problem.