### PR TITLE
Improved rules for `cat`s

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 [compat]
 ChainRulesCore = "0.10.4"
 ChainRulesTestUtils = "0.7.9"
-Compat = "3.30"
+Compat = "3.31"
 FiniteDifferences = "0.12.8"
 StaticArrays = "1.2"
 julia = "1"

--- a/src/rulesets/Base/array.jl
+++ b/src/rulesets/Base/array.jl
@@ -42,9 +42,12 @@ function rrule(::typeof(hcat), Xs::Union{AbstractArray, Number}...)
                 end
             end
             if ndimsX > 0
-                InplaceableThunk(@thunk(dY[ind...]), dX -> dX .+= view(dY, ind...))
-            else
+                # Here InplaceableThunk breaks @inferred, removed for now
+                # InplaceableThunk(@thunk(dY[ind...]), dX -> dX .+= view(dY, ind...))
                 dY[ind...]
+            else
+                # This is a hack to perhaps avoid GPU scalar indexing
+                sum(view(dY, ind...))
             end
         end
         return (NoTangent(), dXs...)
@@ -98,9 +101,10 @@ function rrule(::typeof(vcat), Xs::Union{AbstractArray, Number}...)
                 end
             end
             if ndimsX > 0
-                InplaceableThunk(@thunk(dY[ind...]), dX -> dX .+= view(dY, ind...))
-            else
+                # InplaceableThunk(@thunk(dY[ind...]), dX -> dX .+= view(dY, ind...))
                 dY[ind...]
+            else
+                sum(view(dY, ind...))
             end
         end
         return (NoTangent(), dXs...)
@@ -151,9 +155,10 @@ function rrule(::typeof(cat), Xs::Union{AbstractArray, Number}...; dims)
                 prev[d] += get(sizeX, d, 1)
             end
             if ndimsX > 0
-                InplaceableThunk(@thunk(dY[index...]), dX -> dX .+= view(dY, index...))
-            else
+                # InplaceableThunk(@thunk(dY[index...]), dX -> dX .+= view(dY, index...))
                 dY[index...]
+            else
+                sum(view(dY, index...))
             end
         end
         return (NoTangent(), dXs...)

--- a/src/rulesets/Base/array.jl
+++ b/src/rulesets/Base/array.jl
@@ -24,9 +24,7 @@ end
 ##### `hcat` (🐈)
 #####
 
-using Compat # get here needs Compat 3.31
-
-function rrule(::typeof(hcat), Xs...)
+function rrule(::typeof(hcat), Xs::Union{AbstractArray, Number}...)
     Y = hcat(Xs...)  # note that Y always has 1-based indexing, even if X isa OffsetArray
     ndimsY = Val(ndims(Y))  # this avoids closing over Y, Val() is essential for type-stability
     sizes = map(size, Xs)   # this avoids closing over Xs
@@ -82,7 +80,7 @@ end
 ##### `vcat`
 #####
 
-function rrule(::typeof(vcat), Xs...)
+function rrule(::typeof(vcat), Xs::Union{AbstractArray, Number}...)
     Y = vcat(Xs...)
     ndimsY = Val(ndims(Y))
     sizes = map(size, Xs)
@@ -133,7 +131,7 @@ end
 
 _val(::Val{x}) where {x} = x
 
-function rrule(::typeof(cat), Xs...; dims)
+function rrule(::typeof(cat), Xs::Union{AbstractArray, Number}...; dims)
     Y = cat(Xs...; dims=dims)
     cdims = dims isa Val ? Int(_val(dims)) : dims isa Integer ? Int(dims) : Tuple(dims)
     ndimsY = Val(ndims(Y))
@@ -167,7 +165,7 @@ end
 ##### `hvcat`
 #####
 
-function rrule(::typeof(hvcat), rows, values...)
+function rrule(::typeof(hvcat), rows, values::Union{AbstractArray, Number}...)
     Y = hvcat(rows, values...)
     cols = size(Y,2)
     ndimsY = Val(ndims(Y))

--- a/src/rulesets/Base/array.jl
+++ b/src/rulesets/Base/array.jl
@@ -43,8 +43,11 @@ function rrule(::typeof(hcat), Xs...)
                     d > ndimsX ? 1 : (:)
                 end
             end
