### PR TITLE
Stop doing CI on Windows and Mac

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,17 +17,8 @@ jobs:
         version:
           - '1.0'
           - '1'
-        os:
-          - ubuntu-latest
-          - macOS-latest
-          - windows-latest
-        arch:
-          - x86
-          - x64
-        # 32-bit Julia binaries are not available on macOS
-        exclude:
-          - os: macOS-latest
-            arch: x86
+        os: [ubuntu-latest]
+        arch: [x86, x64]
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1


### PR DESCRIPTION
An alternative/suppliment to #346 
The reason to add Emoji is to help navigate the over a dozen different varieties of things being tested.
What if we just tested less things?
Plus we have a lot of tests from our reverse dependency tests etc.

This code should be entirely OS independent.
We have never had a failure that occurs only one OS.
because we don't touch anything like binaries or IO where things could be weird.
It's just wasting time and CPU cycles testing on these extra OSes.