### PR TITLE
Ensure pullback of exp works for immutable arrays

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "0.7.52"
+version = "0.7.53"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/rulesets/LinearAlgebra/matfun.jl
+++ b/src/rulesets/LinearAlgebra/matfun.jl
@@ -129,7 +129,10 @@ function rrule(::typeof(exp), A0::StridedMatrix{<:BlasFloat})
         A = copy(A0)
         X, intermediates = _matfun!(exp, A)
         function exp_pullback(ΔX)
-            ∂A = _matfun_frechet_adjoint!(exp, ΔX, A, X, intermediates)
+            # Ensures ∂X is mutable. The outer `adjoint` is unwrapped without copy by
+            # the default _matfun_frechet_adjoint!
+            ∂X = Matrix(ΔX')'
+            ∂A = _matfun_frechet_adjoint!(exp, ∂X, A, X, intermediates)
             return NO_FIELDS, ∂A
         end
         return X, exp_pullback

--- a/src/rulesets/LinearAlgebra/matfun.jl
+++ b/src/rulesets/LinearAlgebra/matfun.jl
@@ -131,7 +131,7 @@ function rrule(::typeof(exp), A0::StridedMatrix{<:BlasFloat})
         function exp_pullback(ΔX)
             # Ensures ∂X is mutable. The outer `adjoint` is unwrapped without copy by
             # the default _matfun_frechet_adjoint!
-            ∂X = Matrix(ΔX')'
+            ∂X = ChainRulesCore.is_inplaceable_destination(ΔX) ? ΔX : convert(Matrix, ΔX')'
             ∂A = _matfun_frechet_adjoint!(exp, ∂X, A, X, intermediates)
             return NO_FIELDS, ∂A
         end


### PR DESCRIPTION
Fixes #380 by ensuring that the cotangent used by the pullback of `exp` is mutable.

@Roger-luo can you confirm that this fixes the bug?