### PR TITLE
stop CI testing every  OS

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,15 +19,9 @@ jobs:
           - "1"    # Latest Release
         os:
           - ubuntu-latest
-          - macOS-latest
-          - windows-latest
         arch:
           - x86
           - x64
-        exclude:
-          # 32-bit Julia binaries are not available on macOS
-          - os: macOS-latest
-            arch: x86
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/JuliaNightly.yml
+++ b/.github/workflows/JuliaNightly.yml
@@ -19,15 +19,9 @@ jobs:
           - 'nightly'
         os:
           - ubuntu-latest
-          - macOS-latest
-          - windows-latest
         arch:
           - x86
           - x64
-        exclude:
-          # 32-bit Julia binaries are not available on macOS
-          - os: macOS-latest
-            arch: x86
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1


### PR DESCRIPTION
This package is pretty much OS agnostic.
I say we disable them until someone opens an issue saying something doesn't work on Windows etc.

A possibly alternative to this PR.
Would be to mix our matrix over the "diagonal".
So e.g.
 - Julia 1.0, Mac, 64 bit
 - Julia 1.0, Ubuntu, 32 bit
 - Julia 1.x, Windows, 32 bit
 gives use coverage of all OS and all julia version and all archetectures.
 
 And maybe for bit more completeness:
 - Julia 1.x, Ununtu, 64 bit
 
But writing GHA for that is a bit annoying, so could be a follow up PR