### PR TITLE
fix #379: numeric instabilities in eigen tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "0.8.8"
+version = "0.8.9"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/test/rulesets/LinearAlgebra/factorization.jl
+++ b/test/rulesets/LinearAlgebra/factorization.jl
@@ -29,14 +29,14 @@ function rand_eigen(T::Type, n::Int)
     _rand(T, n...) = rand(T, n...) .* rand(T <: Complex ? [1, im, -1, -im] : [1, -1], n...)
 
     # make sure that each eigenvector has one clearly defined entry with maximum magnitude
-    # so that the normalization of EVs is well defined
+    # so that the complex phase of EVs is well defined
     V = _rand(T, n, n)
     for (col, i) in zip(eachcol(V), shuffle(1:n))
         col[i] += 3 * (T <: Complex ? cispi(2rand()) : rand([1, -1]))
         normalize!(col)
     end
 
-    # make sure the sorting of eigen values is well defined
+    # make sure the sorting of eigenvalues is well defined
     λ = 10(_rand(T, n) .+ (0:3:3(n-1)))
 
     return V * Diagonal(λ) / V

--- a/test/rulesets/LinearAlgebra/factorization.jl
+++ b/test/rulesets/LinearAlgebra/factorization.jl
@@ -213,7 +213,7 @@ const LU_NO_PIVOT = VERSION >= v"1.7.0-DEV.1188" ? NoPivot() : Val(false)
                 _, X̄_vectors_ad = @maybe_inferred back(CT(vectors = V̄))
                 # need the conversion to `complex` here, since FiniteDiff is currently buggy if functions
                 # return arrays of either real or complex values based solely on the input values (not the
-                # input types)
+                # input types). See https://github.com/JuliaLang/julia/issues/41243
                 @test X̄_vectors_ad ≈ j′vp(_fdm, x -> complex.(eigen(x).vectors), complex.(V̄), X)[1] rtol=1e-6
                 F̄ = CT(values = λ̄, vectors = V̄)
                 s̄elf, X̄_ad = @maybe_inferred back(F̄)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@ using ChainRules
 using ChainRulesCore
 using ChainRulesTestUtils
 using ChainRulesTestUtils: rand_tangent, _fdm
-using Compat: hasproperty, only
+using Compat: hasproperty, only, cispi
 using FiniteDifferences
 using FiniteDifferences: rand_tangent
 using LinearAlgebra

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@ using ChainRules
 using ChainRulesCore
 using ChainRulesTestUtils
 using ChainRulesTestUtils: rand_tangent, _fdm
-using Compat: hasproperty, only, cispi
+using Compat: hasproperty, only, cispi, eachcol
 using FiniteDifferences
 using FiniteDifferences: rand_tangent
 using LinearAlgebra


### PR DESCRIPTION
This was causing failures on nightly again. From running these tests a
bunch of times, there is still an approximately 3% chance that they will
fail randomly, but I think that's probably acceptable.