### PR TITLE
Update to using `DoesNotExist()` instead of `nothing` in tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 ChainRulesCore = "0.9.29"
-ChainRulesTestUtils = "0.6.1"
+ChainRulesTestUtils = "0.6.6"
 Compat = "3"
 FiniteDifferences = "0.11, 0.12"
 Reexport = "0.2, 1"

--- a/test/rulesets/Base/array.jl
+++ b/test/rulesets/Base/array.jl
@@ -1,6 +1,6 @@
 @testset "reshape" begin
-    test_rrule(reshape, rand(4, 5), (2, 10) ⊢ nothing)
-    test_rrule(reshape, rand(4, 5), 2 ⊢ nothing, 10 ⊢ nothing)
+    test_rrule(reshape, rand(4, 5), (2, 10) ⊢ DoesNotExist())
+    test_rrule(reshape, rand(4, 5), 2, 10)
 end
 
 @testset "hcat" begin
@@ -14,7 +14,7 @@ end
     A = randn(3, 2)
     B = randn(3, 1)
     C = randn(3, 3)
-    test_rrule(reduce, hcat ⊢ nothing, [A, B, C])
+    test_rrule(reduce, hcat ⊢ DoesNotExist(), [A, B, C])
 end
 
 @testset "vcat" begin
@@ -28,10 +28,10 @@ end
     A = randn(2, 4)
     B = randn(1, 4)
     C = randn(3, 4)
-    test_rrule(reduce, vcat ⊢ nothing, [A, B, C])
+    test_rrule(reduce, vcat ⊢ DoesNotExist(), [A, B, C])
 end
 
 @testset "fill" begin
-    test_rrule(fill, 44.0, 4 ⊢ nothing; check_inferred=false)
-    test_rrule(fill, 2.0, (3, 3, 3) ⊢ nothing)
+    test_rrule(fill, 44.0, 4; check_inferred=false)
+    test_rrule(fill, 2.0, (3, 3, 3) ⊢ DoesNotExist())
 end

--- a/test/rulesets/Base/base.jl
+++ b/test/rulesets/Base/base.jl
@@ -89,8 +89,8 @@
 
     @testset "ldexp" begin
         for n in (0,1,20)
-            test_frule(ldexp, 10rand(), n ⊢ nothing)
-            test_rrule(ldexp, 10rand(), n ⊢ nothing)
+            test_frule(ldexp, 10rand(), n)
+            test_rrule(ldexp, 10rand(), n)
         end
     end
 

--- a/test/rulesets/Base/indexing.jl
+++ b/test/rulesets/Base/indexing.jl
@@ -3,48 +3,48 @@
         x = [1.0 2.0 3.0; 10.0 20.0 30.0]
 
         @testset "single element" begin
-            test_rrule(getindex, x, 2 ⊢ nothing)
-            test_rrule(getindex, x, 2 ⊢ nothing, 1 ⊢ nothing)
-            test_rrule(getindex, x, 2 ⊢ nothing, 2 ⊢ nothing)
+            test_rrule(getindex, x, 2)
+            test_rrule(getindex, x, 2, 1)
+            test_rrule(getindex, x, 2, 2)
 
-            test_rrule(getindex, x, CartesianIndex(2, 3) ⊢ nothing)
+            test_rrule(getindex, x, CartesianIndex(2, 3) ⊢ DoesNotExist())
         end
 
         @testset "slice/index postions" begin
-            test_rrule(getindex, x, 2:3 ⊢ nothing)
-            test_rrule(getindex, x, 3:-1:2 ⊢ nothing)
-            test_rrule(getindex, x, [3,2] ⊢ nothing)
-            test_rrule(getindex, x, [2,3] ⊢ nothing)
+            test_rrule(getindex, x, 2:3 ⊢ DoesNotExist())
+            test_rrule(getindex, x, 3:-1:2 ⊢ DoesNotExist())
+            test_rrule(getindex, x, [3,2] ⊢ DoesNotExist())
+            test_rrule(getindex, x, [2,3] ⊢ DoesNotExist())
 
-            test_rrule(getindex, x, 1:2 ⊢ nothing, 2:3 ⊢ nothing)
-            test_rrule(getindex, x, (:) ⊢ nothing, 2:3 ⊢ nothing)
+            test_rrule(getindex, x, 1:2 ⊢ DoesNotExist(), 2:3 ⊢ DoesNotExist())
+            test_rrule(getindex, x, (:) ⊢ DoesNotExist(), 2:3 ⊢ DoesNotExist())
 
