### PR TITLE
No Differentiable Factorial

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "0.8.16"
+version = "0.8.17"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/rulesets/Base/nondiff.jl
+++ b/src/rulesets/Base/nondiff.jl
@@ -13,7 +13,6 @@
 @non_differentiable ==(::Any, ::Any)
 @non_differentiable ===(::Any, ::Any)
 
-
 @non_differentiable Bool(::Any)
 
 @non_differentiable accumulate(::Any, ::AbstractArray{Bool})
@@ -132,6 +131,8 @@
 VERSION >= v"1.1" && @non_differentiable fieldtypes(T)
 @non_differentiable fieldname(T, ::Integer)
 @non_differentiable fieldnames(T)
+
+@non_differentiable factorial(n::Integer)
 
 @non_differentiable findall(::Union{Regex, AbstractString, Function}, ::AbstractString)
 @non_differentiable findall(::Function, ::AbstractArray)


### PR DESCRIPTION
Fixes #344 

There are no tests for non_differentiable as discussed in https://github.com/JuliaDiff/ChainRules.jl/pull/252 . This *does* add a test here as it fits the criterion of either "add(ing) regression tests when we find issues with these rules / decide to add extra rules" but can just remove these tests if it's not wanted. 