-            dY[ind...]  # no thunk as Xs may have 1 arg but 1 thunk is disallowed,
-                        # and perhaps better to GC clean up dY.
+            if ndimsX > 0
+                InplaceableThunk(@tunk(dY[ind...]), dX -> dX .+= view(dY, ind...))
+            else
+                dY[ind...]
+            end
         end
         return (NoTangent(), dXs...)
     end
@@ -96,7 +99,11 @@ function rrule(::typeof(vcat), Xs...)
                     d > ndimsX ? 1 : (:)
                 end
             end
-            dY[ind...]
+            if ndimsX > 0
+                InplaceableThunk(@tunk(dY[ind...]), dX -> dX .+= view(dY, ind...))
+            else
+                dY[ind...]
+            end
         end
         return (NoTangent(), dXs...)
     end
@@ -145,7 +152,11 @@ function rrule(::typeof(cat), Xs...; dims)
             for d in cdims
                 prev[d] += get(sizeX, d, 1)
             end
-            dY[index...]
+            if ndimsX > 0
+                InplaceableThunk(@tunk(dY[index...]), dX -> dX .+= view(dY, index...))
+            else
+                dY[index...]
+            end
         end
         return (NoTangent(), dXs...)
     end

--- a/src/rulesets/Base/array.jl
+++ b/src/rulesets/Base/array.jl
@@ -47,7 +47,7 @@ function rrule(::typeof(hcat), Xs...)
             dY[ind...]  # no thunk as Xs may have 1 arg but 1 thunk is disallowed,
                         # and perhaps better to GC clean up dY.
         end
-        return (NO_FIELDS, dXs...)
+        return (NoTangent(), dXs...)
     end
     return Y, 🐈_pullback
 end
