### PR TITLE
Add rrule for multiarg array addition

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "0.8.20"
+version = "0.8.21"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "0.8.18"
+version = "0.8.19"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "0.8.19"
+version = "0.8.20"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/rulesets/Base/arraymath.jl
+++ b/src/rulesets/Base/arraymath.jl
@@ -277,8 +277,7 @@ end
 function rrule(::typeof(+), arrs::AbstractArray...)
     y = +(arrs...)
     arr_axs = map(axes, arrs)
-    function add_pullback(dy_raw)
-        dy = unthunk(dy_raw)
+    function add_pullback(dy)
         return (NoTangent(), map(ax -> reshape(dy, ax), arr_axs)...)
     end
     return y, add_pullback

--- a/src/rulesets/Base/arraymath.jl
+++ b/src/rulesets/Base/arraymath.jl
@@ -276,9 +276,7 @@ end
 
 function rrule(::typeof(+), arrs::AbstractArray...)
     y = +(arrs...)
-    function add_pullback(dy)
-        # using ntuple here for type stability
-        return (NoTangent(), ntuple(i -> dy, length(arrs))...)
-    end
+    valN = Val(length(arrs)) # makes add_pullback type-stable without closing over arrs
+    add_pullback(dy) = (NoTangent(), ntuple(_ -> dy, valN)...)
     return y, add_pullback
 end

--- a/src/rulesets/Base/arraymath.jl
+++ b/src/rulesets/Base/arraymath.jl
@@ -276,7 +276,10 @@ end
 
 function rrule(::typeof(+), arrs::AbstractArray...)
     y = +(arrs...)
-    valN = Val(length(arrs)) # makes add_pullback type-stable without closing over arrs
-    add_pullback(dy) = (NoTangent(), ntuple(_ -> dy, valN)...)
+    arr_axs = map(axes, arrs)
+    function add_pullback(dy_raw)
+        dy = unthunk(dy_raw)
+        return (NoTangent(), map(ax -> reshape(dy, ax), arr_axs)...)
+    end
     return y, add_pullback
 end

--- a/src/rulesets/Base/arraymath.jl
+++ b/src/rulesets/Base/arraymath.jl
@@ -277,10 +277,8 @@ end
 function rrule(::typeof(+), arrs::AbstractArray...)
     y = +(arrs...)
     function add_pullback(dy)
-        return (
-            NoTangent(),
-            ntuple(i -> dy .* ones(eltype(arrs[i]), size(arrs[i])), length(arrs))...
-        )
+        # using ntuple here for type stability
+        return (NoTangent(), ntuple(i -> dy, length(arrs))...)
     end
     return y, add_pullback
 end

--- a/src/rulesets/Base/arraymath.jl
+++ b/src/rulesets/Base/arraymath.jl
@@ -268,3 +268,19 @@ function rrule(::typeof(-), x::AbstractArray)
     end
     return -x, negation_pullback
 end
+
+
+#####
+##### Addition (Multiarg `+`)
+#####
+
+function rrule(::typeof(+), arrs::AbstractArray...)
+    y = +(arrs...)
+    function add_pullback(dy)
+        return (
+            NoTangent(),
+            ntuple(i -> dy .* ones(eltype(arrs[i]), size(arrs[i])), length(arrs))...
+        )
+    end
+    return y, add_pullback
+end

--- a/src/rulesets/Base/base.jl
+++ b/src/rulesets/Base/base.jl
@@ -161,3 +161,15 @@ end
 @scalar_rule round(x) zero(x)
 @scalar_rule floor(x) zero(x)
 @scalar_rule ceil(x) zero(x)
+
+# note: rules for ^ are defined in the fastmath_able.jl
+function frule((_, _, Δx, _), ::typeof(Base.literal_pow), ::typeof(^), x::Real, pv::Val{p}) where p
+    y = Base.literal_pow(^, x, pv)
+    return y, (p * y / x * Δx)
+end
+
+function rrule(::typeof(Base.literal_pow), ::typeof(^), x::Real, pv::Val{p}) where p
+    y = Base.literal_pow(^, x, pv)
+    literal_pow_pullback(dy) = NoTangent(), NoTangent(), (p * y / x * dy), NoTangent()
+    return y, literal_pow_pullback
+end

--- a/src/rulesets/Base/nondiff.jl
+++ b/src/rulesets/Base/nondiff.jl
@@ -439,3 +439,8 @@ VERSION >= v"1.1" && @non_differentiable Sys.isopenbsd(::Symbol)
 @non_differentiable Threads.threadid(::Task)
 
 @non_differentiable similar(::Any...)
+
+@non_differentiable one(::Any)
+@non_differentiable ones(::Any...)
+@non_differentiable zero(::Any)
+@non_differentiable zeros(::Any...)

--- a/test/rulesets/Base/arraymath.jl
+++ b/test/rulesets/Base/arraymath.jl
@@ -148,4 +148,12 @@
         test_rrule(-, A)
         test_rrule(-, Diagonal(A); output_tangent=Diagonal(Ā))
     end
+
+    @testset "addition" begin
+        A = randn(4, 4)
+        B = randn(4, 4)
+        C = randn(4, 4)
+
+        test_rrule(+, A, B, C)
+    end
 end

--- a/test/rulesets/Base/arraymath.jl
+++ b/test/rulesets/Base/arraymath.jl
@@ -150,10 +150,7 @@
     end
 
     @testset "addition" begin
-        A = randn(4, 4)
-        B = randn(4, 4)
-        C = randn(4, 4)
-
-        test_rrule(+, A, B, C)
+        test_rrule(+, randn(4, 4), randn(4, 4), randn(4, 4))
+        test_rrule(+, randn(3), randn(3,1), randn(3,1,1))
     end
 end

--- a/test/rulesets/Base/base.jl
+++ b/test/rulesets/Base/base.jl
@@ -176,4 +176,10 @@
         @test frule((NoTangent(), NoTangent(), NoTangent()), Base.depwarn, "message", :f) !== nothing
         @test rrule(Base.depwarn, "message", :f) !== nothing
     end
+
+    @testset "literal_pow" begin
+        # for real x and n, x must be >0
+        test_frule(Base.literal_pow, ^, 3.5, Val(3))
+        test_rrule(Base.literal_pow, ^, 3.5, Val(3))
+    end
 end


### PR DESCRIPTION
Fixes dfdx/Yota.jl#92

This PR doesn't contain `frule` for the same operation, but most other functions in `arraymath.jl` don't have either. Is it normal practice to add only one kind of rules? I don't know much about forward-mode AD ecosystem so it's a bit hard for me to estimate the impact. 