### PR TITLE
Add rule for `prod`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "0.7.65"
+version = "0.7.66"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/rulesets/Base/mapreduce.jl
+++ b/src/rulesets/Base/mapreduce.jl
@@ -100,9 +100,9 @@ function ∇prod_dims!(dx, dims, x, dy, y)
     return dx
 end
 
-# To opt out of this mapslices thing, and accept NaN instead, you could define:
-# ∇prod_dims!(dx, dims, x::CuArray, dy, y) = dx .+= y ./ x .* dy
-# and similarly ∇prod!(dx, x::CuArray, dy, y)
+# To opt out of the mapslices path, and accept NaN instead, you could define for instance:
+# ∇prod_dims!(dx, dims, x::CuArray, dy, y) = dx .+= y ./ conj.(x) .* conj.(dy)
+#            ∇prod!(dx, x::CuArray, dy, y) = dx .+= y ./ conj.(x) .* conj.(dy)
 
 function ∇prod(x, dy::Number=1, y::Number=prod(x))
     T = promote_type(eltype(x), eltype(dy))
@@ -115,10 +115,10 @@ function ∇prod!(dx, x, dy::Number=1, y::Number=prod(x))
     numzero = iszero(y) ? count(iszero, x) : 0
     if numzero == 0  # This can happen while y==0, if there are several small xs
         dx .+= y ./ conj.(x) .* conj.(dy)
-    elseif numzero > 1
-        dx
-    else
+    elseif numzero == 1
         ∇prod_one_zero!(dx, x, dy)
+    else  # numzero > 1, then all first derivatives are zero
+        dx
     end
     return dx
 end

--- a/src/rulesets/Base/mapreduce.jl
+++ b/src/rulesets/Base/mapreduce.jl
@@ -106,7 +106,7 @@ end
 
 function ∇prod(x, dy::Number=1, y::Number=prod(x))
     T = promote_type(eltype(x), eltype(dy))
-    dx = similar(x, T) .= zero(T)
+    dx = fill!(similar(x, T), zero(T))
     ∇prod!(dx, x, y, dy)
     return dx
 end
@@ -128,7 +128,7 @@ function ∇prod_one_zero!(dx, x, dy::Number=1)  # Assumes exactly one x is zero
     p_rest = one(promote_type(eltype(x), typeof(dy)))
     for i in eachindex(x)
         xi = @inbounds x[i]
-        p_rest *= ifelse(iszero(xi), one(eltype(x)), conj(xi))
+        p_rest *= ifelse(iszero(xi), one(xi), conj(xi))
         i_zero = ifelse(iszero(xi), i, i_zero)
     end
     dx[i_zero] += p_rest * dy

--- a/src/rulesets/Base/mapreduce.jl
+++ b/src/rulesets/Base/mapreduce.jl
@@ -79,7 +79,7 @@ function rrule(::typeof(prod), x::AbstractArray{T}; dims=:) where {T<:Commutativ
                 dx -> dx .+= y ./ conj.(x) .* conj.(dy)
             )
         end
-        (NO_FIELDS, x_thunk)
+        return (NO_FIELDS, x_thunk)
     end
     return y, prod_pullback
 end
@@ -112,7 +112,7 @@ function ∇prod(x, dy::Number=1, y::Number=prod(x))
 end
 
 function ∇prod!(dx, x, dy::Number=1, y::Number=prod(x))
-    numzero = count(iszero, x)
+    numzero = iszero(y) ? count(iszero, x) : 0
     if numzero == 0  # This can happen while y==0, if there are several small xs
         dx .+= y ./ conj.(x) .* conj.(dy)
     elseif numzero > 1

--- a/src/rulesets/Base/mapreduce.jl
+++ b/src/rulesets/Base/mapreduce.jl
@@ -89,7 +89,7 @@ end
 
 function ∇prod_dims(dims, x, dy, y=prod(x; dims=dims))
     T = promote_type(eltype(x), eltype(dy))
-    dx = fill!(similar(x, T), zero(T))
+    dx = fill!(similar(x, T, size(x)), zero(T))
     ∇prod_dims!(dx, dims, x, dy, y)
     return dx
 end
@@ -109,7 +109,7 @@ end
 
 function ∇prod(x, dy::Number=1, y::Number=prod(x))
     T = promote_type(eltype(x), eltype(dy))
