### PR TITLE
small printing fix when running test suite

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,7 +17,7 @@ using Test
 Random.seed!(1) # Set seed that all testsets should reset to.
 
 function include_test(path)
-    print("Testing $path:\t")  # print so TravisCI doesn't timeout due to no output
+    println("Testing $path:")  # print so TravisCI doesn't timeout due to no output
     @time include(path)  # show basic timing, (this will print a newline at end)
 end
 


### PR DESCRIPTION
Otherwise, deprecation warnings or stacktraces when running the test suite will show up a bit weird.