### PR TITLE
Drop ChainRulesTestUtils 0.5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 ChainRulesCore = "0.9.25"
-ChainRulesTestUtils = "0.5, 0.6.1"
+ChainRulesTestUtils = "0.6.1"
 Compat = "3"
 FiniteDifferences = "0.11, 0.12"
 Reexport = "0.2, 1"


### PR DESCRIPTION
We are using the `check_inferred` keyword argument.
Which will error on ChainRulesTestUtils v0.5 since it isn't defined

This was missed in #342 