### PR TITLE
Canonicalize Composite{SVD}

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "0.7.54"
+version = "0.7.55"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/ChainRules.jl
+++ b/src/ChainRules.jl
@@ -13,8 +13,7 @@ using Statistics
 
 # Basically everything this package does is overloading these, so we make an exception
 # to the normal rule of only overload via `ChainRulesCore.rrule`.
-import ChainRulesCore: rrule, frule
-
+import ChainRulesCore: rrule, frule, canonicalize
 
 if VERSION < v"1.3.0-DEV.142"
     # In prior versions, the BLAS submodule also exported `dot`, which caused a conflict

--- a/src/rulesets/LinearAlgebra/factorization.jl
+++ b/src/rulesets/LinearAlgebra/factorization.jl
@@ -203,6 +203,18 @@ end
 ##### `svd`
 #####
 
+function canonicalize(comp::Composite{P, <:NamedTuple{L}}) where {P<:SVD, L}
+    nil = (U = Zero(), S = Zero(), V = Zero())
+    combined = merge(nil, ChainRulesCore.backing(comp))
+    if length(combined) !== fieldcount(P)
+        throw(ArgumentError(
+            "Composite fields do not match primal fields.\n" *
+            "Composite fields: $L. Primal ($P) fields: $(fieldnames(P))"
+        ))
+    end
+    return Composite{P, typeof(combined)}(combined)
+end
+
 function rrule(::typeof(svd), X::AbstractMatrix{<:Real})
     F = svd(X)
     function svd_pullback(Ȳ::Composite)

--- a/test/rulesets/LinearAlgebra/factorization.jl
+++ b/test/rulesets/LinearAlgebra/factorization.jl
@@ -79,6 +79,18 @@ end
         end
     end
     @testset "svd" begin
+        @testset "canonicalize" begin
+            composite = Composite{SVD{Float64,Float64,Array{Float64,2}}}(
+                V = [0.6662838804680036 -0.5008780874375076; 0.729969913633919 0.228331721577141],
+            )
+            canonicalized_composite = Composite{SVD{Float64,Float64,Array{Float64,2}}}(
+                U = Zero(),
+                S = Zero(),
+                V = [0.6662838804680036 -0.5008780874375076; 0.729969913633919 0.228331721577141]
+            )
+            @test composite == canonicalized_composite
+        end
+
         for n in [4, 6, 10], m in [3, 5, 10]
             X = randn(n, m)
             F, dX_pullback = rrule(svd, X)


### PR DESCRIPTION
At the moment:
```julia
julia> x = Composite{SVD{Float64,Float64,Array{Float64,2}}}(V = [0.6662838804680036 -0.5008780874375076; 0.729969913633919 0.228331721577141],)

julia> ChainRules.canonicalize(x)
ERROR: ArgumentError: Composite fields do not match primal fields.
Composite fields: (:V,). Primal (SVD{Float64,Float64,Array{Float64,2}}) fields: (:U, :S, :Vt)
```
This seems to make sense because `V` is not a field of `SVD`. However, the `rrule` for `svd` expects the `Ȳ::Composite` to contain `U`, `S`, and `V` fields:
https://github.com/JuliaDiff/ChainRules.jl/blob/76ef95c326e773c6c7140fb56eb2fd16a2af468b/src/rulesets/LinearAlgebra/factorization.jl#L206-L214

I don't know much about svd factorisation so can't really tell why this is the case.

It kind of feels wrong to overload `canonicalize` in this way, but I can't quite tell why. Any thoughts? Also, which file to put this in, it's not really a rule so I don't think it belongs in the `rulesets` folder.

Came across this in https://github.com/FluxML/Zygote.jl/issues/922#issuecomment-805121978