### PR TITLE
WIP: use `project` tangents

### DIFF
--- a/src/rulesets/Base/arraymath.jl
+++ b/src/rulesets/Base/arraymath.jl
@@ -28,12 +28,12 @@ function rrule(
         return (
             NoTangent(),
             InplaceableThunk(
-                @thunk(Ȳ * B'),
-                X̄ -> mul!(X̄, Ȳ, B', true, true)
+                @thunk(project(A, Ȳ * B')),
+                X̄ -> project(A, mul!(X̄, Ȳ, B', true, true))
             ),
             InplaceableThunk(
-                @thunk(A' * Ȳ),
-                X̄ -> mul!(X̄, A', Ȳ, true, true)
+                @thunk(project(B, A' * Ȳ)),
+                X̄ -> project(B, mul!(X̄, A', Ȳ, true, true))
             )
         )
     end


### PR DESCRIPTION
Usage of https://github.com/JuliaDiff/ChainRulesCore.jl/pull/380.

This will need a breaking version of FiniteDifferences which perturbs the Diagonal only down its diagonal entries, and not also the zeros.