@@ -71,7 +71,7 @@ function rrule(::typeof(reduce), ::typeof(hcat), As::AbstractVector{<:AbstractVe
     function reduce_hcat_pullback_1(dY)
         hi = Ref(0)
         dAs = map(_ -> dY[:, hi[]+=1], axe)
-        return (NO_FIELDS, DoesNotExist(), dAs)
+        return (NoTangent(), NoTangent(), dAs)
     end
     return reduce(hcat, As), reduce_hcat_pullback_1
 end
@@ -99,7 +99,7 @@ function rrule(::typeof(vcat), Xs...)
             end
             dY[ind...]
         end
-        return (NO_FIELDS, dXs...)
+        return (NoTangent(), dXs...)
     end
     return Y, vcat_pullback
 end
@@ -148,7 +148,7 @@ function rrule(::typeof(cat), Xs...; dims)
             end
             dY[index...]
         end
-        return (NO_FIELDS, dXs...)
+        return (NoTangent(), dXs...)
     end
     return Y, cat_pullback
 end
@@ -180,7 +180,7 @@ function rrule(::typeof(hvcat), rows, values...)
             end
             dY[index...]
         end
-        return (NO_FIELDS, DoesNotExist(), dXs...)
+        return (NoTangent(), NoTangent(), dXs...)
     end
     return Y, hvcat_pullback
 end

--- a/src/rulesets/Base/array.jl
+++ b/src/rulesets/Base/array.jl
@@ -24,8 +24,7 @@ end
 ##### `hcat` (🐈)
 #####
 
-# work around https://github.com/JuliaLang/julia/issues/40809
-_get(x::Tuple, i::Int, default) = i in 1:length(x) ? x[i] : default
+using Compat # get here needs Compat 3.31
 
 function rrule(::typeof(hcat), Xs...)
     Y = hcat(Xs...)  # note that Y always has 1-based indexing, even if X isa OffsetArray
@@ -36,7 +35,7 @@ function rrule(::typeof(hcat), Xs...)
         dXs = map(sizes) do sizeX
             ndimsX = length(sizeX)
             lo = hi[] + 1
-            hi[] += _get(sizeX, 2, 1)
+            hi[] += get(sizeX, 2, 1)
             ind = ntuple(ndimsY) do d
                 if d==2
                     d > ndimsX ? lo : lo:hi[]
@@ -89,7 +88,7 @@ function rrule(::typeof(vcat), Xs...)
         dXs = map(sizes) do sizeX
             ndimsX = length(sizeX)
             lo = hi[] + 1
-            hi[] += _get(sizeX, 1, 1)
+            hi[] += get(sizeX, 1, 1)
             ind = ntuple(ndimsY) do d
                 if d==1
                     d > ndimsX ? lo : lo:hi[]
@@ -144,7 +143,7 @@ function rrule(::typeof(cat), Xs...; dims)
                 end
             end
             for d in cdims
-                prev[d] += _get(sizeX, d, 1)
+                prev[d] += get(sizeX, d, 1)
             end
             dY[index...]
         end
@@ -173,10 +172,10 @@ function rrule(::typeof(hvcat), rows, values...)
                     d > ndimsX ? 1 : (:)
                 end
             end
-            prev[2] += _get(sizeX, 2, 1)
+            prev[2] += get(sizeX, 2, 1)
             if prev[2] == cols
                 prev[2] = 0
-                prev[1] += _get(sizeX, 1, 1)
+                prev[1] += get(sizeX, 1, 1)
             end
             dY[index...]
         end

--- a/src/rulesets/Base/array.jl
+++ b/src/rulesets/Base/array.jl
@@ -44,7 +44,7 @@ function rrule(::typeof(hcat), Xs...)
                 end
             end
             if ndimsX > 0
-                InplaceableThunk(@tunk(dY[ind...]), dX -> dX .+= view(dY, ind...))
+                InplaceableThunk(@thunk(dY[ind...]), dX -> dX .+= view(dY, ind...))
             else
                 dY[ind...]
             end
@@ -100,7 +100,7 @@ function rrule(::typeof(vcat), Xs...)
                 end
             end
             if ndimsX > 0
-                InplaceableThunk(@tunk(dY[ind...]), dX -> dX .+= view(dY, ind...))
+                InplaceableThunk(@thunk(dY[ind...]), dX -> dX .+= view(dY, ind...))
             else
                 dY[ind...]
             end
@@ -153,7 +153,7 @@ function rrule(::typeof(cat), Xs...; dims)
                 prev[d] += get(sizeX, d, 1)
             end
             if ndimsX > 0
-                InplaceableThunk(@tunk(dY[index...]), dX -> dX .+= view(dY, index...))
+                InplaceableThunk(@thunk(dY[index...]), dX -> dX .+= view(dY, index...))
             else
                 dY[index...]
             end

--- a/src/rulesets/Base/array.jl
+++ b/src/rulesets/Base/array.jl
@@ -128,7 +128,7 @@ end
 _val(::Val{x}) where {x} = x
 
 function rrule(::typeof(cat), Xs...; dims)
-    Y = cat(Xs...; dims)
+    Y = cat(Xs...; dims=dims)
     cdims = dims isa Val ? Int(_val(dims)) : dims isa Integer ? Int(dims) : Tuple(dims)
     ndimsY = Val(ndims(Y))
     sizes = map(size, Xs)

--- a/test/rulesets/Base/array.jl
+++ b/test/rulesets/Base/array.jl
@@ -5,9 +5,9 @@
 end
 
 @testset "hcat" begin
-    test_rrule(hcat, randn(3, 2), randn(3), randn(3, 3))
-    test_rrule(hcat, rand(), rand(1,2), rand(1,2,1))
-    test_rrule(hcat, rand(3,1,1,2), rand(3,3,1,2))
+    test_rrule(hcat, randn(3, 2), randn(3), randn(3, 3); check_inferred=VERSION>v"1.1")
+    test_rrule(hcat, rand(), rand(1,2), rand(1,2,1); check_inferred=VERSION>v"1.1")
+    test_rrule(hcat, rand(3,1,1,2), rand(3,3,1,2); check_inferred=VERSION>v"1.1")
 end
 
 @testset "reduce hcat" begin
@@ -27,10 +27,10 @@ end
 end
 
 @testset "vcat" begin
-    test_rrule(vcat, randn(2, 4), randn(1, 4), randn(3, 4))
-    test_rrule(vcat, rand(), rand())
-    test_rrule(vcat, rand(), rand(3), rand(3,1,1))
-    test_rrule(vcat, rand(3,1,2), rand(4,1,2))
+    test_rrule(vcat, randn(2, 4), randn(1, 4), randn(3, 4); check_inferred=VERSION>v"1.1")
+    test_rrule(vcat, rand(), rand(); check_inferred=VERSION>v"1.1")
+    test_rrule(vcat, rand(), rand(3), rand(3,1,1); check_inferred=VERSION>v"1.1")
+    test_rrule(vcat, rand(3,1,2), rand(4,1,2); check_inferred=VERSION>v"1.1")
 end
 
 @testset "reduce vcat" begin
@@ -45,17 +45,17 @@ end
 end
 
 @testset "cat" begin
-    test_rrule(cat, rand(2, 4), rand(1, 4); fkwargs=(dims=1,))
-    test_rrule(cat, rand(2, 4), rand(2); fkwargs=(dims=Val(2),))
-    test_rrule(cat, rand(), rand(2, 3); fkwargs=(dims=[1,2],))
+    test_rrule(cat, rand(2, 4), rand(1, 4); fkwargs=(dims=1,), check_inferred=VERSION>v"1.1")
+    test_rrule(cat, rand(2, 4), rand(2); fkwargs=(dims=Val(2),), check_inferred=VERSION>v"1.1")
+    test_rrule(cat, rand(), rand(2, 3); fkwargs=(dims=[1,2],), check_inferred=VERSION>v"1.1")
     test_rrule(cat, rand(1), rand(3, 2, 1); fkwargs=(dims=(1,2),), check_inferred=false) # infers Tuple{Zero, Vector{Float64}, Any}
 end
 
 @testset "hvcat" begin
-    test_rrule(hvcat, 2 ⊢ NoTangent(), rand(ComplexF64, 6)...)
-    test_rrule(hvcat, (2, 1) ⊢ NoTangent(), rand(), rand(1,1), rand(2,2))
-    test_rrule(hvcat, 1 ⊢ NoTangent(), rand(3)' ⊢ rand(1,3), transpose(rand(3)) ⊢ rand(1,3))
-    test_rrule(hvcat, 1 ⊢ NoTangent(), rand(0,3), rand(2,3), rand(1,3,1))
+    test_rrule(hvcat, 2 ⊢ NoTangent(), rand(ComplexF64, 6)...; check_inferred=VERSION>v"1.1")
+    test_rrule(hvcat, (2, 1) ⊢ NoTangent(), rand(), rand(1,1), rand(2,2); check_inferred=VERSION>v"1.1")
+    test_rrule(hvcat, 1 ⊢ NoTangent(), rand(3)' ⊢ rand(1,3), transpose(rand(3)) ⊢ rand(1,3); check_inferred=VERSION>v"1.1")
+    test_rrule(hvcat, 1 ⊢ NoTangent(), rand(0,3), rand(2,3), rand(1,3,1); check_inferred=VERSION>v"1.1")
 end
 
 @testset "fill" begin

--- a/test/rulesets/Base/array.jl
+++ b/test/rulesets/Base/array.jl
@@ -5,10 +5,9 @@
 end
 
 @testset "hcat" begin
-    A = randn(3, 2)
-    B = randn(3)
-    C = randn(3, 3)
-    test_rrule(hcat, A, B, C; check_inferred=false)
+    test_rrule(hcat, randn(3, 2), randn(3), randn(3, 3))
+    test_rrule(hcat, rand(), rand(1,2), rand(1,2,1))
+    test_rrule(hcat, rand(3,1,1,2), rand(3,3,1,2))
 end
 
 @testset "reduce hcat" begin
@@ -19,10 +18,10 @@ end
 end
 
 @testset "vcat" begin
-    A = randn(2, 4)
-    B = randn(1, 4)
-    C = randn(3, 4)
-    test_rrule(vcat, A, B, C; check_inferred=false)
+    test_rrule(vcat, randn(2, 4), randn(1, 4), randn(3, 4))
+    test_rrule(vcat, rand(), rand())
+    test_rrule(vcat, rand(), rand(3), rand(3,1,1))
+    test_rrule(vcat, rand(3,1,2), rand(4,1,2))
 end
 
 @testset "reduce vcat" begin
@@ -30,6 +29,20 @@ end
     B = randn(1, 4)
     C = randn(3, 4)
     test_rrule(reduce, vcat ⊢ NoTangent(), [A, B, C])
+end
+
+@testset "cat" begin
+    test_rrule(cat, rand(2, 4), rand(1, 4); fkwargs=(dims=1,))
+    test_rrule(cat, rand(2, 4), rand(2); fkwargs=(dims=Val(2),))
+    test_rrule(cat, rand(), rand(2, 3); fkwargs=(dims=[1,2],))
+    test_rrule(cat, rand(1), rand(3, 2, 1); fkwargs=(dims=(1,2),), check_inferred=false) # infers Tuple{Zero, Vector{Float64}, Any}
+end
+
+@testset "hvcat" begin
+    test_rrule(hvcat, 2 ⊢ DoesNotExist(), rand(ComplexF64, 6)...)
+    test_rrule(hvcat, (2, 1) ⊢ DoesNotExist(), rand(), rand(1,1), rand(2,2))
+    test_rrule(hvcat, 1 ⊢ DoesNotExist(), rand(3)' ⊢ rand(1,3), transpose(rand(3)) ⊢ rand(1,3))
+    test_rrule(hvcat, 1 ⊢ DoesNotExist(), rand(0,3), rand(2,3), rand(1,3,1))
 end
 
 @testset "fill" begin


### PR DESCRIPTION
This provides more complete rules for `cat` and friends. They should do better at preserving dimensions, I have lost my list of edge cases (as I wrote this a while ago) but a few which currently go wrong are:
```
julia> Zygote.gradient(x -> sum(cat(x,x,dims=3)), rand(2,2))  # should be a matrix, trivial dim
(2×2×1 Fill{Float64}: entries equal to 2.0,)

julia> Zygote.gradient(x -> sum(hcat(x,x)),rand(2,1,2))  # should be a 3-array
(2×2 Fill{Float64}: entries equal to 2.0,)

julia> ChainRules.rrule(hcat, rand(2,1,2), rand(2,1,2))[2](ones(2,2,2))[2]
2×2 Matrix{Float64}:
 1.0  1.0
 1.0  1.0
```

They should also almost always be type-stable. This does not seem to lead to major performance changes:
```
julia> @btime gradient(x -> sum(hcat(x,x',x)), $(rand(10,10)));
  1.546 μs (29 allocations: 4.53 KiB)  # with Zygote's rules
  1.442 μs (25 allocations: 4.34 KiB)  # using this PR instead

julia> @btime gradient(xs -> sum(reduce(hcat, xs)), $([rand(10) for _ in 1:100]));
  2.125 μs (18 allocations: 10.11 KiB)
  2.125 μs (18 allocations: 10.11 KiB)  # this PR

julia> @btime gradient(x -> sum(vcat(x,3,x,4)), $(rand(10)));
  3.042 μs (62 allocations: 2.34 KiB)
  2.704 μs (38 allocations: 1.19 KiB)  # this PR

julia> @btime gradient(x -> sum(cat(x,3,x,4, dims=(1,2))), $(rand(10,10)));
  11.458 μs (111 allocations: 8.00 KiB)
  7.646 μs (82 allocations: 7.09 KiB)  # this PR
```

I know of two possible issues. One is that Zygote has special paths to allow the gradient of `vcat(1, cu(rand(3)))` to make a scalar, disabling CUDA's scalar indexing complaint. 

The second is that `vcat(fill(1), fill(2))` will have numbers as its gradient, not zero-arrays. That seems better than vectors (the present behaviour) and consistent with how broadcasting behaves:
```
julia> gradient(x -> sum(vcat(x,x)), fill(3.14))[1] isa AbstractVector
true

julia> ChainRules.rrule(vcat, fill(1), fill(2))[2](ones(2))[2]
1-element Vector{Float64}:
 1.0
 
julia> gradient(x -> x .+ 1, fill(1))
(1,)
```
