### PR TITLE
force sym/herm back to return Matrix (1.6 inference fix)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "0.7.55"
+version = "0.7.56"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/rulesets/LinearAlgebra/symmetric.jl
+++ b/src/rulesets/LinearAlgebra/symmetric.jl
@@ -68,7 +68,7 @@ end
         end
     end
     L, U, D = LowerTriangular(ΔΩ), UpperTriangular(ΔΩ), Diagonal(ΔΩ)
-    return uplo === :U ? U .+ transpose(L) - D : L .+ transpose(U) - D
+    return Matrix(uplo === :U ? U .+ transpose(L) - D : L .+ transpose(U) - D)
 end
 
 @inline function _hermitian_back(ΔΩ, uplo::Symbol)
@@ -83,7 +83,7 @@ end
         end
     end
     L, U, rD = LowerTriangular(ΔΩ), UpperTriangular(ΔΩ), real.(Diagonal(ΔΩ))
-    return uplo === :U ? U .+ L' - rD : L .+ U' - rD
+    return Matrix(uplo === :U ? U .+ L' - rD : L .+ U' - rD)
 end
 
 #####


### PR DESCRIPTION
Fixed the type inference failures we have been seeing in 1.6.
They show up because:

On 1.5:
```julia
julia> L = LowerTriangular(rand(3,3));

julia> U = UpperTriangular(rand(3,3));

julia> typeof(L .+ U')
Array{Float64,2}
```

On 1.6:
```julia
julia> L = LowerTriangular(rand(3,3));

julia> U = UpperTriangular(rand(3,3));

julia> typeof(L .+ U')
LowerTriangular{Float64, Matrix{Float64}}
```

Which honestly is kinda cool, but not what we want if we are to be type stable
Possibly we should push `uplo` into the type domain with a value type,
but that is beyond the scope of this PR.
The other branchs force the result to be a `Matrix` so the last should too