### PR TITLE
tag new release to make available on Zenodo

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "0.7.64"
+version = "0.7.65"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"


### PR DESCRIPTION
I am trying to register ChainRules and related repos at https://zenodo.org/. For a repo to show up though, a new release has to be tagged. Sorry for the noise!