### PR TITLE
add nondiff rule for `similar`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "0.8.8"
+version = "0.8.9"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/rulesets/Base/nondiff.jl
+++ b/src/rulesets/Base/nondiff.jl
@@ -436,3 +436,5 @@ VERSION >= v"1.1" && @non_differentiable Sys.isopenbsd(::Symbol)
 @non_differentiable Threads.nthreads()
 @non_differentiable Threads.threadid()
 @non_differentiable Threads.threadid(::Task)
+
+@non_differentiable similar(::Any...)


### PR DESCRIPTION
This allows Zygote to correctly differentiate things like
`rand!(similar(x))`. Since the output of `similar` does not have a
derivative with respect to the input arguments, this seems reasonable to
me.

fixes FluxML/Zygote.jl#997