### PR TITLE
Rules for LU decomposition of StridedMatrixes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "0.7.49"
+version = "0.7.50"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/rulesets/LinearAlgebra/factorization.jl
+++ b/src/rulesets/LinearAlgebra/factorization.jl
@@ -182,8 +182,8 @@ function frule((_, ΔF), ::typeof(LinearAlgebra.inv!), F::LU{<:Any,<:StridedMatr
     L = UnitLowerTriangular(F.factors)
     U = UpperTriangular(F.factors)
     # compute ∂Y = -(U \ (L \ ∂L + ∂U / U) / L) * P while minimizing allocations
-    ∂Y = ldiv!(L, ΔF.L)
-    ∂Y .+= rdiv!(UpperTriangular(ΔF.U), U)
+    ∂Y = ldiv!(L, tril!(ΔF.L, -1))
+    ∂Y .+= rdiv!(triu!(ΔF.U), U)
     ldiv!(U, ∂Y)
     rdiv!(∂Y, L)
     rmul!(∂Y, -1)

--- a/src/rulesets/LinearAlgebra/factorization.jl
+++ b/src/rulesets/LinearAlgebra/factorization.jl
@@ -60,6 +60,7 @@ function frule(
             L1 = UnitLowerTriangular(L[1:q, :])
             L2 = L[(q + 1):end, :]
         end
+        # Here we manipulate ∂factors both directly and via views: ∂factors1 and  ∂factors2
         rdiv!(∂factors, U)
         ldiv!(L1, ∂factors1)
         ∂U = triu(∂factors1)

--- a/src/rulesets/LinearAlgebra/factorization.jl
+++ b/src/rulesets/LinearAlgebra/factorization.jl
@@ -37,14 +37,13 @@ function frule(
     elseif m < n  # wide A, system is [P*A1 P*A2] = [L*U1 L*U2]
         L = UnitLowerTriangular(F.L)
         U = F.U
+        ldiv!(L, ∂factors)
         @views begin
             ∂factors1 = ∂factors[:, 1:q]
             ∂factors2 = ∂factors[:, (q + 1):end]
             U1 = UpperTriangular(U[:, 1:q])
             U2 = U[:, (q + 1):end]
         end
-        # Here we manipulate ∂factors both directly and via views: ∂factors1 and  ∂factors2
-        ldiv!(L, ∂factors)
         rdiv!(∂factors1, U1)
         ∂L = tril(∂factors1, -1)
         mul!(∂factors2, ∂L, U2, -1, 1)
@@ -54,14 +53,13 @@ function frule(
     else  # tall A, system is [P1*A; P2*A] = [L1*U; L2*U]
         L = F.L
         U = UpperTriangular(F.U)
+        rdiv!(∂factors, U)
         @views begin
             ∂factors1 = ∂factors[1:q, :]
             ∂factors2 = ∂factors[(q + 1):end, :]
             L1 = UnitLowerTriangular(L[1:q, :])
             L2 = L[(q + 1):end, :]
         end
-        # Here we manipulate ∂factors both directly and via views: ∂factors1 and  ∂factors2
-        rdiv!(∂factors, U)
         ldiv!(L1, ∂factors1)
         ∂U = triu(∂factors1)
         mul!(∂factors2, L2, ∂U, -1, 1)

--- a/src/rulesets/LinearAlgebra/factorization.jl
+++ b/src/rulesets/LinearAlgebra/factorization.jl
@@ -80,7 +80,9 @@ function rrule(
     function lu_pullback(ΔF::Composite)
         ∂L = ΔF.L
         ∂U = ΔF.U
-        ∂L isa AbstractZero && ∂U isa AbstractZero && return (NO_FIELDS, ∂L + ∂U)
+        if ∂L isa AbstractZero && ∂U isa AbstractZero
+            return (NO_FIELDS, ∂L + ∂U, DoesNotExist())
+        end
         factors = F.factors
         if eltype(A) <: Real
             ∂L = real(∂L)
@@ -94,7 +96,11 @@ function rrule(
             L = UnitLowerTriangular(factors)
             U = UpperTriangular(factors)
             ∂L isa AbstractZero ? fill!(∂A, 0) : mul!(∂A, L', ∂L)
-            ∂L isa AbstractZero || copyto!(UpperTriangular(∂A), UpperTriangular(∂U * U'))
+            if ∂U isa AbstractZero
+                fill!(UpperTriangular(∂A), 0)
+            else
+                copyto!(UpperTriangular(∂A), UpperTriangular(∂U * U'))
+            end
             rdiv!(∂A, U')
             ldiv!(L', ∂A)
         elseif m < n  # wide A, system is [P*A1 P*A2] = [L*U1 L*U2]

--- a/src/rulesets/LinearAlgebra/factorization.jl
+++ b/src/rulesets/LinearAlgebra/factorization.jl
@@ -88,14 +88,13 @@ function rrule(
             L = UnitLowerTriangular(factors)
             U = UpperTriangular(factors)
             ∂U = UpperTriangular(∂factors)
-            ∂A = similar(∂factors)
             tril!(copyto!(∂A, ∂factors), -1)
             lmul!(L', ∂A)
             copyto!(UpperTriangular(∂A), UpperTriangular(∂U * U'))
             rdiv!(∂A, U')
             ldiv!(L', ∂A)
         elseif m < n  # wide A, system is [P*A1 P*A2] = [L*U1 L*U2]
-            ∂A = triu(∂factors)
+            triu!(copyto!(∂A, ∂factors))
             @views begin
                 factors1 = factors[:, 1:q]
                 U2 = factors[:, (q + 1):end]
@@ -110,7 +109,7 @@ function rrule(
             rdiv!(∂A1, U1')
             ldiv!(L', ∂A)
         else  # tall A, system is [P1*A; P2*A] = [L1*U; L2*U]
-            ∂A = tril(∂factors, -1)
+            tril!(copyto!(∂A, ∂factors), -1)
             @views begin
                 factors1 = factors[1:q, :]
                 L2 = factors[(q + 1):end, :]

--- a/src/rulesets/LinearAlgebra/factorization.jl
+++ b/src/rulesets/LinearAlgebra/factorization.jl
@@ -145,12 +145,14 @@ function rrule(::typeof(getproperty), F::TF, x::Symbol) where {T,TF<:LU{T,<:Stri
     function getproperty_LU_pullback(ΔY)
         ∂factors = if x === :L
             m, n = size(F.factors)
-            m ≥ n ? tril(ΔY, -1) : tril!([ΔY zeros(m, n - m)], -1)
+            T = eltype(ΔY)
+            tril!([ΔY zeros(T, m, max(0, n - m))], -1)
         elseif x === :U
             m, n = size(F.factors)
-            m ≤ n ? triu(ΔY) : triu!([ΔY; zeros(m - n, n)])
+            T = eltype(ΔY)
+            triu!([ΔY; zeros(T, max(0, m - n), n)])
         elseif x === :factors
-            ΔY
+            Matrix(ΔY)
         else
             return (NO_FIELDS, DoesNotExist(), DoesNotExist())
         end

--- a/src/rulesets/LinearAlgebra/factorization.jl
+++ b/src/rulesets/LinearAlgebra/factorization.jl
@@ -145,12 +145,12 @@ function rrule(::typeof(getproperty), F::TF, x::Symbol) where {T,TF<:LU{T,<:Stri
     function getproperty_LU_pullback(ΔY)
         ∂factors = if x === :L
             m, n = size(F.factors)
-            T = eltype(ΔY)
-            tril!([ΔY zeros(T, m, max(0, n - m))], -1)
+            S = eltype(ΔY)
+            tril!([ΔY zeros(S, m, max(0, n - m))], -1)
         elseif x === :U
             m, n = size(F.factors)
-            T = eltype(ΔY)
-            triu!([ΔY; zeros(T, max(0, m - n), n)])
+            S = eltype(ΔY)
+            triu!([ΔY; zeros(S, max(0, m - n), n)])
         elseif x === :factors
             Matrix(ΔY)
         else

--- a/src/rulesets/LinearAlgebra/factorization.jl
+++ b/src/rulesets/LinearAlgebra/factorization.jl
@@ -79,15 +79,15 @@ function rrule(
 )
     F = lu(A, pivot; kwargs...)
     function lu_pullback(ΔF::Composite)
-        ∂L = ΔF.L
-        ∂U = ΔF.U
-        if ∂L isa AbstractZero && ∂U isa AbstractZero
-            return (NO_FIELDS, ∂L + ∂U, DoesNotExist())
+        ΔL = ΔF.L
+        ΔU = ΔF.U
+        if ΔL isa AbstractZero && ΔU isa AbstractZero
+            return (NO_FIELDS, ΔL + ΔU, DoesNotExist())
         end
         factors = F.factors
         if eltype(A) <: Real
-            ∂L = real(∂L)
-            ∂U = real(∂U)
+            ∂L = real(ΔL)
+            ∂U = real(ΔU)
         end
         ∂A = similar(factors)
         m, n = size(A)

--- a/src/rulesets/LinearAlgebra/factorization.jl
+++ b/src/rulesets/LinearAlgebra/factorization.jl
@@ -12,6 +12,9 @@ using LinearAlgebra.BLAS: gemv, gemv!, gemm!, trsm!, axpy!, ger!
 # Differentiation of matrix functionals using triangular factorization.
 # Mathematics of Computation, 80 (275). p. 1585.
 # doi: http://doi.org/10.1090/S0025-5718-2011-02451-8
+# for derivations for wide and tall matrices, see
+# https://sethaxen.com/blog/2021/02/differentiating-the-lu-decomposition/
+
 function frule(
     (_, ΔA), ::typeof(lu!), A::StridedMatrix, pivot::Union{Val{false},Val{true}}; kwargs...
 )

--- a/src/rulesets/LinearAlgebra/factorization.jl
+++ b/src/rulesets/LinearAlgebra/factorization.jl
@@ -39,10 +39,11 @@ function frule(
         U = F.U
         @views begin
             ∂factors1 = ∂factors[:, 1:q]
-            ∂factors2 = ∂factors[:, (q + 1):n]
+            ∂factors2 = ∂factors[:, (q + 1):end]
             U1 = UpperTriangular(U[:, 1:q])
-            U2 = U[:, (q + 1):n]
+            U2 = U[:, (q + 1):end]
         end
+        # Here we manipulate ∂factors both directly and via views: ∂factors1 and  ∂factors2
         ldiv!(L, ∂factors)
         rdiv!(∂factors1, U1)
         ∂L = tril(∂factors1, -1)
@@ -56,9 +57,9 @@ function frule(
         U = UpperTriangular(F.U)
         @views begin
             ∂factors1 = ∂factors[1:q, :]
-            ∂factors2 = ∂factors[(q + 1):m, :]
+            ∂factors2 = ∂factors[(q + 1):end, :]
             L1 = UnitLowerTriangular(L[1:q, :])
-            L2 = L[(q + 1):m, :]
+            L2 = L[(q + 1):end, :]
         end
         rdiv!(∂factors, U)
         ldiv!(L1, ∂factors1)
@@ -106,9 +107,9 @@ function rrule(
         elseif m < n  # wide A, system is [P*A1 P*A2] = [L*U1 L*U2]
             @views begin
                 factors1 = factors[:, 1:q]
-                U2 = factors[:, (q + 1):n]
+                U2 = factors[:, (q + 1):end]
                 ∂A1 = ∂A[:, 1:q]
-                ∂A2 = ∂A[:, (q + 1):n]
+                ∂A2 = ∂A[:, (q + 1):end]
             end
             L = UnitLowerTriangular(factors1)
             U1 = UpperTriangular(factors1)
@@ -125,9 +126,9 @@ function rrule(
         else  # tall A, system is [P1*A; P2*A] = [L1*U; L2*U]
             @views begin
                 factors1 = factors[1:q, :]
-                L2 = factors[(q + 1):m, :]
+                L2 = factors[(q + 1):end, :]
                 ∂A1 = ∂A[1:q, :]
-                ∂A2 = ∂A[(q + 1):m, :]
+                ∂A2 = ∂A[(q + 1):end, :]
             end
             U = UpperTriangular(factors1)
             L1 = UnitLowerTriangular(factors1)
@@ -167,8 +168,8 @@ function rrule(::typeof(getproperty), F::TF, x::Symbol) where {T,TF<:LU{T,<:Stri
         elseif x === :factors
             m, n = size(F.factors)
             q = min(m, n)
-            ∂L = tril(n == q ? ΔY : view(ΔY, :, 1:q), -1)
-            ∂U = triu(m == q ? ΔY : view(ΔY, 1:q, :))
+            ∂L = tril(n === q ? ΔY : view(ΔY, :, 1:q), -1)
+            ∂U = triu(m === q ? ΔY : view(ΔY, 1:q, :))
             C(; L=∂L, U=∂U)
         else
             DoesNotExist()

--- a/src/rulesets/LinearAlgebra/factorization.jl
+++ b/src/rulesets/LinearAlgebra/factorization.jl
@@ -92,7 +92,7 @@ function rrule(
             ∂U = UpperTriangular(∂factors)
             ∂A = similar(∂factors)
             tril!(copyto!(∂A, ∂factors), -1)
-            ∂A = lmul!(L', ∂A)
+            lmul!(L', ∂A)
             copyto!(UpperTriangular(∂A), UpperTriangular(∂U * U'))
             rdiv!(∂A, U')
             ldiv!(L', ∂A)

--- a/src/rulesets/LinearAlgebra/factorization.jl
+++ b/src/rulesets/LinearAlgebra/factorization.jl
@@ -24,8 +24,8 @@ function frule(
         # ∂L = L * tril(L \ (P * ΔA) / U, -1)
         # ∂U = triu(L \ (P * ΔA) / U) * U
         # ∂factors = ∂L + ∂U
-        L = UnitLowerTriangular(F.L)
-        U = UpperTriangular(F.U)
+        L = UnitLowerTriangular(F.factors)
+        U = UpperTriangular(F.factors)
         rdiv!(∂factors, U)
         ldiv!(L, ∂factors)
         ∂L = tril(∂factors, -1)

--- a/test/rulesets/LinearAlgebra/factorization.jl
+++ b/test/rulesets/LinearAlgebra/factorization.jl
@@ -1,3 +1,12 @@
+# TODO: move this to FiniteDifferences
+function FiniteDifferences.to_vec(X::LU)
+    x_vec, back = to_vec(Matrix(X.factors))
+    function LU_from_vec(x_vec)
+        return LU(back(x_vec), X.ipiv, X.info)
+    end
+    return x_vec, LU_from_vec
+end
+
 function FiniteDifferences.to_vec(C::Cholesky)
     C_vec, factors_from_vec = to_vec(C.factors)
     function cholesky_from_vec(v)
@@ -13,9 +22,6 @@ end
 
 @testset "Factorizations" begin
     @testset "lu decomposition" begin
-        # avoid implementing to_vec(::LU)
-        asnt(F::LU) = (U=F.U, L=F.L, factors=F.factors)
-        asnt2(F::LU) = (U=F.U, L=F.L)
         n = 10
         @testset "lu! frule" begin
             @testset "lu!(A::Matrix{$T}, $pivot) for size(A)=($m, $n)" for

--- a/test/rulesets/LinearAlgebra/factorization.jl
+++ b/test/rulesets/LinearAlgebra/factorization.jl
@@ -75,6 +75,14 @@ end
                     @test ∂A_ad ≈ ∂A_fd
                 end
             end
+            @testset "check=false passed to primal function" begin
+                Asingular = zeros(n, n)
+                F = lu(Asingular, Val(true); check=false)
+                ΔF = Composite{typeof(F)}(; U=rand_tangent(F.U), L=rand_tangent(F.L))
+                @test_throws SingularException rrule(lu, Asingular, Val(true))
+                _, back = rrule(lu, Asingular, Val(true); check=false)
+                back(ΔF)
+            end
         end
     end
     @testset "svd" begin

--- a/test/rulesets/LinearAlgebra/factorization.jl
+++ b/test/rulesets/LinearAlgebra/factorization.jl
@@ -32,7 +32,7 @@ end
                 )
                 @test F_ad == F
                 @test ∂F_ad isa Composite{typeof(F)}
-                @test ∂F_ad.L ≈ ∂F_fd.L
+                check_equal(∂F_ad.L, ∂F_fd.L)
                 @test ∂F_ad.U ≈ ∂F_fd.U
                 @test ∂F_ad.factors ≈ ∂F_fd.factors
             end

--- a/test/rulesets/LinearAlgebra/factorization.jl
+++ b/test/rulesets/LinearAlgebra/factorization.jl
@@ -30,11 +30,11 @@ end
                 F_ad, ∂F_ad = @inferred frule(
                     (Zero(), copy(ΔA), DoesNotExist()), lu!, copy(A), pivot
                 )
-                @test F_ad == F
+                check_equal(F_ad, F)
                 @test ∂F_ad isa Composite{typeof(F)}
                 check_equal(∂F_ad.L, ∂F_fd.L)
-                @test ∂F_ad.U ≈ ∂F_fd.U
-                @test ∂F_ad.factors ≈ ∂F_fd.factors
+                check_equal(∂F_ad.U, ∂F_fd.U)
+                check_equal(∂F_ad.factors, ∂F_fd.factors)
             end
             @testset "check=false passed to primal function" begin
                 Asingular = zeros(n, n)
@@ -68,11 +68,11 @@ end
                     end
                     ∂A_fd = only(j′vp(_fdm, A -> asnt2(lu(A, pivot)), ΔF_fd, A))
                     F_ad, back = @inferred rrule(lu, A, pivot)
-                    @test F_ad == F
+                    check_equal(F_ad, F)
                     ∂self, ∂A_ad, ∂pivot_ad = @inferred back(ΔF_ad)
-                    @test ∂self === NO_FIELDS
-                    @test ∂pivot_ad === DoesNotExist()
-                    @test ∂A_ad ≈ ∂A_fd
+                    check_equal(∂self, NO_FIELDS)
+                    check_equal(∂pivot_ad, DoesNotExist())
+                    check_equal(∂A_ad, ∂A_fd)
                 end
             end
             @testset "check=false passed to primal function" begin
@@ -97,14 +97,14 @@ end
                     ΔX = rand_tangent(X)
                     # don't test inferrability, because primal is not inferrable
                     X_ad, back = rrule(getproperty, F, k)
-                    @test X_ad == X
+                    check_equal(X_ad, X)
                     ∂self, ∂F_ad, ∂k = back(ΔX)
-                    @test ∂self === NO_FIELDS
-                    @test ∂k === DoesNotExist()
+                    check_equal(∂self, NO_FIELDS)
+                    check_equal(∂k, DoesNotExist())
                     @test ∂F_ad isa Composite{typeof(F)}
                     ∂A_fd = only(j′vp(_fdm, A -> getproperty(lu(A), k), ΔX, A))
                     ∂A_ad = rrule(lu, A, Val(true))[2](∂F_ad)[2]
-                    @test ∂A_ad ≈ ∂A_fd
+                    check_equal(∂A_ad, ∂A_fd)
                 end
             end
             @testset "matrix inverse using LU" begin
@@ -116,8 +116,8 @@ end
                         Y = inv(F)
                         ∂Y_fd = jvp(_fdm, inv, (A, ΔA))
                         Y_ad, ∂Y_ad = @inferred frule((Zero(), ΔF), LinearAlgebra.inv!, F)
-                        @test Y_ad == Y
-                        @test ∂Y_ad ≈ ∂Y_fd
+                        check_equal(Y_ad, Y)
+                        check_equal(∂Y_ad, ∂Y_fd)
                     end
                 end
                 @testset "inv(::LU) rrule" begin
@@ -127,13 +127,13 @@ end
                         Y = inv(F)
                         ΔY = rand_tangent(Y)
                         Y_ad, back = @inferred rrule(inv, F)
-                        @test Y_ad == Y
+                        check_equal(Y_ad, Y)
                         ∂self, ∂F_fd = @inferred back(ΔY)
-                        @test ∂self === NO_FIELDS
+                        check_equal(∂self, NO_FIELDS)
                         @test ∂F_fd isa Composite{typeof(F)}
                         ∂A_fd = only(j′vp(_fdm, inv, ΔY, A))
                         ∂A_ad = rrule(lu, A, Val(true))[2](∂F_fd)[2]
-                        @test ∂A_ad ≈ ∂A_fd
+                        check_equal(∂A_ad, ∂A_fd)
                     end
                 end
             end


### PR DESCRIPTION
This PR adds rules for the LU decomposition of `StridedMatrix`es, as well as its use for computing the matrix inverse.
- [x] `frule` for `lu!(::StridedMatrix)`
- [x] `rrule` for `lu(::StridedMatrix)`
- [x] `rrule` for `getproperty(::LU, k)`
- [x] `frule` for `inv!(::LU)`
- [x] `rrule` for `inv(::LU)`

All rules are restricted to `StridedMatrix` inputs because these rules do not make efficient use of storage for inputs of type `SparseMatrixCSC` or `Tridiagonal`, each of which has their own specialized `lu` method.

EDIT: for a derivation of the rules, see https://sethaxen.com/blog/2021/02/differentiating-the-lu-decomposition/