### PR TITLE
SpecialFunctions.jl autotangent

### DIFF
--- a/test/rulesets/packages/SpecialFunctions.jl
+++ b/test/rulesets/packages/SpecialFunctions.jl
@@ -46,12 +46,8 @@ end
 
         if isdefined(SpecialFunctions, :logabsgamma)
             isreal(x) || continue
-
-            Δx, x̄ = randn(2)
-            Δz = Composite{Tuple{Float64, DoesNotExist}}(randn(), randn())
-
-            frule_test(SpecialFunctions.logabsgamma, (x, Δx))
-            rrule_test(SpecialFunctions.logabsgamma, Δz, (x, x̄))
+            test_frule(logabsgamma, x)
+            test_rrule(logabsgamma, x; output_tangent=(randn(), randn()))
         end
     end
 end


### PR DESCRIPTION
part of https://github.com/JuliaDiff/ChainRules.jl/issues/360

Testign this is hard,
I had to manually add SpecialFunctions@0.10
because we need a version old enough to have `lgamma` and not the have `ChainRulesCore`.
CI will not do that and so the result will be meaningless

This code changes are pretty much just what is in 
https://github.com/JuliaMath/SpecialFunctions.jl/pull/300/files
but without `beta` stuff as  we don't define that apparently.