-    dx = fill!(similar(x, T), zero(T))
+    dx = fill!(similar(x, T, size(x)), zero(T))
     ∇prod!(dx, x, dy, y)
     return dx
 end
@@ -120,8 +120,8 @@ function ∇prod!(dx, x, dy::Number=1, y::Number=prod(x))
         dx .+= y ./ conj.(x) .* conj.(dy)
     elseif numzero == 1
         ∇prod_one_zero!(dx, x, dy)
-    else  # numzero > 1, then all first derivatives are zero
-        dx
+    else
+        # numzero > 1, then all first derivatives are zero
     end
     return dx
 end

--- a/src/rulesets/Base/mapreduce.jl
+++ b/src/rulesets/Base/mapreduce.jl
@@ -89,7 +89,7 @@ end
 
 function ∇prod_dims(dims, x, dy, y=prod(x; dims=dims))
     T = promote_type(eltype(x), eltype(dy))
-    dx = fill!(similar(x, T, size(x)), zero(T))
+    dx = fill!(similar(x, T, axes(x)), zero(T))
     ∇prod_dims!(dx, dims, x, dy, y)
     return dx
 end
@@ -109,7 +109,7 @@ end
 
 function ∇prod(x, dy::Number=1, y::Number=prod(x))
     T = promote_type(eltype(x), eltype(dy))
-    dx = fill!(similar(x, T, size(x)), zero(T))
+    dx = fill!(similar(x, T, axes(x)), zero(T)) # axes(x) makes MArray on StaticArrays, Array for structured matrices
     ∇prod!(dx, x, dy, y)
     return dx
 end

