### PR TITLE
RFC: rules related to 3-arg `*`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "1.18.1"
+version = "1.19"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/rulesets/Base/arraymath.jl
+++ b/src/rulesets/Base/arraymath.jl
@@ -144,27 +144,28 @@ if VERSION > v"1.7.0-DEV.1284"
         B::StridedMaybeAdjOrTransMat{<:CommutativeMulNumber},
         γ::CommutativeMulNumber
     )
-        AB  = mat_mat_scalar(A, B, one(γ))  # one(γ) allows for γ having a wider type than A, B
-        function mat_mat_scalar_back(Ȳ)
+        project_A = ProjectTo(A)
+        project_B = ProjectTo(B)
+        project_γ = ProjectTo(γ)
+        C = mat_mat_scalar(A, B, γ)
+        function mat_mat_scalar_back(Ȳraw)
+            Ȳ = unthunk(Ȳraw)
             Athunk = InplaceableThunk(
                 dA -> mul!(dA, Ȳ, B', conj(γ), true),
-                @thunk(mat_mat_scalar(Ȳ, B', conj(γ))),
+                @thunk(project_A(mat_mat_scalar(Ȳ, B', conj(γ)))),
             )
             Bthunk = InplaceableThunk(
                 dB -> mul!(dB, A', Ȳ, conj(γ), true),
-                @thunk(mat_mat_scalar(A', Ȳ, conj(γ))),
+                @thunk(project_B(mat_mat_scalar(A', Ȳ, conj(γ)))),
             )
             γthunk = @thunk if iszero(γ)
-                dot(AB, Ȳ)
+                # Could save A*B on the forward pass, but it's messy.
+                # This ought to be rare, and guarantees the same type:
+                project_γ(dot(mat_mat_scalar(A, B, oneunit(γ)), Ȳ))
             else
-                dot(AB, Ȳ) / conj(γ)  # in this case AB has been mutated by rmul! below
+                project_γ(dot(C, Ȳ) / conj(γ))
             end
             return (NoTangent(), Athunk, Bthunk, γthunk)
-        end
-        C = if iszero(γ)
-            zero(AB)
-        else
-            rmul!(AB, γ)  # mutate to save an allocation, which fused * also does
         end
         return C, mat_mat_scalar_back
     end
@@ -175,27 +176,26 @@ if VERSION > v"1.7.0-DEV.1284"
         b::StridedVector{<:CommutativeMulNumber},
         γ::CommutativeMulNumber
     )
-        Ab  = mat_vec_scalar(A, b, one(γ))
-        function mat_vec_scalar_back(dy)
+        project_A = ProjectTo(A)
+        project_b = ProjectTo(b)
+        project_γ = ProjectTo(γ)
+        y  = mat_vec_scalar(A, b, γ)
+        function mat_vec_scalar_back(dy_raw)
+            dy = unthunk(dy_raw)
             Athunk = InplaceableThunk(
                 dA -> mul!(dA, dy, b', conj(γ), true),
-                @thunk(mat_mat_scalar(dy, b', conj(γ))),
+                @thunk(project_A(*(dy, b', conj(γ)))),
             )
             Bthunk = InplaceableThunk(
                 db -> mul!(db, A', dy, conj(γ), true),
-                @thunk(mat_mat_scalar(A', dy, conj(γ))),
+                @thunk(project_b(*(A', dy, conj(γ)))),
             )
             γthunk = @thunk if iszero(γ)
-                dot(Ab, dy)
+                project_γ(dot(mat_vec_scalar(A, b, oneunit(γ)), dy))
             else
-                dot(Ab, dy) / conj(γ)  # re-use mutated AB
+                project_γ(dot(y, dy) / conj(γ))
             end
             return (NoTangent(), Athunk, Bthunk, γthunk)
-        end
-        y = if iszero(γ)
-            zero(Ab)
-        else
-            rmul!(Ab, γ)
         end
         return y, mat_vec_scalar_back
     end

--- a/src/rulesets/Base/arraymath.jl
+++ b/src/rulesets/Base/arraymath.jl
@@ -132,7 +132,7 @@ end
 ##### fused 3-argument *
 #####
 
-if VERSION > v"1.7.0-DEV.1284"
+if VERSION > v"1.7.0-"
 
     const mat_mat_scalar = LinearAlgebra.mat_mat_scalar
     const mat_vec_scalar = LinearAlgebra.mat_vec_scalar
@@ -160,8 +160,8 @@ if VERSION > v"1.7.0-DEV.1284"
             )
             γthunk = @thunk if iszero(γ)
                 # Could save A*B on the forward pass, but it's messy.
-                # This ought to be rare, and guarantees the same type:
-                project_γ(dot(mat_mat_scalar(A, B, oneunit(γ)), Ȳ))
+                # This ought to be rare, should guarantee the same type:
+                project_γ(dot(mat_mat_scalar(A, B, oneunit(γ)), Ȳ) / one(γ))
             else
                 project_γ(dot(C, Ȳ) / conj(γ))
             end

--- a/src/rulesets/Base/arraymath.jl
+++ b/src/rulesets/Base/arraymath.jl
@@ -128,6 +128,77 @@ function rrule(
     return A * B, times_pullback
 end
 
+#####
+##### fused 3-argument *
+#####
+
+using LinearAlgebra: mat_mat_scalar, mat_vec_scalar, rmul!
+
+function rrule(
+    ::typeof(mat_mat_scalar),
+    A::AbstractMatrix{<:CommutativeMulNumber},
+    B::AbstractMatrix{<:CommutativeMulNumber},
+    γ::CommutativeMulNumber
+)
+    AB  = A * B
+    function mat_mat_scalar_back(Ȳ)
+        return (
+            NO_FIELDS,
+            InplaceableThunk(
+                @thunk(mat_mat_scalar(Ȳ, B', conj(γ))),
+                dA -> mul!(dA, Ȳ, B', conj(γ), true)
+            ),
+            InplaceableThunk(
+                @thunk(mat_mat_scalar(A', Ȳ, conj(γ))),
+                dB -> mul!(dB, A', Ȳ, conj(γ), true)
+            ),
+            @thunk(sum(Ȳ .* conj.(AB)) * size(A,2)), # not so certain!
+        )
+    end
+    return rmul!(AB, γ), mat_mat_scalar_back
+end
+
+#=
+julia> A = rand(100,100); B = rand(100,100);
+julia> AB = A*B;
+julia> Ȳ = rand(100,100);
+
+julia> @btime sum($Ȳ .* conj.($AB))
+  7.206 μs (2 allocations: 78.20 KiB)
+
+julia> @btime sum(y * conj(ab) for (y,ab) in zip($Ȳ, $AB))
+  11.162 μs (0 allocations: 0 bytes)
+
+julia> @btime mapreduce((y,ab) -> y * conj(ab), +, $Ȳ, $AB)
+  11.239 μs (6 allocations: 78.31 KiB)
+
+julia> @btime sum(Broadcast.broadcasted((y,ab) -> y * conj(ab), $Ȳ, $AB))
+  73.458 μs (0 allocations: 0 bytes)
+=#
+
+function rrule(
+    ::typeof(mat_mat_scalar),
+    A::AbstractMatrix{<:CommutativeMulNumber},
+    b::AbstractVector{<:CommutativeMulNumber},
+    γ::CommutativeMulNumber
+)
+    Ab  = A * b
+    function mat_vec_scalar_back(dy)
+        return (
+            NO_FIELDS,
+            InplaceableThunk(
+                @thunk(mat_mat_scalar(dy, b', conj(γ))),
+                dA -> mul!(dA, dy, b', conj(γ), true)
+            ),
+            InplaceableThunk(
+                @thunk(mat_mat_scalar(A', dy, conj(γ))),
+                db -> mul!(db, A', dy, conj(γ), true)
+            ),
+            @thunk(sum(dy .* conj.(Ab)) * size(A,2))
+        )
+    end
+    return rmul!(Ab, γ), mat_vec_scalar_back
+end
 
 #####
 ##### `muladd`

--- a/src/rulesets/Base/arraymath.jl
+++ b/src/rulesets/Base/arraymath.jl
@@ -132,6 +132,8 @@ end
 ##### fused 3-argument *
 #####
 
+if VERSION > v"1.7.0-DEV.1284"
+
 using LinearAlgebra: mat_mat_scalar, mat_vec_scalar, rmul!, StridedMaybeAdjOrTransMat
 
 function rrule(
@@ -199,6 +201,8 @@ function rrule(
     end
     return y, mat_vec_scalar_back
 end
+
+end # VERSION
 
 #####
 ##### `muladd`

--- a/src/rulesets/Base/arraymath.jl
+++ b/src/rulesets/Base/arraymath.jl
@@ -134,7 +134,9 @@ end
 
 if VERSION > v"1.7.0-DEV.1284"
 
-    using LinearAlgebra: mat_mat_scalar, mat_vec_scalar, rmul!, StridedMaybeAdjOrTransMat
+    const mat_mat_scalar = LinearAlgebra.mat_mat_scalar
+    const mat_vec_scalar = LinearAlgebra.mat_vec_scalar
+    const StridedMaybeAdjOrTransMat = LinearAlgebra.StridedMaybeAdjOrTransMat
 
     function rrule(
         ::typeof(mat_mat_scalar),

--- a/src/rulesets/Base/arraymath.jl
+++ b/src/rulesets/Base/arraymath.jl
@@ -134,9 +134,7 @@ end
 
 if VERSION > v"1.7.0-"
 
-    const mat_mat_scalar = LinearAlgebra.mat_mat_scalar
-    const mat_vec_scalar = LinearAlgebra.mat_vec_scalar
-    const StridedMaybeAdjOrTransMat = LinearAlgebra.StridedMaybeAdjOrTransMat
+    @eval using LinearAlgebra: mat_mat_scalar, mat_vec_scalar, StridedMaybeAdjOrTransMat
 
     function rrule(
         ::typeof(mat_mat_scalar),
@@ -179,7 +177,7 @@ if VERSION > v"1.7.0-"
         project_A = ProjectTo(A)
         project_b = ProjectTo(b)
         project_γ = ProjectTo(γ)
-        y  = mat_vec_scalar(A, b, γ)
+        y = mat_vec_scalar(A, b, γ)
         function mat_vec_scalar_back(dy_raw)
             dy = unthunk(dy_raw)
             Athunk = InplaceableThunk(

--- a/src/rulesets/Base/arraymath.jl
+++ b/src/rulesets/Base/arraymath.jl
@@ -145,12 +145,12 @@ if VERSION > v"1.7.0-DEV.1284"
         AB  = mat_mat_scalar(A, B, one(γ))  # one(γ) allows for γ having a wider type than A, B
         function mat_mat_scalar_back(Ȳ)
             Athunk = InplaceableThunk(
-                @thunk(mat_mat_scalar(Ȳ, B', conj(γ))),
                 dA -> mul!(dA, Ȳ, B', conj(γ), true),
+                @thunk(mat_mat_scalar(Ȳ, B', conj(γ))),
             )
             Bthunk = InplaceableThunk(
-                @thunk(mat_mat_scalar(A', Ȳ, conj(γ))),
                 dB -> mul!(dB, A', Ȳ, conj(γ), true),
+                @thunk(mat_mat_scalar(A', Ȳ, conj(γ))),
             )
             γthunk = @thunk if iszero(γ)
                 dot(AB, Ȳ)
@@ -176,12 +176,12 @@ if VERSION > v"1.7.0-DEV.1284"
         Ab  = mat_vec_scalar(A, b, one(γ))
         function mat_vec_scalar_back(dy)
             Athunk = InplaceableThunk(
-                @thunk(mat_mat_scalar(dy, b', conj(γ))),
                 dA -> mul!(dA, dy, b', conj(γ), true),
+                @thunk(mat_mat_scalar(dy, b', conj(γ))),
             )
             Bthunk = InplaceableThunk(
-                @thunk(mat_mat_scalar(A', dy, conj(γ))),
                 db -> mul!(db, A', dy, conj(γ), true),
+                @thunk(mat_mat_scalar(A', dy, conj(γ))),
             )
             γthunk = @thunk if iszero(γ)
                 dot(Ab, dy)

--- a/test/rulesets/Base/arraymath.jl
+++ b/test/rulesets/Base/arraymath.jl
@@ -122,6 +122,7 @@
             test_rrule(mat_mat_scalar, rand(T,4,4), rand(T,4,4), rand(T))
             test_rrule(mat_mat_scalar, rand(T,4,4), rand(T,4,4), 0.0)
             test_rrule(mat_mat_scalar, rand(T,4,4)' ⊢ rand(T,4,4), rand(T,4,4), rand(T))
+            
             test_rrule(mat_vec_scalar, rand(T,4,4), rand(T,4), rand(T))
             test_rrule(mat_vec_scalar, rand(T,4,4), rand(T,4), 0.0)
 

--- a/test/rulesets/Base/arraymath.jl
+++ b/test/rulesets/Base/arraymath.jl
@@ -112,12 +112,9 @@
     end
 
     if VERSION > v"1.7.0-"
-        mat_mat_scalar = LinearAlgebra.mat_mat_scalar
-        mat_vec_scalar = LinearAlgebra.mat_vec_scalar
-        StridedMaybeAdjOrTransMat = LinearAlgebra.StridedMaybeAdjOrTransMat
-        # using LinearAlgebra: mat_mat_scalar, mat_vec_scalar, StridedMaybeAdjOrTransMat
+        @eval using LinearAlgebra: mat_mat_scalar, mat_vec_scalar, StridedMaybeAdjOrTransMat
 
-        @testset "3-arg *, $T" for T in [Float64] # , ComplexF64]
+        @testset "3-arg *, $T" for T in [Float64, ComplexF64]
 
             test_rrule(mat_mat_scalar, rand(T,4,4), rand(T,4,4), rand(T))
             test_rrule(mat_mat_scalar, rand(T,4,4), rand(T,4,4), 0.0)
@@ -126,12 +123,13 @@
             test_rrule(mat_vec_scalar, rand(T,4,4), rand(T,4), rand(T))
             test_rrule(mat_vec_scalar, rand(T,4,4), rand(T,4), 0.0)
 
+            T == ComplexF64 && continue
             # Test with γ of a wider type
             A, B, b, γ = rand(3,3), rand(3,3), rand(3), rand()
             dZ, dz = rand(3,3), rand(3)
-            unthunk(rrule(mat_mat_scalar, A, B, γ+0im   )[2](dZ)[4]) ≈ unthunk(rrule(mat_mat_scalar, A, B, γ)[2](dZ)[4])
-            unthunk(rrule(mat_mat_scalar, A, B, 0.0+0im )[2](dZ)[4]) ≈ unthunk(rrule(mat_mat_scalar, A, B, 0)[2](dZ)[4])
-            unthunk(rrule(mat_vec_scalar, A, b, γ+0im   )[2](dz)[4]) ≈ unthunk(rrule(mat_vec_scalar, A, b, γ)[2](dz)[4])
+            unthunk(rrule(mat_mat_scalar, A, B, γ + 0im)[2](dZ)[4]) ≈ unthunk(rrule(mat_mat_scalar, A, B, γ)[2](dZ)[4])
+            unthunk(rrule(mat_mat_scalar, A, B, 0 + 0im)[2](dZ)[4]) ≈ unthunk(rrule(mat_mat_scalar, A, B, 0)[2](dZ)[4])
+            unthunk(rrule(mat_vec_scalar, A, b, γ + 0im)[2](dz)[4]) ≈ unthunk(rrule(mat_vec_scalar, A, b, γ)[2](dz)[4])
         end
     end # VERSION
 

--- a/test/rulesets/Base/arraymath.jl
+++ b/test/rulesets/Base/arraymath.jl
@@ -111,6 +111,26 @@
         end
     end
 
+if VERSION > v"1.7.0-DEV.1284"
+    @testset "3-arg *, $T" for T in [Float64] # , ComplexF64]
+        using LinearAlgebra: mat_mat_scalar, mat_vec_scalar
+
+        test_rrule(mat_mat_scalar, rand(T,4,4), rand(T,4,4), rand(T))
+        test_rrule(mat_mat_scalar, rand(T,4,4), rand(T,4,4), 0.0)
+        test_rrule(mat_mat_scalar, rand(T,4,4)' ⊢ rand(T,4,4), rand(T,4,4), rand(T))
+        test_rrule(mat_vec_scalar, rand(T,4,4), rand(T,4), rand(T))
+        test_rrule(mat_vec_scalar, rand(T,4,4), rand(T,4), 0.0)
+
+        # Test with γ of a wider type
+        A, B, b, γ = rand(3,3), rand(3,3), rand(3), rand()
+        dZ, dz = rand(3,3), rand(3)
+        rrule(mat_mat_scalar, A, B, γ+0im   )[2](dZ)[4]() ≈ rrule(mat_mat_scalar, A, B, γ)[2](dZ)[4]()
+        rrule(mat_mat_scalar, A, B, 0.0+0im )[2](dZ)[4]() ≈ rrule(mat_mat_scalar, A, B, 0)[2](dZ)[4]()
+        rrule(mat_vec_scalar, A, b, γ+0im   )[2](dz)[4]() ≈ rrule(mat_vec_scalar, A, b, γ)[2](dz)[4]()
+    end
+
+end # VERSION
+
     @testset "$f" for f in (/, \)
         @testset "Matrix" begin
             for n in 3:5, m in 3:5

--- a/test/rulesets/Base/arraymath.jl
+++ b/test/rulesets/Base/arraymath.jl
@@ -112,8 +112,12 @@
     end
 
     if VERSION > v"1.7.0-DEV.1284"
+        mat_mat_scalar = LinearAlgebra.mat_mat_scalar
+        mat_vec_scalar = LinearAlgebra.mat_vec_scalar
+        StridedMaybeAdjOrTransMat = LinearAlgebra.StridedMaybeAdjOrTransMat
+        # using LinearAlgebra: mat_mat_scalar, mat_vec_scalar, StridedMaybeAdjOrTransMat
+
         @testset "3-arg *, $T" for T in [Float64] # , ComplexF64]
-            using LinearAlgebra: mat_mat_scalar, mat_vec_scalar
 
             test_rrule(mat_mat_scalar, rand(T,4,4), rand(T,4,4), rand(T))
             test_rrule(mat_mat_scalar, rand(T,4,4), rand(T,4,4), 0.0)
@@ -124,9 +128,9 @@
             # Test with γ of a wider type
             A, B, b, γ = rand(3,3), rand(3,3), rand(3), rand()
             dZ, dz = rand(3,3), rand(3)
-            rrule(mat_mat_scalar, A, B, γ+0im   )[2](dZ)[4]() ≈ rrule(mat_mat_scalar, A, B, γ)[2](dZ)[4]()
-            rrule(mat_mat_scalar, A, B, 0.0+0im )[2](dZ)[4]() ≈ rrule(mat_mat_scalar, A, B, 0)[2](dZ)[4]()
-            rrule(mat_vec_scalar, A, b, γ+0im   )[2](dz)[4]() ≈ rrule(mat_vec_scalar, A, b, γ)[2](dz)[4]()
+            unthunk(rrule(mat_mat_scalar, A, B, γ+0im   )[2](dZ)[4]) ≈ unthunk(rrule(mat_mat_scalar, A, B, γ)[2](dZ)[4])
+            unthunk(rrule(mat_mat_scalar, A, B, 0.0+0im )[2](dZ)[4]) ≈ unthunk(rrule(mat_mat_scalar, A, B, 0)[2](dZ)[4])
+            unthunk(rrule(mat_vec_scalar, A, b, γ+0im   )[2](dz)[4]) ≈ unthunk(rrule(mat_vec_scalar, A, b, γ)[2](dz)[4])
         end
     end # VERSION
 

--- a/test/rulesets/Base/arraymath.jl
+++ b/test/rulesets/Base/arraymath.jl
@@ -111,25 +111,24 @@
         end
     end
 
-if VERSION > v"1.7.0-DEV.1284"
-    @testset "3-arg *, $T" for T in [Float64] # , ComplexF64]
-        using LinearAlgebra: mat_mat_scalar, mat_vec_scalar
+    if VERSION > v"1.7.0-DEV.1284"
+        @testset "3-arg *, $T" for T in [Float64] # , ComplexF64]
+            using LinearAlgebra: mat_mat_scalar, mat_vec_scalar
 
-        test_rrule(mat_mat_scalar, rand(T,4,4), rand(T,4,4), rand(T))
-        test_rrule(mat_mat_scalar, rand(T,4,4), rand(T,4,4), 0.0)
-        test_rrule(mat_mat_scalar, rand(T,4,4)' ⊢ rand(T,4,4), rand(T,4,4), rand(T))
-        test_rrule(mat_vec_scalar, rand(T,4,4), rand(T,4), rand(T))
-        test_rrule(mat_vec_scalar, rand(T,4,4), rand(T,4), 0.0)
+            test_rrule(mat_mat_scalar, rand(T,4,4), rand(T,4,4), rand(T))
+            test_rrule(mat_mat_scalar, rand(T,4,4), rand(T,4,4), 0.0)
+            test_rrule(mat_mat_scalar, rand(T,4,4)' ⊢ rand(T,4,4), rand(T,4,4), rand(T))
+            test_rrule(mat_vec_scalar, rand(T,4,4), rand(T,4), rand(T))
+            test_rrule(mat_vec_scalar, rand(T,4,4), rand(T,4), 0.0)
 
-        # Test with γ of a wider type
-        A, B, b, γ = rand(3,3), rand(3,3), rand(3), rand()
-        dZ, dz = rand(3,3), rand(3)
-        rrule(mat_mat_scalar, A, B, γ+0im   )[2](dZ)[4]() ≈ rrule(mat_mat_scalar, A, B, γ)[2](dZ)[4]()
-        rrule(mat_mat_scalar, A, B, 0.0+0im )[2](dZ)[4]() ≈ rrule(mat_mat_scalar, A, B, 0)[2](dZ)[4]()
-        rrule(mat_vec_scalar, A, b, γ+0im   )[2](dz)[4]() ≈ rrule(mat_vec_scalar, A, b, γ)[2](dz)[4]()
-    end
-
-end # VERSION
+            # Test with γ of a wider type
+            A, B, b, γ = rand(3,3), rand(3,3), rand(3), rand()
+            dZ, dz = rand(3,3), rand(3)
+            rrule(mat_mat_scalar, A, B, γ+0im   )[2](dZ)[4]() ≈ rrule(mat_mat_scalar, A, B, γ)[2](dZ)[4]()
+            rrule(mat_mat_scalar, A, B, 0.0+0im )[2](dZ)[4]() ≈ rrule(mat_mat_scalar, A, B, 0)[2](dZ)[4]()
+            rrule(mat_vec_scalar, A, b, γ+0im   )[2](dz)[4]() ≈ rrule(mat_vec_scalar, A, b, γ)[2](dz)[4]()
+        end
+    end # VERSION
 
     @testset "$f" for f in (/, \)
         @testset "Matrix" begin

--- a/test/rulesets/Base/arraymath.jl
+++ b/test/rulesets/Base/arraymath.jl
@@ -111,7 +111,7 @@
         end
     end
 
-    if VERSION > v"1.7.0-DEV.1284"
+    if VERSION > v"1.7.0-"
         mat_mat_scalar = LinearAlgebra.mat_mat_scalar
         mat_vec_scalar = LinearAlgebra.mat_vec_scalar
         StridedMaybeAdjOrTransMat = LinearAlgebra.StridedMaybeAdjOrTransMat
@@ -122,7 +122,7 @@
             test_rrule(mat_mat_scalar, rand(T,4,4), rand(T,4,4), rand(T))
             test_rrule(mat_mat_scalar, rand(T,4,4), rand(T,4,4), 0.0)
             test_rrule(mat_mat_scalar, rand(T,4,4)' ⊢ rand(T,4,4), rand(T,4,4), rand(T))
-            
+
             test_rrule(mat_vec_scalar, rand(T,4,4), rand(T,4), rand(T))
             test_rrule(mat_vec_scalar, rand(T,4,4), rand(T,4), 0.0)
 


### PR DESCRIPTION
https://github.com/JuliaLang/julia/pull/37898 adds some 3- and 4-arg methods to `*`, do to things like contract matrices in the optimal order. That eventually calls pairwise `*` so shouldn't break AD.

It also fuses scalar-matrix-matrix multiplication, which involves calling `mul!`, and thus I think will break things. So this adds some rules!

The RFC is about exactly which functions to attach rules to, and with what signatures. The basic function is `mat_vec_scalar(A, x, γ) = A * (x .* γ)`, but this has some methods which call `_mat_vec_scalar` which actually does the mutation. The minimal thing would be to attach the rule to `_mat_vec_scalar`, but it might be more efficient to call the fused rule in some other cases, rather than leaving AD to sort out the broadcast etc. (It's also not too late to fiddle with the Base PR, if someone has bright ideas.)

Tests will obviously fail on CI; they also fail locally for complex numbers right now.