### PR TITLE
WIP: use `preproject` implementation

### DIFF
--- a/src/rulesets/Base/arraymath.jl
+++ b/src/rulesets/Base/arraymath.jl
@@ -28,12 +28,12 @@ function rrule(
         return (
             NoTangent(),
             InplaceableThunk(
-                @thunk(Ȳ * B'),
-                X̄ -> mul!(X̄, Ȳ, B', true, true)
+                @thunk(project(A, Ȳ * B')),
+                X̄ -> project(A, mul!(X̄, Ȳ, B', true, true))
             ),
             InplaceableThunk(
-                @thunk(A' * Ȳ),
-                X̄ -> mul!(X̄, A', Ȳ, true, true)
+                @thunk(project(B, A' * Ȳ)),
+                X̄ -> project(B, mul!(X̄, A', Ȳ, true, true))
             )
         )
     end


### PR DESCRIPTION
This is quite ugly since it extracts the relevant information outside the pullback. An extra complication is that
```julia
julia> function noinfers(x::AbstractArray)
           T = eltype(x)
           function myclosure()
               return zeros(T, 2, 2)
           end
           return myclosure
       end
noinfers (generic function with 2 methods)

julia> cl = noinfers([1.0, 2.0, 3.0]); @inferred cl()
ERROR: return type Matrix{Float64} does not match inferred return type Matrix{_A} where _A
Stacktrace:
 [1] error(s::String)
   @ Base ./error.jl:33
 [2] top-level scope
   @ REPL[82]:1

julia> function infers(x::AbstractArray)
           function myclosure()
               return zeros(eltype(x), 2, 2)
           end
           return myclosure
       end
infers (generic function with 2 methods)

julia> cl = infers([1.0, 2.0, 3.0]); @inferred cl()
2×2 Matrix{Float64}:
 0.0  0.0
 0.0  0.0
```
to which @mcabbott suggested the `_val` solution on Slack. (without seeing the use case, so he might know a more elegant solution)