--- a/src/rulesets/Base/mapreduce.jl
+++ b/src/rulesets/Base/mapreduce.jl
@@ -70,7 +70,7 @@ function rrule(::typeof(prod), x::AbstractArray{T}; dims=:) where {T<:Commutativ
                 ∇prod(x, dy, y)
             elseif any(iszero, x)  # Then, and only then, will ./x lead to NaN
                 vald = dims isa Colon ? nothing : dims isa Integer ? Val(Int(dims)) : Val(Tuple(dims))
-                ∇prod_dims(vald, x, dy, y)
+                ∇prod_dims(vald, x, dy, y)  # val(Int(dims)) is about 2x faster than Val(Tuple(dims))
             else
                 conj.(y ./ x) .* dy
             end
@@ -106,10 +106,6 @@ function ∇prod_dims!(dx, ::Val{dims}, x, dy, y) where {dims}
     return dx
 end
 
-# To opt out of the mapslices path, and accept NaN instead, you could define for instance:
-# ∇prod_dims!(dx, dims, x::CuArray, dy, y) = dx .+= y ./ conj.(x) .* conj.(dy)
-#            ∇prod!(dx, x::CuArray, dy, y) = dx .+= y ./ conj.(x) .* conj.(dy)
-
 function ∇prod(x, dy::Number=1, y::Number=prod(x))
     T = promote_type(eltype(x), eltype(dy))
     dx = fill!(similar(x, T, axes(x)), zero(T)) # axes(x) makes MArray on StaticArrays, Array for structured matrices
@@ -140,32 +136,3 @@ function ∇prod_one_zero!(dx, x, dy::Number=1)  # Assumes exactly one x is zero
     dx[i_zero] += p_rest * dy
     return
 end
-
-#=
-
-julia> @btime gradient(x -> sum(prod(x, dims=1)), x)[1]  setup=(x=rand(10,100); x[1:21:end].=0)  # Zygote
-  1.292 μs (3 allocations: 8.83 KiB)
-10×100 Matrix{Float64}:
- NaN    1.64248e-6    0.0  2.85863e-5     0.0  …    0.0  0.00412328    0.0  0.000262674
-
-julia> @btime gradient(x -> sum(prod(x, dims=1)), x)[1]  setup=(x=rand(10,100); x[1:21:end].=0)  # this PR
-  56.000 μs (1706 allocations: 51.06 KiB)
-10×100 Matrix{Float64}:
- 1.499e-5  2.54822e-5  0.0         0.000129398  …  0.000634891  0.0         0.00343482
-
-julia> @btime gradient(x -> sum(prod(x, dims=1)), x)[1]  setup=(x=rand(10,100); x[1:21:end].=0)  # dims=1 hard coded
-  1.842 μs (5 allocations: 8.86 KiB)
-10×100 Matrix{Float64}:
- 0.00285835  0.000569394  0.0         0.000422376  …  0.000110362  0.0         0.000481694
-
-julia> @btime gradient(x -> sum(prod(x, dims=1)), x)[1]  setup=(x=rand(10,100); x[1:21:end].=0)  # with Val(Tuple(dims))
-  3.359 μs (40 allocations: 10.45 KiB)
-10×100 Matrix{Float64}:
- 3.15652e-6  6.80856e-5   0.0          7.42845e-5   …  4.69112e-6   0.0         0.000449198
-
-julia> @btime gradient(x -> sum(prod(x, dims=1)), x)[1]  setup=(x=rand(10,100); x[1:21:end].=0)  # with Val(Int(dims))
-  1.850 μs (5 allocations: 8.86 KiB)
-10×100 Matrix{Float64}:
- 1.12526e-6  0.000483517  0.0         5.28479e-6  …  0.000555819  0.0         0.00126222
-
-=#

--- a/src/rulesets/Base/mapreduce.jl
+++ b/src/rulesets/Base/mapreduce.jl
@@ -70,7 +70,7 @@ function rrule(::typeof(prod), x::AbstractArray{T}; dims=:) where {T<:Commutativ
             elseif any(iszero, x)  # Then, and only then, will ./x lead to NaN
                 ∇prod_dims(dims, x, dy, y)
             else
-                y ./ conj.(x) .* conj.(dy)
+                conj.(y ./ x) .* dy
             end
             ,
             # In-place versions -- same branching
@@ -79,7 +79,7 @@ function rrule(::typeof(prod), x::AbstractArray{T}; dims=:) where {T<:Commutativ
             elseif any(iszero, x) 
                 ∇prod_dims!(dx, dims, x, dy, y)
             else
-                dx .+= y ./ conj.(x) .* conj.(dy)
+                dx .+= conj.(y ./ x) .* dy
             end
             )
         return (NO_FIELDS, x_thunk)
@@ -117,7 +117,7 @@ end
 function ∇prod!(dx, x, dy::Number=1, y::Number=prod(x))
     numzero = iszero(y) ? count(iszero, x) : 0
     if numzero == 0  # This can happen while y==0, if there are several small xs
-        dx .+= y ./ conj.(x) .* conj.(dy)
+        dx .+= conj.(y ./ x) .* dy
     elseif numzero == 1
         ∇prod_one_zero!(dx, x, dy)
     else

--- a/test/rulesets/Base/mapreduce.jl
+++ b/test/rulesets/Base/mapreduce.jl
@@ -20,4 +20,41 @@
             end
         end
     end  # sum abs2
+
+    @testset "prod" begin
+        @testset "Array{$T}" for T in [Float64, ComplexF64]
+            @testset "size = $sz, dims = $dims" for (sz, dims) in [
+                ((12,), :), ((12,), 1),
+                ((3,4), 1), ((3,4), 2), ((3,4), :), ((3,4), [1,2]),
+                ((3,4,1), 1), ((3,2,2), 3), ((3,2,2), 2:3),
+                ]
+                x, xdot, xbar = randn(T, sz), randn(T, sz), randn(T, sz)
+                # frule_test(prod, (x, xdot); fkwargs=(dims=dims,))
+                rrule_test(prod, prod(x; dims=dims), (x, xbar); fkwargs=(dims=dims,))
+
+                x[1] = 0
+                rrule_test(prod, prod(x; dims=dims), (x, xbar); fkwargs=(dims=dims,))
+
+                x[5] = 0
+                rrule_test(prod, prod(x; dims=dims), (x, xbar); fkwargs=(dims=dims,))
+
+                x[3] = x[7] = 0  # two zeros along some slice, for any dims
+                rrule_test(prod, prod(x; dims=dims), (x, xbar); fkwargs=(dims=dims,))
+
+                if ndims(x) == 3
+                    xp = PermutedDimsArray(x, (3,2,1))  # not a StridedArray
+                    xpdot, xpbar = permutedims(xdot, (3,2,1)), permutedims(xbar, (3,2,1))
+                    # frule_test(prod, (xp, xpdot); fkwargs=dims)
+                    rrule_test(prod, prod(xp; dims=dims), (xp, xpbar); fkwargs=(dims=dims,))
+                end
+            end
+        end
+        @testset "Array{Float32}" begin
+            v = [1f-5, 1f-10, 1f-15, 1f-20]
+            @test prod(v) == 0
+            vbar = randn(Float32, 4)
+            @test unthunk(rrule(prod, v)[2](1f0)[2]) == zeros(4)
+            rrule_test(prod, 0f0, (v, vbar))
+        end
+    end # prod
 end

--- a/test/rulesets/Base/mapreduce.jl
+++ b/test/rulesets/Base/mapreduce.jl
@@ -24,31 +24,30 @@
     @testset "prod" begin
         @testset "Array{$T}" for T in [Float64] # [Float64, ComplexF64]
             @testset "size = $sz, dims = $dims" for (sz, dims) in [
-                # ((12,), :), ((12,), 1),
-                ((3,4), 1),
-                # ((3,4), 1), ((3,4), 2), ((3,4), :), ((3,4), [1,2]),
-                # ((3,4,1), 1), ((3,2,2), 3), ((3,2,2), 2:3),
+                ((12,), :), ((12,), 1),
+                ((3,4), 1), ((3,4), 2), ((3,4), :), ((3,4), [1,2]),
+                ((3,4,1), 1), ((3,2,2), 3), ((3,2,2), 2:3),
                 ]
                 x = randn(T, sz)
-                test_rrule(prod, x; fkwargs=(dims=dims,), check_inferred=false)
+                test_rrule(prod, x; fkwargs=(dims=dims,), check_inferred=true)
 
                 x[1] = 0
-                test_rrule(prod, x; fkwargs=(dims=dims,), check_inferred=false)
+                test_rrule(prod, x; fkwargs=(dims=dims,), check_inferred=true)
 
                 x[5] = 0
-                test_rrule(prod, x; fkwargs=(dims=dims,), check_inferred=false)
+                test_rrule(prod, x; fkwargs=(dims=dims,), check_inferred=true)
 
                 x[3] = x[7] = 0  # two zeros along some slice, for any dims
-                test_rrule(prod, x; fkwargs=(dims=dims,), check_inferred=false)
+                test_rrule(prod, x; fkwargs=(dims=dims,), check_inferred=true)
 
                 if ndims(x) == 3
                     xp = PermutedDimsArray(x, (3,2,1))  # not a StridedArray
                     xpdot, xpbar = permutedims(rand(T, sz), (3,2,1)), permutedims(rand(T, sz), (3,2,1))
-                    test_rrule(prod, xp ⊢ xpbar; fkwargs=(dims=dims,), check_inferred=false)
+                    test_rrule(prod, xp ⊢ xpbar; fkwargs=(dims=dims,), check_inferred=true)
                 end
             end
         end
-        @testset "Array{Float32}" begin
+        @testset "Array{Float32}, no zero entries" begin
             v = [1f-5, 1f-10, 1f-15, 1f-20]
             @test prod(v) == 0
             @test unthunk(rrule(prod, v)[2](1f0)[2]) == zeros(4)

--- a/test/rulesets/Base/mapreduce.jl
+++ b/test/rulesets/Base/mapreduce.jl
@@ -57,23 +57,16 @@
                 @test iszero(unthunk(rrule(prod, Diagonal(rand(T,3)), dims=1)[2](ones(1,3))[2]))
                 @test unthunk(rrule(prod, Diagonal(rand(T,1)))[2](1.0)[2]) == hcat(1) # 1x1 sparse matrix
                 @test unthunk(rrule(prod, Diagonal(ones(T,2)), dims=1)[2](ones(1,2))[2]) == [0 1; 1 0]
+
                 # Triangular -- almost equally stupud
                 @test iszero(unthunk(rrule(prod, UpperTriangular(rand(T,3,3)))[2](1.0)[2]))
                 @test unthunk(rrule(prod, UpperTriangular(ones(T,2,2)))[2](1.0)[2]) == [0 0; 1 0]
+
                 # Symmetric -- at least this doesn't have zeros, still an unlikely combination
                 xs = Symmetric(rand(T,4,4))
                 @test_skip test_rrule(prod, xs ⊢ rand(T,4,4))
                 @test_skip test_rrule(prod, xs ⊢ rand(T,4,4), fkwargs=(dims=2,))
-#=
-xs = Symmetric(100randn(3,3))
-Zygote.gradient(x -> sum(prod(x,dims=1)), xs)[1]
-ForwardDiff.gradient(x -> sum(prod(x,dims=1)), Matrix(xs))
-Zygote.gradient(x -> sum(prod(x,dims=1)), Matrix(xs))[1]
-# These all agree. This time test_rrule, besides an error, gives a complaint that aa ≈ bb fails, where:
-aa, bb = [19520.328243416912 -10637.452753538959 10525.400561900045; -2510.9032814879456 -3998.8778331597046 -9169.556884964955; 635.6849617151897 -2346.1691173613817 1445.40000910585], [19520.32824346742 -13148.35603493111 11161.0855235898; -13148.35603493111 -3998.877833179008 -11515.726002337731; 11161.0855235898 -11515.726002337731 1445.4000090979655]
-bb ≈ (aa .+ aa') .- Diagonal(aa)  # not quite a projection. Is that right?
-=#
-                @test unthunk(rrule(prod, Symmetric(rand(T,3,3)))[2](1.0)[2]) isa Matrix
+                @test unthunk(rrule(prod, Symmetric(ones(T,2,2)))[2](1.0)[2]) == [1 1; 1 1]
             end
         end
         @testset "Array{Float32}, no zero entries" begin

--- a/test/rulesets/Base/mapreduce.jl
+++ b/test/rulesets/Base/mapreduce.jl
@@ -54,7 +54,7 @@
             @test prod(v) == 0
             vbar = randn(Float32, 4)
             @test unthunk(rrule(prod, v)[2](1f0)[2]) == zeros(4)
-            rrule_test(prod, 0f0, (v, vbar))
+            rrule_test(prod, rand(Float32), (v, vbar))
         end
     end # prod
 end

--- a/test/rulesets/Base/mapreduce.jl
+++ b/test/rulesets/Base/mapreduce.jl
@@ -30,13 +30,10 @@
                 ]
                 x = randn(T, sz)
                 test_rrule(prod, x; fkwargs=(dims=dims,), check_inferred=true)
-
                 x[1] = 0
                 test_rrule(prod, x; fkwargs=(dims=dims,), check_inferred=true)
-
                 x[5] = 0
                 test_rrule(prod, x; fkwargs=(dims=dims,), check_inferred=true)
-
                 x[3] = x[7] = 0  # two zeros along some slice, for any dims
                 test_rrule(prod, x; fkwargs=(dims=dims,), check_inferred=true)
 
@@ -45,6 +42,41 @@
                     xpdot, xpbar = permutedims(rand(T, sz), (3,2,1)), permutedims(rand(T, sz), (3,2,1))
                     test_rrule(prod, xp ⊢ xpbar; fkwargs=(dims=dims,), check_inferred=true)
                 end
+            end
+            
+            @testset "structured" begin
+                # Adjoint -- like PermutedDimsArray this may actually be used
+                xa = adjoint(rand(T,4,4))
+                test_rrule(prod, xa ⊢ rand(T,4,4))
+                @test_skip test_rrule(prod, xa ⊢ rand(T,4,4), fkwargs=(dims=2,)) # seems broken?
+#=
+xa = rand(3,3)'
+Zygote.gradient(x -> sum(prod(x,dims=1)), xa)[1]
+ForwardDiff.gradient(x -> sum(prod(x,dims=1)), xa)
+Zygote.gradient(x -> sum(prod(x,dims=1)), Matrix(xa))[1]
+# These all agree, so the fault is in the testing, somehow. No doubt I'm holding it wrong.
+=#
+                @test unthunk(rrule(prod, adjoint(rand(T,3,3)))[2](1.0)[2]) isa Matrix
+                @test unthunk(rrule(prod, adjoint(rand(T,3,3)), dims=1)[2](ones(1,3))[2]) isa Matrix
+                # Diagonal -- a stupid thing to do, product of zeros! Shouldn't be an error though:
+                @test iszero(unthunk(rrule(prod, Diagonal(rand(T,3)))[2](1.0)[2]))
+                @test iszero(unthunk(rrule(prod, Diagonal(rand(T,3)), dims=1)[2](ones(1,3))[2]))
+                @test unthunk(rrule(prod, Diagonal(rand(T,1)))[2](1.0)[2]) == hcat(1) # 1x1 sparse matrix
+                @test unthunk(rrule(prod, Diagonal(ones(T,2)), dims=1)[2](ones(1,2))[2]) == [0 1; 1 0]
+                # Triangular -- almost equally stupud
+                @test iszero(unthunk(rrule(prod, UpperTriangular(rand(T,3,3)))[2](1.0)[2]))
+                @test unthunk(rrule(prod, UpperTriangular(ones(T,2,2)))[2](1.0)[2]) == [0 0; 1 0]
+                # Symmetric -- at least this doesn't have zeros, still an unlikely combination
+                xs = Symmetric(rand(T,4,4))
+                @test_skip test_rrule(prod, xs ⊢ rand(T,4,4))
+                @test_skip test_rrule(prod, xs ⊢ rand(T,4,4), fkwargs=(dims=2,))
+#=
+xs = Symmetric(rand(3,3))
+Zygote.gradient(x -> sum(prod(x,dims=1)), xs)[1]
+ForwardDiff.gradient(x -> sum(prod(x,dims=1)), Matrix(xs))
+Zygote.gradient(x -> sum(prod(x,dims=1)), Matrix(xs))[1]
+=#
+                @test unthunk(rrule(prod, Symmetric(rand(T,3,3)))[2](1.0)[2]) isa Matrix
             end
         end
         @testset "Array{Float32}, no zero entries" begin

--- a/test/rulesets/Base/mapreduce.jl
+++ b/test/rulesets/Base/mapreduce.jl
@@ -48,16 +48,10 @@
                 # Adjoint -- like PermutedDimsArray this may actually be used
                 xa = adjoint(rand(T,4,4))
                 test_rrule(prod, xa ⊢ rand(T,4,4))
-                @test_skip test_rrule(prod, xa ⊢ rand(T,4,4), fkwargs=(dims=2,)) # seems broken?
-#=
-xa = randn(3,3)'
-Zygote.gradient(x -> sum(prod(x,dims=1)), xa)[1]
-ForwardDiff.gradient(x -> sum(prod(x,dims=1)), xa)
-Zygote.gradient(x -> sum(prod(x,dims=1)), Matrix(xa))[1]
-# These all agree, so the fault is in the testing, somehow.
-=#
+                test_rrule(prod, xa ⊢ rand(T,4,4), fkwargs=(dims=2,))
                 @test unthunk(rrule(prod, adjoint(rand(T,3,3)))[2](1.0)[2]) isa Matrix
                 @test unthunk(rrule(prod, adjoint(rand(T,3,3)), dims=1)[2](ones(1,3))[2]) isa Matrix
+
                 # Diagonal -- a stupid thing to do, product of zeros! Shouldn't be an error though:
                 @test iszero(unthunk(rrule(prod, Diagonal(rand(T,3)))[2](1.0)[2]))
                 @test iszero(unthunk(rrule(prod, Diagonal(rand(T,3)), dims=1)[2](ones(1,3))[2]))

--- a/test/rulesets/Base/mapreduce.jl
+++ b/test/rulesets/Base/mapreduce.jl
@@ -22,7 +22,7 @@
     end  # sum abs2
 
     @testset "prod" begin
-        @testset "Array{$T}" for T in [Float64] # [Float64, ComplexF64]
+        @testset "Array{$T}" for T in [Float64, ComplexF64]
             @testset "size = $sz, dims = $dims" for (sz, dims) in [
                 ((12,), :), ((12,), 1),
                 ((3,4), 1), ((3,4), 2), ((3,4), :), ((3,4), [1,2]),

--- a/test/rulesets/Base/mapreduce.jl
+++ b/test/rulesets/Base/mapreduce.jl
@@ -29,23 +29,25 @@
                 ((3,4,1), 1), ((3,2,2), 3), ((3,2,2), 2:3),
                 ]
                 x, xdot, xbar = randn(T, sz), randn(T, sz), randn(T, sz)
+                ybar = randn(T, size(prod(x; dims=dims)))
                 # frule_test(prod, (x, xdot); fkwargs=(dims=dims,))
-                rrule_test(prod, prod(x; dims=dims), (x, xbar); fkwargs=(dims=dims,))
+                rrule_test(prod, ybar, (x, xbar); fkwargs=(dims=dims,))
 
                 x[1] = 0
-                rrule_test(prod, prod(x; dims=dims), (x, xbar); fkwargs=(dims=dims,))
+                rrule_test(prod, ybar, (x, xbar); fkwargs=(dims=dims,))
 
                 x[5] = 0
-                rrule_test(prod, prod(x; dims=dims), (x, xbar); fkwargs=(dims=dims,))
+                rrule_test(prod, ybar, (x, xbar); fkwargs=(dims=dims,))
 
                 x[3] = x[7] = 0  # two zeros along some slice, for any dims
-                rrule_test(prod, prod(x; dims=dims), (x, xbar); fkwargs=(dims=dims,))
+                rrule_test(prod, ybar, (x, xbar); fkwargs=(dims=dims,))
 
                 if ndims(x) == 3
                     xp = PermutedDimsArray(x, (3,2,1))  # not a StridedArray
                     xpdot, xpbar = permutedims(xdot, (3,2,1)), permutedims(xbar, (3,2,1))
+                    ybar = randn(T, size(prod(xp; dims=dims)))
                     # frule_test(prod, (xp, xpdot); fkwargs=dims)
-                    rrule_test(prod, prod(xp; dims=dims), (xp, xpbar); fkwargs=(dims=dims,))
+                    rrule_test(prod, ybar, (xp, xpbar); fkwargs=(dims=dims,))
                 end
             end
         end

--- a/test/rulesets/Base/mapreduce.jl
+++ b/test/rulesets/Base/mapreduce.jl
@@ -43,18 +43,18 @@
                     test_rrule(prod, xp ⊢ xpbar; fkwargs=(dims=dims,), check_inferred=true)
                 end
             end
-            
-            @testset "structured" begin
+
+            @testset "structured wrappers" begin
                 # Adjoint -- like PermutedDimsArray this may actually be used
                 xa = adjoint(rand(T,4,4))
                 test_rrule(prod, xa ⊢ rand(T,4,4))
                 @test_skip test_rrule(prod, xa ⊢ rand(T,4,4), fkwargs=(dims=2,)) # seems broken?
 #=
-xa = rand(3,3)'
+xa = randn(3,3)'
 Zygote.gradient(x -> sum(prod(x,dims=1)), xa)[1]
 ForwardDiff.gradient(x -> sum(prod(x,dims=1)), xa)
 Zygote.gradient(x -> sum(prod(x,dims=1)), Matrix(xa))[1]
-# These all agree, so the fault is in the testing, somehow. No doubt I'm holding it wrong.
+# These all agree, so the fault is in the testing, somehow.
 =#
                 @test unthunk(rrule(prod, adjoint(rand(T,3,3)))[2](1.0)[2]) isa Matrix
                 @test unthunk(rrule(prod, adjoint(rand(T,3,3)), dims=1)[2](ones(1,3))[2]) isa Matrix
@@ -71,10 +71,13 @@ Zygote.gradient(x -> sum(prod(x,dims=1)), Matrix(xa))[1]
                 @test_skip test_rrule(prod, xs ⊢ rand(T,4,4))
                 @test_skip test_rrule(prod, xs ⊢ rand(T,4,4), fkwargs=(dims=2,))
 #=
-xs = Symmetric(rand(3,3))
+xs = Symmetric(100randn(3,3))
 Zygote.gradient(x -> sum(prod(x,dims=1)), xs)[1]
 ForwardDiff.gradient(x -> sum(prod(x,dims=1)), Matrix(xs))
 Zygote.gradient(x -> sum(prod(x,dims=1)), Matrix(xs))[1]
+# These all agree. This time test_rrule, besides an error, gives a complaint that aa ≈ bb fails, where:
+aa, bb = [19520.328243416912 -10637.452753538959 10525.400561900045; -2510.9032814879456 -3998.8778331597046 -9169.556884964955; 635.6849617151897 -2346.1691173613817 1445.40000910585], [19520.32824346742 -13148.35603493111 11161.0855235898; -13148.35603493111 -3998.877833179008 -11515.726002337731; 11161.0855235898 -11515.726002337731 1445.4000090979655]
+bb ≈ (aa .+ aa') .- Diagonal(aa)  # not quite a projection. Is that right?
 =#
                 @test unthunk(rrule(prod, Symmetric(rand(T,3,3)))[2](1.0)[2]) isa Matrix
             end

--- a/test/rulesets/Base/mapreduce.jl
+++ b/test/rulesets/Base/mapreduce.jl
@@ -66,7 +66,7 @@
                 xs = Symmetric(rand(T,4,4))
                 @test_skip test_rrule(prod, xs ⊢ rand(T,4,4))
                 @test_skip test_rrule(prod, xs ⊢ rand(T,4,4), fkwargs=(dims=2,))
-                @test unthunk(rrule(prod, Symmetric(ones(T,2,2)))[2](1.0)[2]) == [1 1; 1 1]
+                @test unthunk(rrule(prod, Symmetric(T[1 2; -333 4]))[2](1.0)[2]) == [16 8; 8 4]
             end
         end
         @testset "Array{Float32}, no zero entries" begin

--- a/test/rulesets/Base/mapreduce.jl
+++ b/test/rulesets/Base/mapreduce.jl
@@ -22,41 +22,37 @@
     end  # sum abs2
 
     @testset "prod" begin
-        @testset "Array{$T}" for T in [Float64, ComplexF64]
+        @testset "Array{$T}" for T in [Float64] # [Float64, ComplexF64]
             @testset "size = $sz, dims = $dims" for (sz, dims) in [
-                ((12,), :), ((12,), 1),
-                ((3,4), 1), ((3,4), 2), ((3,4), :), ((3,4), [1,2]),
-                ((3,4,1), 1), ((3,2,2), 3), ((3,2,2), 2:3),
+                # ((12,), :), ((12,), 1),
+                ((3,4), 1),
+                # ((3,4), 1), ((3,4), 2), ((3,4), :), ((3,4), [1,2]),
+                # ((3,4,1), 1), ((3,2,2), 3), ((3,2,2), 2:3),
                 ]
-                x, xdot, xbar = randn(T, sz), randn(T, sz), randn(T, sz)
-                ybar = randn(T, size(prod(x; dims=dims)))
-                # frule_test(prod, (x, xdot); fkwargs=(dims=dims,))
-                rrule_test(prod, ybar, (x, xbar); fkwargs=(dims=dims,))
+                x = randn(T, sz)
+                test_rrule(prod, x; fkwargs=(dims=dims,), check_inferred=false)
 
                 x[1] = 0
-                rrule_test(prod, ybar, (x, xbar); fkwargs=(dims=dims,))
+                test_rrule(prod, x; fkwargs=(dims=dims,), check_inferred=false)
 
                 x[5] = 0
-                rrule_test(prod, ybar, (x, xbar); fkwargs=(dims=dims,))
+                test_rrule(prod, x; fkwargs=(dims=dims,), check_inferred=false)
 
                 x[3] = x[7] = 0  # two zeros along some slice, for any dims
-                rrule_test(prod, ybar, (x, xbar); fkwargs=(dims=dims,))
+                test_rrule(prod, x; fkwargs=(dims=dims,), check_inferred=false)
 
                 if ndims(x) == 3
                     xp = PermutedDimsArray(x, (3,2,1))  # not a StridedArray
-                    xpdot, xpbar = permutedims(xdot, (3,2,1)), permutedims(xbar, (3,2,1))
-                    ybar = randn(T, size(prod(xp; dims=dims)))
-                    # frule_test(prod, (xp, xpdot); fkwargs=dims)
-                    rrule_test(prod, ybar, (xp, xpbar); fkwargs=(dims=dims,))
+                    xpdot, xpbar = permutedims(rand(T, sz), (3,2,1)), permutedims(rand(T, sz), (3,2,1))
+                    test_rrule(prod, xp ⊢ xpbar; fkwargs=(dims=dims,), check_inferred=false)
                 end
             end
         end
         @testset "Array{Float32}" begin
             v = [1f-5, 1f-10, 1f-15, 1f-20]
             @test prod(v) == 0
-            vbar = randn(Float32, 4)
             @test unthunk(rrule(prod, v)[2](1f0)[2]) == zeros(4)
-            rrule_test(prod, rand(Float32), (v, vbar))
+            test_rrule(prod, v)
         end
     end # prod
 end


### PR DESCRIPTION
This adds a reverse-mode gradient for `prod(x; dims)`, which should correctly treat zero entries. 

It ends up a little more complicated than seems ideal. In particular this won't work on CuArrays (at least when there are zeros, I think it will give a scalar access warning, which might be better than `NaN`s; when there aren't, it should work). Is there a mechanism worked out for where a Cu version of `∇prod_dims!` should live, if someone were to write one?

It also probably won't work well for second derivatives. 