### PR TITLE
Add nondiff rules for one ones zero zeros

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "0.8.18"
+version = "0.8.19"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/rulesets/Base/nondiff.jl
+++ b/src/rulesets/Base/nondiff.jl
@@ -442,5 +442,5 @@ VERSION >= v"1.1" && @non_differentiable Sys.isopenbsd(::Symbol)
 
 @non_differentiable one(::Any)
 @non_differentiable ones(::Any...)
-@non_differentiable zero(::Any...)
+@non_differentiable zero(::Any)
 @non_differentiable zeros(::Any...)

--- a/src/rulesets/Base/nondiff.jl
+++ b/src/rulesets/Base/nondiff.jl
@@ -440,7 +440,7 @@ VERSION >= v"1.1" && @non_differentiable Sys.isopenbsd(::Symbol)
 
 @non_differentiable similar(::Any...)
 
-@non_differentiable one(::Any...)
+@non_differentiable one(::Any)
 @non_differentiable ones(::Any...)
 @non_differentiable zero(::Any...)
 @non_differentiable zeros(::Any...)

--- a/src/rulesets/Base/nondiff.jl
+++ b/src/rulesets/Base/nondiff.jl
@@ -439,3 +439,8 @@ VERSION >= v"1.1" && @non_differentiable Sys.isopenbsd(::Symbol)
 @non_differentiable Threads.threadid(::Task)
 
 @non_differentiable similar(::Any...)
+
+@non_differentiable one(::Any...)
+@non_differentiable ones(::Any...)
+@non_differentiable zero(::Any...)
+@non_differentiable zeros(::Any...)


### PR DESCRIPTION
Porting nograd rules for `one`, `ones`, `zero`, `zeros` from Zygote https://github.com/FluxML/Zygote.jl/blob/master/src/lib/array.jl#L11

Follow-up to https://github.com/JuliaDiff/ChainRules.jl/pull/252
