### PR TITLE
rrule for sort and partialsort

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "0.7.57"
+version = "0.7.58"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/ChainRules.jl
+++ b/src/ChainRules.jl
@@ -36,6 +36,7 @@ include("rulesets/Base/evalpoly.jl")
 include("rulesets/Base/array.jl")
 include("rulesets/Base/arraymath.jl")
 include("rulesets/Base/indexing.jl")
+include("rulesets/Base/sort.jl")
 include("rulesets/Base/mapreduce.jl")
 
 include("rulesets/Statistics/statistics.jl")

--- a/src/rulesets/Base/sort.jl
+++ b/src/rulesets/Base/sort.jl
@@ -4,18 +4,15 @@ function rrule(::typeof(partialsort), xs::AbstractVector, k::Union{Integer,Ordin
 
     function partialsort_pullback(Δys)
         function partialsort_add!(Δxs)
-            for (Δy, i) in zip(Δys, inds)
-                Δxs[i] += Δy
-            end
+            Δxs[inds] += Δys
             return Δxs
         end
 
-        Δxs = InplaceableThunk(
-            @thunk(partialsort_add!(zero(xs))),
-            partialsort_add!
-        )
+        Δxs = InplaceableThunk(@thunk(partialsort_add!(zero(xs))), partialsort_add!)
+
         return NO_FIELDS, Δxs, DoesNotExist()
     end
+
     return ys, partialsort_pullback
 end
 
@@ -29,10 +26,7 @@ function rrule(::typeof(sort), xs::AbstractVector; kwargs...)
             return Δxs
         end
 
-        Δxs = InplaceableThunk(
-            @thunk(sort_add!(zero(xs))),
-            sort_add!
-        )
+        Δxs = InplaceableThunk(@thunk(sort_add!(zero(Δys))), sort_add!)
 
         return NO_FIELDS, Δxs
     end

--- a/src/rulesets/Base/sort.jl
+++ b/src/rulesets/Base/sort.jl
@@ -1,0 +1,40 @@
+function rrule(::typeof(partialsort), xs::AbstractVector, k::Union{Integer,OrdinalRange}; kwargs...)
+    inds = partialsortperm(xs, k; kwargs...)
+    ys = xs[inds]
+
+    function partialsort_pullback(Δys)
+        function partialsort_add!(Δxs)
+            for (Δy, i) in zip(Δys, inds)
+                Δxs[i] += Δy
+            end
+            return Δxs
+        end
+
+        Δxs = InplaceableThunk(
+            @thunk(partialsort_add!(zero(xs))),
+            partialsort_add!
+        )
+        return NO_FIELDS, Δxs, DoesNotExist()
+    end
+    return ys, partialsort_pullback
+end
+
+function rrule(::typeof(sort), xs::AbstractVector; kwargs...)
+    inds = sortperm(xs; kwargs...)
+    ys = xs[inds]
+
+    function sort_pullback(Δys)
+        function sort_add!(Δxs)
+            Δxs[inds] += Δys
+            return Δxs
+        end
+
+        Δxs = InplaceableThunk(
+            @thunk(sort_add!(zero(xs))),
+            sort_add!
+        )
+
+        return NO_FIELDS, Δxs
+    end
+    return ys, sort_pullback
+end

--- a/test/rulesets/Base/sort.jl
+++ b/test/rulesets/Base/sort.jl
@@ -1,0 +1,15 @@
+@testset "sort.jl" begin
+    @testset "sort" begin
+        a = rand(10)
+        test_rrule(sort, a)
+        test_rrule(sort, a; fkwargs=(;rev=true))
+    end
+    @testset "partialsort" begin
+        a = rand(10)
+        test_rrule(partialsort, a, 4 ⊢ nothing)
+        test_rrule(partialsort, a, 3:5 ⊢ nothing)
+        test_rrule(partialsort, a, 1:2:6 ⊢ nothing)
+
+        test_rrule(partialsort, a, 4 ⊢ nothing, fkwargs=(;rev=true))
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,6 +32,7 @@ println("Testing ChainRules.jl")
             include_test("rulesets/Base/arraymath.jl")
             include_test("rulesets/Base/indexing.jl")
             include_test("rulesets/Base/mapreduce.jl")
+            include_test("rulesets/Base/sort.jl")
         end
         println()
 


### PR DESCRIPTION
After #394  `sortperm` and `partialsortperm` rrule are in and Zygote can compute `sort` on its own, but not `partialsort`.

no speed gain for the `sort` rule in Zygote as of now but supporting thunks will make it faster in the future, or for AD systems which natively support ChainRules types.

Helps with #392 