### PR TITLE
modify tests

### DIFF
--- a/test/rulesets/Random/random.jl
+++ b/test/rulesets/Random/random.jl
@@ -14,7 +14,7 @@ Random.rand(d::NormalDistribution) = d.μ + d.σ*randn()
 
             rng, pb = rrule(MersenneTwister)
             @test rng isa MersenneTwister
-            @test first(pb(10)) isa Zero
+            @test first(pb(10)) isa typeof(NO_FIELDS)
         end
         @testset "unary" begin
             rng, dΩ = frule((5.0, 4.0), MersenneTwister, 123)
@@ -23,7 +23,7 @@ Random.rand(d::NormalDistribution) = d.μ + d.σ*randn()
 
             rng, pb = rrule(MersenneTwister, 123)
             @test rng isa MersenneTwister
-            @test all(map(x -> x isa Zero, pb(10)))
+            @test all(map(x -> x isa AbstractZero, pb(10)))
         end
     end
 


### PR DESCRIPTION
These two tests implicitly assume that `NO_FIELDS` is a `ZeroTangent`. This PR removes this assumption to make way for https://github.com/JuliaDiff/ChainRulesCore.jl/pull/358