### PR TITLE
Ox/muladd

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,9 +14,9 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 [compat]
 ChainRulesCore = "0.9.44"
 ChainRulesTestUtils = "0.6.8"
-Compat = "3"
 FiniteDifferences = "0.11, 0.12"
 Reexport = "0.2, 1"
+Compat = "3.30"
 Requires = "0.5.2, 1"
 julia = "1"
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "0.7.68"
+version = "0.7.69"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/Project.toml
+++ b/Project.toml
@@ -14,9 +14,9 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 [compat]
 ChainRulesCore = "0.9.44"
 ChainRulesTestUtils = "0.6.8"
-FiniteDifferences = "0.11, 0.12"
-Reexport = "0.2, 1"
 Compat = "3.30"
+FiniteDifferences = "0.12.8"
+Reexport = "0.2, 1"
 Requires = "0.5.2, 1"
 julia = "1"
 

--- a/src/rulesets/Base/arraymath.jl
+++ b/src/rulesets/Base/arraymath.jl
@@ -140,7 +140,17 @@ function rrule(
         z::CommutativeMulNumber,
     )
     # This case is dot(u,v)+z, but would also match signature above.
-    muladd_pullback_2(dy) = (NO_FIELDS, @thunk(v' .* dy), @thunk(ut' .* dy), z isa Bool ? DoesNotExist() : dy)
+    function muladd_pullback_2(dy)
+        ut_thunk = InplaceableThunk(
+            @thunk(v' .* dy),
+            dut -> dut .+= v' .* dy
+        )
+        v_thunk = InplaceableThunk(
+            @thunk(ut' .* dy),
+            dv -> dv .+= ut' .* dy
+        )
+        (NO_FIELDS, ut_thunk, v_thunk, z isa Bool ? DoesNotExist() : dy)
+    end
     return muladd(ut, v, z), muladd_pullback_2
 end
 

--- a/src/rulesets/Base/arraymath.jl
+++ b/src/rulesets/Base/arraymath.jl
@@ -118,7 +118,7 @@ function rrule(
             )
         )
         addon = if z isa Bool
-            Zero()
+            DoesNotExist()
         elseif z isa Number
             @thunk(sum(Ȳ))
         else
@@ -140,7 +140,7 @@ function rrule(
         z::CommutativeMulNumber,
     )
     # This case is dot(u,v)+z, but would also match signature above.
-    muladd_pullback_2(dy) = (NO_FIELDS, @thunk(v' .* dy), @thunk(ut' .* dy), dy)
+    muladd_pullback_2(dy) = (NO_FIELDS, @thunk(v' .* dy), @thunk(ut' .* dy), z isa Bool ? DoesNotExist() : dy)
     return muladd(ut, v, z), muladd_pullback_2
 end
 
@@ -157,7 +157,7 @@ function rrule(
             @thunk(vec(sum(u .* conj.(Ȳ), dims=1))'),
         )
         addon = if z isa Bool
-            Zero()
+            DoesNotExist()
         elseif z isa Number
             @thunk(sum(Ȳ))
         else

--- a/src/rulesets/Base/arraymath.jl
+++ b/src/rulesets/Base/arraymath.jl
@@ -144,35 +144,6 @@ function rrule(
     return muladd(ut, v, z), muladd_pullback_2
 end
 
-function rrule(
-        ::typeof(muladd),
-        u::AbstractVector{<:CommutativeMulNumber},
-        vt::LinearAlgebra.AdjOrTransAbsVec{<:CommutativeMulNumber},
-        z::Union{CommutativeMulNumber, AbstractVecOrMat{<:CommutativeMulNumber}},
-    )
-    # Outer product, just broadcasting
-    function muladd_pullback_3(Ȳ)
-        proj = (
-            @thunk(vec(sum(Ȳ .* conj.(vt), dims=2))),
-            @thunk(vec(sum(u .* conj.(Ȳ), dims=1))'),
-        )
-        addon = if z isa Bool
-            Zero()
-        elseif z isa Number
-            @thunk(sum(Ȳ))
-        else
-            T = eltype(Ȳ)
-            InplaceableThunk(
-                @thunk(sum!(similar(z, T), Ȳ)),
-                dz -> sum!(dz, Ȳ; init=false)
-            )
-        end
-        (NO_FIELDS, proj..., addon)
-    end
-    return muladd(u, vt, z), muladd_pullback_3
-end
-
-
 #####
 ##### `/`
 #####

--- a/src/rulesets/Base/arraymath.jl
+++ b/src/rulesets/Base/arraymath.jl
@@ -144,6 +144,34 @@ function rrule(
     return muladd(ut, v, z), muladd_pullback_2
 end
 
+function rrule(
+        ::typeof(muladd),
+        u::AbstractVector{<:CommutativeMulNumber},
+        vt::LinearAlgebra.AdjOrTransAbsVec{<:CommutativeMulNumber},
+        z::Union{CommutativeMulNumber, AbstractVecOrMat{<:CommutativeMulNumber}},
+    )
+    # Outer product, just broadcasting
+    function muladd_pullback_3(Ȳ)
+        proj = (
+            @thunk(vec(sum(Ȳ .* conj.(vt), dims=2))),
+            @thunk(vec(sum(u .* conj.(Ȳ), dims=1))'),
+        )
+        addon = if z isa Bool
+            Zero()
+        elseif z isa Number
+            @thunk(sum(Ȳ))
+        else
+            T = eltype(Ȳ)
+            InplaceableThunk(
+                @thunk(sum!(similar(z, T), Ȳ)),
+                dz -> sum!(dz, Ȳ; init=false)
+            )
+        end
+        (NO_FIELDS, proj..., addon)
+    end
+    return muladd(u, vt, z), muladd_pullback_3
+end
+
 #####
 ##### `/`
 #####

--- a/src/rulesets/Base/arraymath.jl
+++ b/src/rulesets/Base/arraymath.jl
@@ -122,9 +122,8 @@ function rrule(
         elseif z isa Number
             @thunk(sum(Ȳ))
         else
-            T = eltype(Ȳ)
             InplaceableThunk(
-                @thunk(sum!(similar(z, T), Ȳ)),
+                @thunk(sum!(similar(z, eltype(Ȳ)), Ȳ)),
                 dz -> sum!(dz, Ȳ; init=false)
             )
         end
@@ -171,9 +170,8 @@ function rrule(
         elseif z isa Number
             @thunk(sum(Ȳ))
         else
-            T = eltype(Ȳ)
             InplaceableThunk(
-                @thunk(sum!(similar(z, T), Ȳ)),
+                @thunk(sum!(similar(z, eltype(Ȳ)), Ȳ)),
                 dz -> sum!(dz, Ȳ; init=false)
             )
         end

--- a/test/rulesets/Base/arraymath.jl
+++ b/test/rulesets/Base/arraymath.jl
@@ -65,7 +65,7 @@
     _adjoint(x) = x'
     _adjoint(::Nothing) = nothing
 
-    VERSION >= v"1.6.0-DEV.1536" && @testset "muladd: $T" for T in (Float64, ComplexF64)
+    @testset "muladd: $T" for T in (Float64, ComplexF64)
         @testset "add $(typeof(z))" for z in [rand(T), rand(T, 3), rand(T, 3, 3), false]
             dz = if z===false
                 nothing  # gradient for z::Bool is tested to be DoesNotExist()

--- a/test/rulesets/Base/arraymath.jl
+++ b/test/rulesets/Base/arraymath.jl
@@ -63,6 +63,52 @@
     end
 
 
+    VERSION >= v"1.6.0-DEV.1536" && @testset "muladd: $T" for T in (Float64, ComplexF64)
+        @testset "add $(typeof(z))" for z in [rand(T), rand(T,3), rand(T,3,3)] #, false]
+            dz = rand(T, fill(3, ndims(z))...)
+            @testset "matrix * matrix" begin
+                A, B = rand(T,3,3), rand(T,3,3)
+                dA, dB = rand(T,3,3), rand(T,3,3)
+                rrule_test(muladd, A*B.+z, (A, dA), (B, dB), (z, dz))
+                rrule_test(muladd, A'*B.+z, (A', dA'), (B, dB), (z, dz))
+                rrule_test(muladd, A*B'.+z, (A, dA), (B', dB'), (z, dz))
+            end
+            if ndims(z) <= 1
+                @testset "matrix * vector" begin
+                    A, B = rand(T,3,3), rand(T,3)
+                    dA, dB = rand(T,3,3), rand(T,3)
+                    rrule_test(muladd, A*B.+z, (A, dA), (B, dB), (z, dz))
+                    dA, dB = rand(T,3,3), rand(T,3,1)
+                    rrule_test(muladd, A*B.+z, (A, dA), (B, dB), (z, dz))
+                end
+                @testset "adjoint * matrix" begin
+                    At, B, zt = rand(T,3)', rand(T,3,3), z'
+                    dAt, dB, dzt = rand(T,3)', rand(T,3,3), z'
+                    rrule_test(muladd, At*B.+zt, (At, dAt), (B, dB), (zt, dzt))
+                    dAt, dB, dzt = rand(T,1,3), rand(T,3,3), z'
+                    rrule_test(muladd, At*B.+zt, (At, dAt), (B, dB), (zt, dzt))
+                end
+            end
+            if ndims(z) == 0
+                @testset "adjoint * vector" begin # like dot
+                    A, B = rand(T,3)', rand(T,3)
+                    dA, dB = rand(T,3)', rand(T,3)
+                    rrule_test(muladd, A*B.+z, (A, dA), (B, dB), (z, dz))
+                    dA, dB = rand(T,1,3), rand(T,3)
+                    rrule_test(muladd, A*B.+z, (A, dA), (B, dB), (z, dz))
+                end
+            end
+            if ndims(z) == 2
+                @testset "vector * adjoint" begin # outer product
+                    A, B = rand(T,3), rand(T,3)'
+                    dA, dB = rand(T,3), rand(T,3)'
+                    rrule_test(muladd, A*B.+z, (A, dA), (B, dB), (z, dz))
+                    dA, dB = rand(T,3), rand(T,1,3)
+                    rrule_test(muladd, A*B.+z, (A, dA), (B, dB), (z, dz))
+                end
+            end
+        end
+    end
     @testset "$f" for f in (/, \)
         @testset "Matrix" begin
             for n in 3:5, m in 3:5

--- a/test/rulesets/Base/arraymath.jl
+++ b/test/rulesets/Base/arraymath.jl
@@ -98,6 +98,15 @@
                     rrule_test(muladd, A*B.+z, (A, dA), (B, dB), (z, dz))
                 end
             end
+            if ndims(z) == 2 # other dims lead to e.g. muladd(ones(4), ones(1,4), 1)
+                @testset "vector * adjoint" begin # outer product
+                    A, B = rand(T,3), rand(T,3)'
+                    dA, dB = rand(T,3), rand(T,3)'
+                    rrule_test(muladd, A*B.+z, (A, dA), (B, dB), (z, dz))
+                    dA, dB = rand(T,3), rand(T,1,3)
+                    rrule_test(muladd, A*B.+z, (A, dA), (B, dB), (z, dz))
+                end
+            end
         end
     end
     @testset "$f" for f in (/, \)

--- a/test/rulesets/Base/arraymath.jl
+++ b/test/rulesets/Base/arraymath.jl
@@ -62,10 +62,16 @@
         end
     end
 
+    _adjoint(x) = x'
+    _adjoint(::Nothing) = nothing
 
     VERSION >= v"1.6.0-DEV.1536" && @testset "muladd: $T" for T in (Float64, ComplexF64)
-        @testset "add $(typeof(z))" for z in [rand(T), rand(T, 3), rand(T, 3, 3)] #, false]
-            dz = rand(T, fill(3, ndims(z))...)
+        @testset "add $(typeof(z))" for z in [rand(T), rand(T, 3), rand(T, 3, 3), false]
+            dz = if z===false
+                nothing  # gradient for z::Bool is tested to be DoesNotExist()
+            else
+                rand(T, fill(3, ndims(z))...)
+            end
             @testset "matrix * matrix" begin
                 A, B = rand(T, 3, 3), rand(T, 3, 3)
                 dA, dB = rand(T, 3, 3), rand(T, 3, 3)
@@ -85,10 +91,10 @@
                     rrule_test(muladd, A*B.+z, (A, dA), (B, dB), (z, dz))
                 end
                 @testset "adjoint * matrix" begin
-                    At, B, zt = rand(T, 3)', rand(T, 3, 3), z'
-                    dAt, dB, dzt = rand(T, 3)', rand(T, 3, 3), z'
+                    At, B, zt = rand(T, 3)', rand(T, 3, 3), _adjoint(z)
+                    dAt, dB, dzt = rand(T, 3)', rand(T, 3, 3), _adjoint(dz)
                     rrule_test(muladd, At*B.+zt, (At, dAt), (B, dB), (zt, dzt))
-                    dAt, dB, dzt = rand(T,1,3), rand(T, 3, 3), z'
+                    dAt, dB, dzt = rand(T,1,3), rand(T, 3, 3), _adjoint(dz)
                     rrule_test(muladd, At*B.+zt, (At, dAt), (B, dB), (zt, dzt))
                 end
             end

--- a/test/rulesets/Base/arraymath.jl
+++ b/test/rulesets/Base/arraymath.jl
@@ -98,15 +98,6 @@
                     rrule_test(muladd, A*B.+z, (A, dA), (B, dB), (z, dz))
                 end
             end
-            if ndims(z) == 2
-                @testset "vector * adjoint" begin # outer product
-                    A, B = rand(T,3), rand(T,3)'
-                    dA, dB = rand(T,3), rand(T,3)'
-                    rrule_test(muladd, A*B.+z, (A, dA), (B, dB), (z, dz))
-                    dA, dB = rand(T,3), rand(T,1,3)
-                    rrule_test(muladd, A*B.+z, (A, dA), (B, dB), (z, dz))
-                end
-            end
         end
     end
     @testset "$f" for f in (/, \)

--- a/test/rulesets/Base/arraymath.jl
+++ b/test/rulesets/Base/arraymath.jl
@@ -64,46 +64,46 @@
 
 
     VERSION >= v"1.6.0-DEV.1536" && @testset "muladd: $T" for T in (Float64, ComplexF64)
-        @testset "add $(typeof(z))" for z in [rand(T), rand(T,3), rand(T,3,3)] #, false]
+        @testset "add $(typeof(z))" for z in [rand(T), rand(T, 3), rand(T, 3, 3)] #, false]
             dz = rand(T, fill(3, ndims(z))...)
             @testset "matrix * matrix" begin
-                A, B = rand(T,3,3), rand(T,3,3)
-                dA, dB = rand(T,3,3), rand(T,3,3)
+                A, B = rand(T, 3, 3), rand(T, 3, 3)
+                dA, dB = rand(T, 3, 3), rand(T, 3, 3)
                 rrule_test(muladd, A*B.+z, (A, dA), (B, dB), (z, dz))
                 rrule_test(muladd, A'*B.+z, (A', dA'), (B, dB), (z, dz))
                 rrule_test(muladd, A*B'.+z, (A, dA), (B', dB'), (z, dz))
             end
             if ndims(z) <= 1
                 @testset "matrix * vector" begin
-                    A, B = rand(T,3,3), rand(T,3)
-                    dA, dB = rand(T,3,3), rand(T,3)
+                    A, B = rand(T, 3, 3), rand(T, 3)
+                    dA, dB = rand(T, 3, 3), rand(T, 3)
                     rrule_test(muladd, A*B.+z, (A, dA), (B, dB), (z, dz))
-                    dA, dB = rand(T,3,3), rand(T,3,1)
+                    dA, dB = rand(T, 3, 3), rand(T, 3,1)
                     rrule_test(muladd, A*B.+z, (A, dA), (B, dB), (z, dz))
                 end
                 @testset "adjoint * matrix" begin
-                    At, B, zt = rand(T,3)', rand(T,3,3), z'
-                    dAt, dB, dzt = rand(T,3)', rand(T,3,3), z'
+                    At, B, zt = rand(T, 3)', rand(T, 3, 3), z'
+                    dAt, dB, dzt = rand(T, 3)', rand(T, 3, 3), z'
                     rrule_test(muladd, At*B.+zt, (At, dAt), (B, dB), (zt, dzt))
-                    dAt, dB, dzt = rand(T,1,3), rand(T,3,3), z'
+                    dAt, dB, dzt = rand(T,1,3), rand(T, 3, 3), z'
                     rrule_test(muladd, At*B.+zt, (At, dAt), (B, dB), (zt, dzt))
                 end
             end
             if ndims(z) == 0
                 @testset "adjoint * vector" begin # like dot
-                    A, B = rand(T,3)', rand(T,3)
-                    dA, dB = rand(T,3)', rand(T,3)
+                    A, B = rand(T, 3)', rand(T, 3)
+                    dA, dB = rand(T, 3)', rand(T, 3)
                     rrule_test(muladd, A*B.+z, (A, dA), (B, dB), (z, dz))
-                    dA, dB = rand(T,1,3), rand(T,3)
+                    dA, dB = rand(T,1,3), rand(T, 3)
                     rrule_test(muladd, A*B.+z, (A, dA), (B, dB), (z, dz))
                 end
             end
             if ndims(z) == 2 # other dims lead to e.g. muladd(ones(4), ones(1,4), 1)
                 @testset "vector * adjoint" begin # outer product
-                    A, B = rand(T,3), rand(T,3)'
-                    dA, dB = rand(T,3), rand(T,3)'
+                    A, B = rand(T, 3), rand(T, 3)'
+                    dA, dB = rand(T, 3), rand(T, 3)'
                     rrule_test(muladd, A*B.+z, (A, dA), (B, dB), (z, dz))
-                    dA, dB = rand(T,3), rand(T,1,3)
+                    dA, dB = rand(T, 3), rand(T,1,3)
                     rrule_test(muladd, A*B.+z, (A, dA), (B, dB), (z, dz))
                 end
             end

--- a/test/rulesets/Base/arraymath.jl
+++ b/test/rulesets/Base/arraymath.jl
@@ -72,6 +72,9 @@
                 rrule_test(muladd, A*B.+z, (A, dA), (B, dB), (z, dz))
                 rrule_test(muladd, A'*B.+z, (A', dA'), (B, dB), (z, dz))
                 rrule_test(muladd, A*B'.+z, (A, dA), (B', dB'), (z, dz))
+                A, B = rand(T, 3, 5), rand(T, 5, 3)
+                dA, dB = rand(T, 3, 5), rand(T, 5, 3)
+                rrule_test(muladd, A*B.+z, (A, dA), (B, dB), (z, dz))
             end
             if ndims(z) <= 1
                 @testset "matrix * vector" begin


### PR DESCRIPTION
This is just #312. by @mcabbott  with 2 commits of mine tacked on the end.
It took me so long to merge #312 that how we tested rules had changed, 
so this PR adds to #312 the changes nessecary to work with the newer version of ChainRulesTestUtils
Also fixes type inference.
Which was failing cos julia doesn't specialize on types that were closed over.

It does require https://github.com/JuliaDiff/FiniteDifferences.jl/pull/165 first
