### PR TITLE
stop redefining rules for `redirect_stdio` on 1.6

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "0.7.50"
+version = "0.7.51"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/rulesets/Base/nondiff.jl
+++ b/src/rulesets/Base/nondiff.jl
@@ -311,9 +311,21 @@ VERSION >= v"1.4" && @non_differentiable only(::Char)
 @non_differentiable readuntil(::IO, ::AbstractChar)
 @non_differentiable readuntil(::IO, ::AbstractString)
 @non_differentiable realpath(::AbstractString)
-@non_differentiable redirect_stderr(::Union{IOStream, Base.LibuvStream})
-@non_differentiable redirect_stdin(::Union{IOStream, Base.LibuvStream})
-@non_differentiable redirect_stdout(::Union{IOStream, Base.LibuvStream})
+if isdefined(Base, :redirect_stdio)
+    @non_differentiable (::Base.redirect_stdio)(
+        ::Union{IOStream, Base.LibuvStream, Base.DevNull, Base.AbstractPipe},
+    )
+else
+    @non_differentiable redirect_stderr(
+        ::Union{IOStream, Base.LibuvStream, Base.DevNull, IOContext},
+    )
+    @non_differentiable redirect_stdin(
+        ::Union{IOStream, Base.LibuvStream, Base.DevNull, IOContext},
+    )
+    @non_differentiable redirect_stdout(
+        ::Union{IOStream, Base.LibuvStream, Base.DevNull, IOContext},
+    )
+end
 @non_differentiable relpath(::AbstractString, ::AbstractString)
 @non_differentiable relpath(::String)
 @non_differentiable repr(::Any)


### PR DESCRIPTION
Ref https://github.com/JuliaLang/julia/pull/39132. I have also widened the signature here, since those correspond to the ones in Base. Not sure how to test this, I don't think there's a nice way to test the absence of method redefinition warnings when loading a module. Still requires https://github.com/JuliaDiff/ChainRulesCore.jl/pull/298.