### PR TITLE
Add rules for solutions to Sylvester and Lyapunov equations

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "0.7.52"
+version = "0.7.53"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "0.7.53"
+version = "0.7.54"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/ChainRules.jl
+++ b/src/ChainRules.jl
@@ -42,6 +42,7 @@ include("rulesets/Statistics/statistics.jl")
 
 include("rulesets/LinearAlgebra/utils.jl")
 include("rulesets/LinearAlgebra/blas.jl")
+include("rulesets/LinearAlgebra/lapack.jl")
 include("rulesets/LinearAlgebra/dense.jl")
 include("rulesets/LinearAlgebra/norm.jl")
 include("rulesets/LinearAlgebra/matfun.jl")

--- a/src/rulesets/LinearAlgebra/lapack.jl
+++ b/src/rulesets/LinearAlgebra/lapack.jl
@@ -1,0 +1,25 @@
+#####
+##### `LAPACK.trsyl!`
+#####
+
+function ChainRules.frule(
+    (_, _, _, ΔA, ΔB, ΔC),
+    ::typeof(LAPACK.trsyl!),
+    transa::AbstractChar,
+    transb::AbstractChar,
+    A::AbstractMatrix{T},
+    B::AbstractMatrix{T},
+    C::AbstractMatrix{T},
+    isgn::Int,
+) where {T<:BlasFloat}
+    C, scale = LAPACK.trsyl!(transa, transb, A, B, C, isgn)
+    Y = (C, scale)
+    ΔAtrans = transa === 'T' ? transpose(ΔA) : (transa === 'C' ? ΔA' : ΔA)
+    ΔBtrans = transb === 'T' ? transpose(ΔB) : (transb === 'C' ? ΔB' : ΔB)
+    mul!(ΔC, ΔAtrans, C, -1, scale)
+    mul!(ΔC, C, ΔBtrans, -isgn, true)
+    ΔC, scale2 = LAPACK.trsyl!(transa, transb, A, B, ΔC, isgn)
+    rmul!(ΔC, inv(scale2))
+    ∂Y = Composite{typeof(Y)}(ΔC, Zero())
+    return Y, ∂Y
+end

--- a/test/rulesets/LinearAlgebra/dense.jl
+++ b/test/rulesets/LinearAlgebra/dense.jl
@@ -102,4 +102,18 @@
         test_frule(tr, randn(4, 4))
         test_rrule(tr, randn(4, 4))
     end
+    @testset "sylvester" begin
+        @testset "T=$T, m=$m, n=$n" for T in (Float64, ComplexF64), m in (2, 3), n in (1, 3)
+            A = randn(T, m, m)
+            B = randn(T, n, n)
+            C = randn(T, m, n)
+            Y = sylvester(A, B, C)
+            test_frule(sylvester, A, B, C)
+            test_rrule(sylvester, A, B, C)
+            @testset "overflowing (co)tangent correctly handled" begin
+                test_frule(sylvester, A, B, C ⊢ 1e295 * rand_tangent(C))
+                test_rrule(sylvester, A, B, C; output_tangent=1e295 * rand_tangent(Y))
+            end
+        end
+    end
 end

--- a/test/rulesets/LinearAlgebra/dense.jl
+++ b/test/rulesets/LinearAlgebra/dense.jl
@@ -107,13 +107,8 @@
             A = randn(T, m, m)
             B = randn(T, n, n)
             C = randn(T, m, n)
-            Y = sylvester(A, B, C)
             test_frule(sylvester, A, B, C)
             test_rrule(sylvester, A, B, C)
-            @testset "overflowing (co)tangent correctly handled" begin
-                test_frule(sylvester, A, B, C ⊢ 1e295 * rand_tangent(C))
-                test_rrule(sylvester, A, B, C; output_tangent=1e295 * rand_tangent(Y))
-            end
         end
     end
     @testset "lyap" begin
@@ -121,13 +116,8 @@
         @testset "Float64" for T in (Float64, ComplexF64)
             A = randn(T, n, n)
             C = randn(T, n, n)
-            Y = lyap(A, C)
             test_frule(lyap, A, C)
             test_rrule(lyap, A, C)
-            @testset "overflowing (co)tangent correctly handled" begin
-                test_frule(lyap, A, C ⊢ 1e295 * rand_tangent(C))
-                test_rrule(lyap, A, C; output_tangent=1e295 * rand_tangent(Y))
-            end
         end
     end
 end

--- a/test/rulesets/LinearAlgebra/dense.jl
+++ b/test/rulesets/LinearAlgebra/dense.jl
@@ -116,4 +116,18 @@
             end
         end
     end
+    @testset "lyap" begin
+        n = 3
+        @testset "Float64" for T in (Float64, ComplexF64)
+            A = randn(T, n, n)
+            C = randn(T, n, n)
+            Y = lyap(A, C)
+            test_frule(lyap, A, C)
+            test_rrule(lyap, A, C)
+            @testset "overflowing (co)tangent correctly handled" begin
+                test_frule(lyap, A, C ⊢ 1e295 * rand_tangent(C))
+                test_rrule(lyap, A, C; output_tangent=1e295 * rand_tangent(Y))
+            end
+        end
+    end
 end

--- a/test/rulesets/LinearAlgebra/lapack.jl
+++ b/test/rulesets/LinearAlgebra/lapack.jl
@@ -1,0 +1,42 @@
+@testset "LAPACK" begin
+    @testset "trsyl!" begin
+        @testset "T=$T, m=$m, n=$n, transa='$transa', transb='$transb', isgn=$isgn" for
+            T in (Float64, ComplexF64),
+            transa in (T <: Real ? ('N', 'C', 'T') : ('N', 'C')),
+            transb in (T <: Real ? ('N', 'C', 'T') : ('N', 'C')),
+            m in (2, 3),
+            n in (1, 3),
+            isgn in (1, -1)
+
+            # make A and B quasi upper-triangular (or upper-triangular for complex)
+            # and their tangents have the same sparsity pattern
+            A = schur(randn(T, m, m)).T
+            B = schur(randn(T, n, n)).T
+            C = randn(T, m, n)
+            ΔA = rand_tangent(A) .* (!iszero).(A)
+            ΔB = rand_tangent(B) .* (!iszero).(B)
+            ΔC = rand_tangent(C)
+
+            test_frule(
+                LAPACK.trsyl!,
+                transa ⊢ nothing,
+                transb ⊢ nothing,
+                A ⊢ ΔA,
+                B ⊢ ΔB,
+                C,
+                isgn ⊢ nothing,
+            )
+            @testset "overflowing (co)tangent correctly handled" begin
+                test_frule(
+                    LAPACK.trsyl!,
+                    transa ⊢ nothing,
+                    transb ⊢ nothing,
+                    A ⊢ ΔA,
+                    B ⊢ ΔB,
+                    C ⊢ (1e295 * ΔC),
+                    isgn ⊢ nothing,
+                )
+            end
+        end
+    end
+end

--- a/test/rulesets/LinearAlgebra/lapack.jl
+++ b/test/rulesets/LinearAlgebra/lapack.jl
@@ -13,15 +13,12 @@
             A = schur(randn(T, m, m)).T
             B = schur(randn(T, n, n)).T
             C = randn(T, m, n)
-            ΔA = rand_tangent(A) .* (!iszero).(A)
-            ΔB = rand_tangent(B) .* (!iszero).(B)
-
             test_frule(
                 LAPACK.trsyl!,
                 transa ⊢ nothing,
                 transb ⊢ nothing,
-                A ⊢ ΔA,
-                B ⊢ ΔB,
+                A ⊢ rand_tangent(A) .* (!iszero).(A),  # Match sparsity pattern
+                B ⊢ rand_tangent(B) .* (!iszero).(B),
                 C,
                 isgn ⊢ nothing,
             )

--- a/test/rulesets/LinearAlgebra/lapack.jl
+++ b/test/rulesets/LinearAlgebra/lapack.jl
@@ -15,7 +15,6 @@
             C = randn(T, m, n)
             ΔA = rand_tangent(A) .* (!iszero).(A)
             ΔB = rand_tangent(B) .* (!iszero).(B)
-            ΔC = rand_tangent(C)
 
             test_frule(
                 LAPACK.trsyl!,
@@ -26,17 +25,6 @@
                 C,
                 isgn ⊢ nothing,
             )
-            @testset "overflowing (co)tangent correctly handled" begin
-                test_frule(
-                    LAPACK.trsyl!,
-                    transa ⊢ nothing,
-                    transb ⊢ nothing,
-                    A ⊢ ΔA,
-                    B ⊢ ΔB,
-                    C ⊢ (1e295 * ΔC),
-                    isgn ⊢ nothing,
-                )
-            end
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -48,6 +48,7 @@ println("Testing ChainRules.jl")
             include_test("rulesets/LinearAlgebra/symmetric.jl")
             include_test("rulesets/LinearAlgebra/factorization.jl")
             include_test("rulesets/LinearAlgebra/blas.jl")
+            include_test("rulesets/LinearAlgebra/lapack.jl")
         end
         println()
 


### PR DESCRIPTION
This PR adds rules for the following functions:
- `frule` for `LAPACK.trsyl!` (solution to the Sylvester equation for (quasi)-triangular inputs)
- `frule`/`rrule` for `sylvester` (solution to the Sylvester equation)
- `frule`/`rrule` for `lyap` (solution to the Lyapunov equation)

All of the rules can be written in terms of the primal function itself. However, `sylvester` and `lyap` both use a Schur decomposition to solve an easier equation using `LAPACK.trsyl!`, so these rules then reuse that Schur decomposition. As a result, the included rule for `lyap` is much more efficient than the one in Zygote for `StridedMatrix` inputs.