-            test_rrule(getindex, x, 1:2 ⊢ nothing, 1 ⊢ nothing)
-            test_rrule(getindex, x, 1 ⊢ nothing, 1:2 ⊢ nothing)
+            test_rrule(getindex, x, 1:2 ⊢ DoesNotExist(), 1)
+            test_rrule(getindex, x, 1, 1:2 ⊢ DoesNotExist())
 
-            test_rrule(getindex, x, 1:2 ⊢ nothing, 2:3 ⊢ nothing)
-            test_rrule(getindex, x, (:) ⊢ nothing, 2:3 ⊢ nothing)
+            test_rrule(getindex, x, 1:2 ⊢ DoesNotExist(), 2:3 ⊢ DoesNotExist())
+            test_rrule(getindex, x, (:) ⊢ DoesNotExist(), 2:3 ⊢ DoesNotExist())
 
-            test_rrule(getindex, x, (:) ⊢ nothing, (:) ⊢ nothing)
-            test_rrule(getindex, x, (:) ⊢ nothing)
+            test_rrule(getindex, x, (:) ⊢ DoesNotExist(), (:) ⊢ DoesNotExist())
+            test_rrule(getindex, x, (:) ⊢ DoesNotExist())
         end
 
         @testset "masking" begin
-            test_rrule(getindex, x, trues(size(x)) ⊢ nothing)
-            test_rrule(getindex, x, trues(length(x)) ⊢ nothing)
+            test_rrule(getindex, x, trues(size(x)) ⊢ DoesNotExist())
+            test_rrule(getindex, x, trues(length(x)) ⊢ DoesNotExist())
 
             mask = falses(size(x))
             mask[2,3] = true
             mask[1,2] = true
-            test_rrule(getindex, x, mask ⊢ nothing)
+            test_rrule(getindex, x, mask ⊢ DoesNotExist())
 
-            test_rrule(getindex, x, [true, false] ⊢ nothing, (:) ⊢ nothing)
+            test_rrule(getindex, x, [true, false] ⊢ DoesNotExist(), (:) ⊢ DoesNotExist())
         end
 
         @testset "By position with repeated elements" begin
-            test_rrule(getindex, x, [2, 2] ⊢ nothing)
-            test_rrule(getindex, x, [2, 2, 2] ⊢ nothing)
-            test_rrule(getindex, x, [2,2] ⊢ nothing, [3,3] ⊢ nothing)
+            test_rrule(getindex, x, [2, 2] ⊢ DoesNotExist())
+            test_rrule(getindex, x, [2, 2, 2] ⊢ DoesNotExist())
+            test_rrule(getindex, x, [2,2] ⊢ DoesNotExist(), [3,3] ⊢ DoesNotExist())
         end
     end
 end

--- a/test/rulesets/Base/mapreduce.jl
+++ b/test/rulesets/Base/mapreduce.jl
@@ -16,7 +16,7 @@
             @testset "Array{$N, $T}" for N in eachindex(sizes), T in (Float64, ComplexF64)
                 x = randn(T, sizes[1:N]...)
                 test_frule(sum, abs2, x; fkwargs=(;dims=dims))
-                test_rrule(sum, abs2 ⊢ nothing, x; fkwargs=(;dims=dims))
+                test_rrule(sum, abs2 ⊢ DoesNotExist(), x; fkwargs=(;dims=dims))
             end
         end
     end  # sum abs2

--- a/test/rulesets/Base/sort.jl
+++ b/test/rulesets/Base/sort.jl
@@ -6,10 +6,10 @@
     end
     @testset "partialsort" begin
         a = rand(10)
-        test_rrule(partialsort, a, 4 ⊢ nothing)
-        test_rrule(partialsort, a, 3:5 ⊢ nothing)
-        test_rrule(partialsort, a, 1:2:6 ⊢ nothing)
+        test_rrule(partialsort, a, 4)
+        test_rrule(partialsort, a, 3:5 ⊢ DoesNotExist())
+        test_rrule(partialsort, a, 1:2:6 ⊢ DoesNotExist())
 
-        test_rrule(partialsort, a, 4 ⊢ nothing, fkwargs=(;rev=true))
+        test_rrule(partialsort, a, 4, fkwargs=(;rev=true))
     end
 end

