### PR TITLE
Change eigen and svd pullbacks to accept Composite{Any}

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "0.7.44"
+version = "0.7.45"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/rulesets/LinearAlgebra/factorization.jl
+++ b/src/rulesets/LinearAlgebra/factorization.jl
@@ -101,7 +101,7 @@ end
 
 function rrule(::typeof(eigen), A::StridedMatrix{T}; kwargs...) where {T<:Union{Real,Complex}}
     F = eigen(A; kwargs...)
-    function eigen_pullback(ΔF::Composite{<:Eigen})
+    function eigen_pullback(ΔF::Composite)
         λ, V = F.values, F.vectors
         Δλ, ΔV = ΔF.values, ΔF.vectors
         ΔV isa AbstractZero && Δλ isa AbstractZero && return (NO_FIELDS, Δλ + ΔV)

--- a/src/rulesets/LinearAlgebra/symmetric.jl
+++ b/src/rulesets/LinearAlgebra/symmetric.jl
@@ -115,7 +115,7 @@ function rrule(
     kwargs...,
 )
     F = eigen(A; kwargs...)
-    function eigen_pullback(ΔF::Composite{<:Eigen})
+    function eigen_pullback(ΔF::Composite)
         λ, U = F.values, F.vectors
         Δλ, ΔU = ΔF.values, ΔF.vectors
         ΔU = ΔU isa AbstractZero ? ΔU : copy(ΔU)
@@ -227,7 +227,7 @@ end
 # is supported by reverse-mode AD packages
 function rrule(::typeof(svd), A::LinearAlgebra.RealHermSymComplexHerm{<:BLAS.BlasReal,<:StridedMatrix})
     F = svd(A)
-    function svd_pullback(ΔF::Composite{<:SVD})
+    function svd_pullback(ΔF::Composite)
         U, V = F.U, F.V
         c = _svd_eigvals_sign!(similar(F.S), U, V)
         λ = F.S .* c


### PR DESCRIPTION
In https://github.com/FluxML/Zygote.jl/pull/875, I discovered that Zygote passes `Composite{Any}` types to our `rrule`s. #321 and #323 added rrules whose pullbacks were constrained to `Composite{<:Eigen}` and `Composite{<:SVD}`, which would cause Zygote to error. This PR changes those signatures to `::Composite`. It adds no new tests.