### PR TITLE
Allow division by complex numbers

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "0.8.7"
+version = "0.8.8"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/rulesets/Base/arraymath.jl
+++ b/src/rulesets/Base/arraymath.jl
@@ -235,12 +235,13 @@ function rrule(::typeof(/), A::AbstractArray{<:CommutativeMulNumber}, b::Commuta
     return Y, slash_pullback_scalar
 end
 
-function rrule(::typeof(\), b::Real, A::AbstractArray{<:Real})
-    Y = b\A
-    function backslash_pullback_scalar(Ȳ)
-        return (NoTangent(), @thunk(-dot(A,Ȳ) / b^2), @thunk(Ȳ / conj(b)))
+function rrule(::typeof(\), b::CommutativeMulNumber, A::AbstractArray{<:CommutativeMulNumber})
+    Y, back = rrule(/, A, b)
+    function backslash_pullback(dY)  # just reverses the arguments!
+        d0, dA, db = back(dY)
+        return (d0, db, dA)
     end
-    return Y, backslash_pullback_scalar
+    return Y, backslash_pullback
 end
 
 #####

--- a/src/rulesets/Base/arraymath.jl
+++ b/src/rulesets/Base/arraymath.jl
@@ -227,20 +227,20 @@ end
 ##### `\`, `/` matrix-scalar_rule
 #####
 
-function rrule(::typeof(/), A::AbstractArray{<:Real}, b::Real)
+function rrule(::typeof(/), A::AbstractArray{<:CommutativeMulNumber}, b::CommutativeMulNumber)
     Y = A/b
-    function slash_pullback(Ȳ)
-        return (NoTangent(), @thunk(Ȳ/b), @thunk(-dot(Ȳ, Y)/b))
+    function slash_pullback_scalar(Ȳ)
+        return (NoTangent(), @thunk(Ȳ / conj(b)), @thunk(-dot(A,Ȳ) / b^2))
     end
-    return Y, slash_pullback
+    return Y, slash_pullback_scalar
 end
 
 function rrule(::typeof(\), b::Real, A::AbstractArray{<:Real})
     Y = b\A
-    function backslash_pullback(Ȳ)
-        return (NoTangent(), @thunk(-dot(Ȳ, Y)/b), @thunk(Ȳ/b))
+    function backslash_pullback_scalar(Ȳ)
+        return (NoTangent(), @thunk(-dot(A,Ȳ) / b^2), @thunk(Ȳ / conj(b)))
     end
-    return Y, backslash_pullback
+    return Y, backslash_pullback_scalar
 end
 
 #####

--- a/src/rulesets/Base/arraymath.jl
+++ b/src/rulesets/Base/arraymath.jl
@@ -230,7 +230,12 @@ end
 function rrule(::typeof(/), A::AbstractArray{<:CommutativeMulNumber}, b::CommutativeMulNumber)
     Y = A/b
     function slash_pullback_scalar(Ȳ)
-        return (NoTangent(), @thunk(Ȳ / conj(b)), @thunk(-dot(A,Ȳ) / b^2))
+        Athunk = InplaceableThunk(
+            @thunk(Ȳ / conj(b)),
+            dA -> dA .+= Ȳ ./ conj(b),
+        )
+        bthunk = @thunk(-dot(A,Ȳ) / conj(b^2))
+        return (NoTangent(), Athunk, bthunk)
     end
     return Y, slash_pullback_scalar
 end

--- a/test/rulesets/Base/arraymath.jl
+++ b/test/rulesets/Base/arraymath.jl
@@ -132,9 +132,19 @@
     end
 
     @testset "/ and \\ Scalar-AbstractArray" begin
-        A = randn(3, 4, 5)
+        A = round.(10 .* randn(3, 4, 5), digits=1)
         test_rrule(/, A, 7.2)
         test_rrule(\, 7.2, A)
+
+        # test_rrule(/, A, 7.2+8.3im)
+        # test_rrule(\, 7.2+8.3im, A)
+
+        C = round.(10 .* randn(6) .+ im .* 10 .* randn(6), digits=1)
+        # test_rrule(/, C, 7.2)
+        # test_rrule(\, 7.2, C)
+
+        test_rrule(/, C, 7.2+8.3im)
+        test_rrule(\, 7.2+8.3im, C)
     end
 
     @testset "negation" begin

--- a/test/rulesets/Base/arraymath.jl
+++ b/test/rulesets/Base/arraymath.jl
@@ -136,13 +136,7 @@
         test_rrule(/, A, 7.2)
         test_rrule(\, 7.2, A)
 
-        # test_rrule(/, A, 7.2+8.3im)
-        # test_rrule(\, 7.2+8.3im, A)
-
         C = round.(10 .* randn(6) .+ im .* 10 .* randn(6), digits=1)
-        # test_rrule(/, C, 7.2)
-        # test_rrule(\, 7.2, C)
-
         test_rrule(/, C, 7.2+8.3im)
         test_rrule(\, 7.2+8.3im, C)
     end


### PR DESCRIPTION
Fixes this:
```
julia> Zygote.gradient(x -> sum(abs, x / im), [1+im])
ERROR: StackOverflowError:
Stacktrace:
     [1] map
       @ ./tuple.jl:216 [inlined]
     [2] _pullback(::Zygote.Context, ::typeof(Core._apply_iterate), ::typeof(iterate), ::Function, ::Tuple{typeof(/)}, ::Tuple{Vector{Complex{Int64}}, Complex{Bool}})
       @ Zygote ~/.julia/dev/ZygoteRules/src/adjoint.jl:60
     [3] _pullback
       @ ./broadcast.jl:871 [inlined]
     [4] _pullback(::Zygote.Context, ::typeof(Base.Broadcast.broadcast_preserving_zero_d), ::typeof(/), ::Vector{Complex{Int64}}, ::Complex{Bool})
       @ Zygote ~/.julia/dev/Zygote/src/compiler/interface2.jl:0
```