### PR TITLE
[WIP] Fix eigen rules for matrices with exactly repeating eigenvalues 

### DIFF
--- a/src/rulesets/LinearAlgebra/factorization.jl
+++ b/src/rulesets/LinearAlgebra/factorization.jl
@@ -271,7 +271,7 @@ end
 # TODO:
 # - support correct differential of phase convention when A is hermitian
 # - simplify when A is diagonal
-# - support degenerate matrices (see #144)
+# - support almost-degenerate matrices (see #144)
 
 function frule((_, ΔA), ::typeof(eigen!), A::StridedMatrix{T}; kwargs...) where {T<:BlasFloat}
     ΔA isa AbstractZero && return (eigen!(A; kwargs...), ΔA)

--- a/src/rulesets/LinearAlgebra/factorization.jl
+++ b/src/rulesets/LinearAlgebra/factorization.jl
@@ -269,7 +269,6 @@ end
 #####
 
 # TODO:
-# - support correct differential of phase convention when A is hermitian
 # - simplify when A is diagonal
 # - support almost-degenerate matrices (see #144)
 

--- a/src/rulesets/LinearAlgebra/factorization.jl
+++ b/src/rulesets/LinearAlgebra/factorization.jl
@@ -289,7 +289,14 @@ function frule((_, ΔA), ::typeof(eigen!), A::StridedMatrix{T}; kwargs...) where
     ∂K = tmp * V
     ∂Kdiag = @view ∂K[diagind(∂K)]
     ∂λ = eltype(λ) <: Real ? real.(∂Kdiag) : copy(∂Kdiag)
-    ∂K ./= transpose(λ) .- λ
+    # in-place ∂X = sylvester(Λ, -Λ, ∂K),
+    broadcast!(∂K, ∂K, transpose(λ), λ) do ∂Kij, λj, λi
+        Δλ = λj - λi
+        # when Δλ=0, then ∂Xij * Δλ = ∂Kij only has a solution when ∂Kij=0.
+        # of infinite solutions, choose ∂Xij = 0
+        iszero(Δλ) && iszero(∂Kij) && return zero(∂Kij)
+        return ∂Kij / Δλ
+    end
     fill!(∂Kdiag, 0)
     ∂V = mul!(tmp, V, ∂K)
     _eigen_norm_phase_fwd!(∂V, A, V)
@@ -316,7 +323,14 @@ function rrule(::typeof(eigen), A::StridedMatrix{T}; kwargs...) where {T<:Union{
             ∂V = copyto!(similar(ΔV), ΔV)
             _eigen_norm_phase_rev!(∂V, A, V)
             ∂K = V' * ∂V
-            ∂K ./= λ' .- conj.(λ)
+            # in-place ∂X = sylvester(Λ', -Λ', ∂K),
+            broadcast!(∂K, ∂K, transpose(λ), λ) do ∂Kij, λj, λi
+                Δλji = λj - λi
+                # when Δλ=0, then ∂Xij * Δλji' = ∂Kij only has a solution when ∂Kij=0.
+                # of infinite solutions, choose ∂Xij = 0
+                iszero(Δλji) && iszero(∂Kij) && return ∂Kij
+                return ∂Kij / conj(Δλji)
+            end
             ∂K[diagind(∂K)] .= Δλ
             ∂A = mul!(∂K, V' \ ∂K, V')
         end

--- a/src/rulesets/LinearAlgebra/symmetric.jl
+++ b/src/rulesets/LinearAlgebra/symmetric.jl
@@ -101,6 +101,11 @@ end
 #
 # accounting for normalization convention appears in Boeddeker && Hanebrink.
 # account for phase convention is unpublished.
+
+# workaround for exactly degenerate matrices inspired by
+# Kasim M.F. Derivatives of partial eigendecomposition of a real symmetric matrix for
+# degenerate cases. 2020. arXiv:2011.04366v1 [math.NA]
+
 function frule(
     (_, ΔA),
     ::typeof(eigen!),

--- a/src/rulesets/LinearAlgebra/symmetric.jl
+++ b/src/rulesets/LinearAlgebra/symmetric.jl
@@ -114,7 +114,14 @@ function frule(
     ∂K = mul!(ΔA.data, tmp, U)
     ∂Kdiag = @view ∂K[diagind(∂K)]
     ∂λ = real.(∂Kdiag)
-    ∂K ./= λ' .- λ
+    # in-place ∂X = sylvester(Λ, -Λ, ∂K),
+    broadcast!(∂K, ∂K, transpose(λ), λ) do ∂Kij, λj, λi
+        Δλ = λj - λi
+        # when Δλ=0, then ∂Xij * Δλ = ∂Kij only has a solution when ∂Kij=0.
+        # of infinite solutions, choose ∂Xij = 0
+        iszero(Δλ) && iszero(∂Kij) && return zero(∂Kij)
+        return ∂Kij / Δλ
+    end
     fill!(∂Kdiag, 0)
     ∂U = mul!(tmp, U, ∂K)
     _eigen_norm_phase_fwd!(∂U, A, U)
@@ -149,7 +156,16 @@ function eigen_rev!(A::LinearAlgebra.RealHermSymComplexHerm, λ, U, ∂λ, ∂U)
     else
         _eigen_norm_phase_rev!(∂U, A, U)
         ∂K = mul!(Ā, U', ∂U)
-        ∂K ./= λ' .- λ
+        # in-place ∂X = sylvester(Λ, -Λ, skew(∂K)),
+        # where skew(X) = (X - X') / 2 is a projection to skew-Hermitian matrices
+        broadcast!(∂K, ∂K, ∂K', transpose(λ), λ) do ∂Kij, ∂Kji′, λj, λi
+            Δ∂K = ∂Kij - ∂Kji′
+            Δλ = λj - λi
+            # when Δλ=0, then ∂Xij * Δλ = Δ∂K only has a solution when Δ∂K=0.
+            # of infinite solutions, choose ∂Xij = 0
+            iszero(Δλ) && iszero(Δ∂K) && return Δ∂K
+            return Δ∂K / 2Δλ
+        end
         ∂K[diagind(∂K)] .= real.(∂λ)
         mul!(tmp, ∂K, U')
         mul!(Ā, U, tmp)


### PR DESCRIPTION
Based on discussion at https://github.com/google/jax/issues/669#issuecomment-800805598, this PR implements a simple fix for matrices with exactly repeating eigenvalues (which are rare). The PR still needs tests. While it's not too hard to contrive a Hermitian matrix with exactly repeating eigenvalues (e.g. a diagonal matrix), I've had no luck so far coming up with a non-Hermitian matrix that after `eigen` still has exactly equal eigenvalues. Perhaps for the purposes of such a test, we could mock `eigen` somehow?