### PR TITLE
Install VersionVigilante

### DIFF
--- a/.github/workflows/VersionVigilante_pull_request.yml
+++ b/.github/workflows/VersionVigilante_pull_request.yml
@@ -1,0 +1,31 @@
+name: VersionVigilante
+
+on: pull_request
+
+jobs:
+  VersionVigilante:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1.0.0
+      - uses: julia-actions/setup-julia@latest
+      - name: VersionVigilante.main
+        id: versionvigilante_main
+        run: |
+          julia -e 'using Pkg; Pkg.add("VersionVigilante")'
+          julia -e 'using VersionVigilante; VersionVigilante.main("https://github.com/${{ github.repository }}")'
+      - name: ✅ Un-Labeller (if success)
+        if: (steps.versionvigilante_main.outputs.compare_versions == 'success') && (success() || failure())
+        continue-on-error: true
+        uses: actions/github-script@0.3.0
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.issues.removeLabel({...context.issue, name: 'needs version bump'})
+      - name: ❌ Labeller (if failure)
+        if: (steps.versionvigilante_main.outputs.compare_versions == 'failure') && (success() || failure())
+        continue-on-error: true
+        uses: actions/github-script@0.3.0
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.issues.addLabels({...context.issue, labels: ['needs version bump']})

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "0.7.47"
+version = "0.7.48"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"


### PR DESCRIPTION
Installs [this](https://github.com/bcbi/VersionVigilante.jl) wonderful GHA that @oxinabox pointed me towards.

Downsides:
1. It insists on a version bump for _every_ PR, regardless which bit of the code the PR touches.

Upsides:
1. It should substantially reduce the chance of forgetting to bump the patch -- it's annoying when this happens.
2. Will make it clearer to new contributors that we expect the version number to change when they contribute, over and above what is already discussed in ColPrac.

On balance I think this is a win, hence the PR. If we achieve consensus around this, I'll open PRs to the other ChainRules-related packages.