### PR TITLE
Correctly test real matrix exponential

### DIFF
--- a/test/rulesets/LinearAlgebra/matfun.jl
+++ b/test/rulesets/LinearAlgebra/matfun.jl
@@ -5,7 +5,8 @@
         @testset "A::Matrix{$T}, opnorm(A,1)=$nrm" for T in (Float64, ComplexF64),
             nrm in (0.01, 0.1, 0.5, 1.5, 3.0, 6.0, 12.0)
 
-            A, ΔA = randn(ComplexF64, n, n), randn(ComplexF64, n, n)
+            A = randn(T, n, n)
+            ΔA = randn(T, n, n)
             A *= nrm / opnorm(A, 1)
             frule_test(LinearAlgebra.exp!, (A, ΔA))
         end
@@ -14,9 +15,9 @@
             ΔA = rand_tangent(A)
             frule_test(LinearAlgebra.exp!, (A, ΔA))
         end
-        @testset "hermitian A" begin
-            A = Matrix(Hermitian(randn(ComplexF64, n, n)))
-            ΔA = randn(ComplexF64, n, n)
+        @testset "hermitian A, T=$T" for T in (Float64, ComplexF64)
+            A = Matrix(Hermitian(randn(T, n, n)))
+            ΔA = randn(T, n, n)
             frule_test(LinearAlgebra.exp!, (A, Matrix(Hermitian(ΔA))))
             frule_test(LinearAlgebra.exp!, (A, ΔA))
         end
@@ -28,8 +29,9 @@
         @testset "A::Matrix{$T}, opnorm(A,1)=$nrm" for T in (Float64, ComplexF64),
             nrm in (0.01, 0.1, 0.5, 1.5, 3.0, 6.0, 12.0)
 
-            A, ΔA = randn(ComplexF64, n, n), randn(ComplexF64, n, n)
-            ΔY = randn(ComplexF64, n, n)
+            A = randn(T, n, n)
+            ΔA = randn(T, n, n)
+            ΔY = randn(T, n, n)
             A *= nrm / opnorm(A, 1)
             # rrule is not inferrable, but pullback should be
             rrule_test(exp, ΔY, (A, ΔA); check_inferred=false)
@@ -42,9 +44,10 @@
             ΔY = rand_tangent(exp(A))
             rrule_test(exp, ΔY, (A, ΔA); check_inferred=false)
         end
-        @testset "hermitian A" begin
-            A, ΔA = Matrix(Hermitian(randn(ComplexF64, n, n))), randn(ComplexF64, n, n)
-            ΔY = randn(ComplexF64, n, n)
+        @testset "hermitian A, T=$T" for T in (Float64, ComplexF64)
+            A = Matrix(Hermitian(randn(T, n, n)))
+            ΔA = randn(T, n, n)
+            ΔY = randn(T, n, n)
             rrule_test(exp, Matrix(Hermitian(ΔY)), (A, ΔA); check_inferred=false)
             rrule_test(exp, ΔY, (A, ΔA); check_inferred=false)
         end

--- a/test/rulesets/LinearAlgebra/matfun.jl
+++ b/test/rulesets/LinearAlgebra/matfun.jl
@@ -8,7 +8,8 @@
             A = randn(T, n, n)
             ΔA = randn(T, n, n)
             A *= nrm / opnorm(A, 1)
-            frule_test(LinearAlgebra.exp!, (A, ΔA))
+            tols = nrm == 0.1 ? (atol=1e-8, rtol=1e-8) : NamedTuple()
+            frule_test(LinearAlgebra.exp!, (A, ΔA); tols...)
         end
         @testset "imbalanced A" begin
             A = Float64[0 10 0 0; -1 0 0 0; 0 0 0 0; -2 0 0 0]
@@ -34,7 +35,8 @@
             ΔY = randn(T, n, n)
             A *= nrm / opnorm(A, 1)
             # rrule is not inferrable, but pullback should be
-            rrule_test(exp, ΔY, (A, ΔA); check_inferred=false)
+            tols = nrm == 0.1 ? (atol=1e-8, rtol=1e-8) : NamedTuple()
+            rrule_test(exp, ΔY, (A, ΔA); check_inferred=false, tols...)
             Y, back = rrule(exp, A)
             @inferred back(ΔY)
         end


### PR DESCRIPTION
The test suite for `exp` added in #331 accidentally only tested the real case. This PR fixes that. For some reason, the pushforwards and pullbacks are imprecise for `opnorm(A, 1) == 0.1` for real `A` for this seed. If I had to guess, it's because FiniteDifferences hits multiple branches in `exp`, and the branches have different precisions. I verified that we use the same coefficients for the Pade approximants that LinearAlgebra uses, and I verified that its coefficients are the exact same as those from the source code included with the corresponding paper. 🤷 