--- a/test/rulesets/LinearAlgebra/blas.jl
+++ b/test/rulesets/LinearAlgebra/blas.jl
@@ -12,11 +12,11 @@
             incy = 3
             test_rrule(
                 BLAS.dot,
-                n ⊢ nothing,
+                n,
                 randn(n * incx),
-                incx ⊢ nothing,
+                incx,
                 randn(n * incy),
-                incy ⊢ nothing,
+                incy,
             )
         end
     end
@@ -37,7 +37,7 @@
                 s = (dims[1] * incx, dims[2:N]...)
                 n = div(prod(s), incx)
                 test_rrule(
-                    BLAS.nrm2, n ⊢ nothing, randn(T, s), incx ⊢ nothing; atol=0, rtol=1e-5,
+                    BLAS.nrm2, n, randn(T, s), incx; atol=0, rtol=1e-5,
                 )
             end
         end
@@ -58,7 +58,7 @@
             @testset "Array{$T,$N}" for N in eachindex(dims), T in (Float64, ComplexF64)
                 s = (dims[1] * incx, dims[2:N]...)
                 n = div(prod(s), incx)
-                test_rrule( BLAS.asum, n ⊢ nothing, randn(T, s), incx ⊢ nothing)
+                test_rrule( BLAS.asum, n, randn(T, s), incx)
             end
         end
     end
@@ -67,9 +67,9 @@
         for m in 3:5, n in 3:5, p in 3:5, tA in ('N', 'C', 'T'), tB in ('N', 'C', 'T'), T in (Float64, ComplexF64)
             A = randn(T, tA === 'N' ? (m, n) : (n, m))
             B = randn(T, tB === 'N' ? (n, p) : (p, n))
-            test_rrule(gemm, tA ⊢ nothing, tB ⊢ nothing, A, B; check_inferred=false)
+            test_rrule(gemm, tA, tB, A, B; check_inferred=false)
             test_rrule(  # 5 arg version with scaling scalar
-                gemm, tA ⊢ nothing, tB ⊢ nothing, randn(T), A, B; check_inferred=false,
+                gemm, tA, tB, randn(T), A, B; check_inferred=false,
             )
         end
     end
@@ -77,7 +77,7 @@
     @testset "gemv" begin
         for n in 3:5, m in 3:5, t in ('N', 'C', 'T'), T in (Float64, ComplexF64)
             x = randn(T, t === 'N' ? n : m)
-            test_rrule(gemv, t ⊢ nothing, randn(T), randn(T, m, n), x; check_inferred=false)
+            test_rrule(gemv, t, randn(T), randn(T, m, n), x; check_inferred=false)
         end
     end
 end

--- a/test/rulesets/LinearAlgebra/blas.jl
+++ b/test/rulesets/LinearAlgebra/blas.jl
@@ -58,7 +58,7 @@
             @testset "Array{$T,$N}" for N in eachindex(dims), T in (Float64, ComplexF64)
                 s = (dims[1] * incx, dims[2:N]...)
                 n = div(prod(s), incx)
-                test_rrule( BLAS.asum, n, randn(T, s), incx)
+                test_rrule(BLAS.asum, n, randn(T, s), incx)
             end
         end
     end

--- a/test/rulesets/LinearAlgebra/factorization.jl
+++ b/test/rulesets/LinearAlgebra/factorization.jl
@@ -29,7 +29,7 @@ end
                 pivot in (Val(true), Val(false)),
                 m in (7, 10, 13)
 
-                test_frule(lu!, randn(T, m, n), pivot ⊢ nothing)
+                test_frule(lu!, randn(T, m, n), pivot ⊢ DoesNotExist())
             end
             @testset "check=false passed to primal function" begin
                 Asingular = zeros(n, n)
@@ -47,7 +47,7 @@ end
                 pivot in (Val(true), Val(false)),
                 m in (7, 10, 13)
 
-                test_rrule(lu, randn(T, m, n), pivot ⊢ nothing)
+                test_rrule(lu, randn(T, m, n), pivot ⊢ DoesNotExist())
             end
             @testset "check=false passed to primal function" begin
                 Asingular = zeros(n, n)
@@ -67,7 +67,7 @@ end
                     m in (7, 10, 13)
 
                     F = lu(randn(m, n))
-                    test_rrule(getproperty, F, k ⊢ nothing ; check_inferred=false)
+                    test_rrule(getproperty, F, k; check_inferred=false)
                 end
             end
             @testset "matrix inverse using LU" begin
@@ -93,10 +93,10 @@ end
                 F = svd(X)
                 rand_adj = adjoint(rand(reverse(size(F.V))...))
 
-                test_rrule(getproperty, F, :U ⊢ nothing; check_inferred=false)
-                test_rrule(getproperty, F, :S ⊢ nothing; check_inferred=false)
-                test_rrule(getproperty, F, :Vt ⊢ nothing; check_inferred=false)
-                test_rrule(getproperty, F, :V ⊢ nothing; check_inferred=false, output_tangent=rand_adj)
+                test_rrule(getproperty, F, :U; check_inferred=false)
+                test_rrule(getproperty, F, :S; check_inferred=false)
+                test_rrule(getproperty, F, :Vt; check_inferred=false)
+                test_rrule(getproperty, F, :V; check_inferred=false, output_tangent=rand_adj)
             end
         end
 
@@ -364,7 +364,7 @@ end
             D = Diagonal(rand(5) .+ 0.1)
             C = cholesky(D)
             test_rrule(
-                cholesky, D ⊢ Diagonal(randn(5)), Val(false) ⊢ nothing;
+                cholesky, D ⊢ Diagonal(randn(5)), Val(false) ⊢ DoesNotExist();
                 output_tangent=Composite{typeof(C)}(factors=Diagonal(randn(5)))
             )
         end

--- a/test/rulesets/LinearAlgebra/lapack.jl
+++ b/test/rulesets/LinearAlgebra/lapack.jl
@@ -15,12 +15,12 @@
             C = randn(T, m, n)
             test_frule(
                 LAPACK.trsyl!,
-                transa ⊢ nothing,
-                transb ⊢ nothing,
+                transa,
+                transb,
                 A ⊢ rand_tangent(A) .* (!iszero).(A),  # Match sparsity pattern
                 B ⊢ rand_tangent(B) .* (!iszero).(B),
                 C,
-                isgn ⊢ nothing,
+                isgn,
             )
         end
     end

--- a/test/rulesets/LinearAlgebra/structured.jl
+++ b/test/rulesets/LinearAlgebra/structured.jl
@@ -42,7 +42,7 @@
         test_rrule(diag, randn(N, N) ⊢ Diagonal(randn(N)))
         test_rrule(diag, Diagonal(randn(N)) ⊢ Diagonal(randn(N)))
         VERSION ≥ v"1.3" && @testset "k=$k" for k in (-1, 0, 2)
-            test_rrule(diag, randn(N, N), k ⊢ nothing)
+            test_rrule(diag, randn(N, N), k)
         end
     end
     @testset "diagm" begin
@@ -138,7 +138,7 @@
         n = 7
         test_rrule(Op, randn(n, n))
         @testset "k=$k" for k in -2:2
-            test_rrule(Op, randn(n, n), k ⊢ nothing)
+            test_rrule(Op, randn(n, n), k)
         end
     end
 

--- a/test/rulesets/LinearAlgebra/symmetric.jl
+++ b/test/rulesets/LinearAlgebra/symmetric.jl
@@ -5,7 +5,7 @@
         uplo in (:U, :L)
 
         @testset "frule" begin
-            test_frule(SymHerm, rand(T, 3, 3), uplo ⊢ nothing)
+            test_frule(SymHerm, rand(T, 3, 3), uplo)
         end
         @testset "rrule" begin
             # on old versions of julia this combination doesn't infer but we don't care as
@@ -16,7 +16,7 @@
                 x = randn(T, 3, 3)
                 ΔΩ = MT(randn(T, 3, 3))
                 test_rrule(
-                    SymHerm, x, uplo ⊢ nothing;
+                    SymHerm, x, uplo;
                     output_tangent = ΔΩ,
                     # type stability here critically relies on uplo being constant propagated,
                     # so we need to test this more carefully below
@@ -32,7 +32,7 @@
                 x = randn(T, 3, 3)
                 ΔΩ = Diagonal(randn(T, 3, 3))
                 test_rrule(
-                    SymHerm, x ⊢ Diagonal(randn(T, 3)), uplo ⊢ nothing;
+                    SymHerm, x ⊢ Diagonal(randn(T, 3)), uplo;
                     check_inferred=false,
                     output_tangent = ΔΩ,
                 )


### PR DESCRIPTION
Depends on https://github.com/JuliaDiff/ChainRulesTestUtils.jl/pull/129

For integers and symbols the explicit tangent is removed as `rand_tangent` returns `DoesNotExist()`