### PR TITLE
Add missing generic repeat method

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "1.8.1"
+version = "1.9"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/rulesets/Base/array.jl
+++ b/src/rulesets/Base/array.jl
@@ -89,46 +89,16 @@ function rrule(::typeof(repeat), xs::AbstractArray; inner=ntuple(_->1, ndims(xs)
     return repeat(xs; inner = inner, outer = outer), repeat_pullback
 end
 
-function rrule(::typeof(repeat), xs::AbstractArray, counts::Integer...)
+function rrule(::typeof(repeat), xs::AbstractArray{T, N}, counts::Integer...) where {T,N}
 
     S = size(xs)
-    function repeat_pullback(ȳ)
+    function repeat_pullback(ȳ::AbstractArray{T2, M}) where {T2, M}
         dY = unthunk(ȳ)
         size2ndims = ntuple(d -> isodd(d) ? get(S, 1+d÷2, 1) : get(counts, d÷2, 1), 2*ndims(dY))
         reduced = sum(reshape(dY, size2ndims); dims = ntuple(d -> 2d, ndims(dY)))
-        return (NoTangent(), reshape(reduced, S), map(_->NoTangent(), counts)...)
+        return (NoTangent(), reshape(reduced, S)::Array{T2, N}, map(_->NoTangent(), counts)...)
     end
     return repeat(xs, counts...), repeat_pullback
-end
-
-# Type inference issues in removing these methods and just using the generic
-function rrule(::typeof(repeat), xs::AbstractVector, m::Integer)
-
-    d1 = size(xs, 1)
-    function repeat_pullback(ȳ)
-        Δ′ = dropdims(sum(reshape(ȳ, d1, :); dims=2); dims=2)
-        return (NoTangent(), Δ′, NoTangent())
-    end
-
-    return repeat(xs, m), repeat_pullback
-end
-
-function rrule(::typeof(repeat), xs::AbstractVecOrMat, m::Integer, n::Integer)
-    d1, d2 = size(xs, 1), size(xs, 2)
-    function repeat_pullback(ȳ)
-        ȳ′ = reshape(ȳ, d1, m, d2, n)
-        return NoTangent(), reshape(sum(ȳ′; dims=(2,4)), (d1, d2)), NoTangent(), NoTangent()
-    end
-
-    return repeat(xs, m, n), repeat_pullback
-end
-
-function rrule(T::typeof(repeat), xs::AbstractVecOrMat, m::Integer)
-
-    # Workaround use of positional default (i.e. repeat(xs, m, n = 1)))
-    y, full_pb = rrule(T, xs, m, 1)
-    repeat_pullback(ȳ) = full_pb(ȳ)[1:3]
-    return y, repeat_pullback
 end
 
 #####

--- a/src/rulesets/Base/array.jl
+++ b/src/rulesets/Base/array.jl
@@ -69,18 +69,6 @@ end
 ##### `repeat`
 #####
 
-function rrule(::typeof(repeat), xs::AbstractArray, counts::Integer...)
-
-    S = size(xs)
-    function repeat_pullback(ȳ)
-        dY = unthunk(ȳ)
-        size2ndims = ntuple(d -> isodd(d) ? get(S, 1+d÷2, 1) : get(counts, d÷2, 1), 2*ndims(dY))
-        reduced = sum(reshape(dY, size2ndims); dims = ntuple(d -> 2d, ndims(dY)))
-        return (NoTangent(), reshape(reduced, S), map(_->NoTangent(), counts)...)
-    end
-    return repeat(xs, counts...), repeat_pullback
-end
-
 function rrule(::typeof(repeat), xs::AbstractArray; inner=ntuple(_->1, ndims(xs)), outer=ntuple(_->1, ndims(xs)))
 
     S = size(xs)
@@ -99,6 +87,48 @@ function rrule(::typeof(repeat), xs::AbstractArray; inner=ntuple(_->1, ndims(xs)
     end
 
     return repeat(xs; inner = inner, outer = outer), repeat_pullback
+end
+
+function rrule(::typeof(repeat), xs::AbstractArray, counts::Integer...)
+
+    S = size(xs)
+    function repeat_pullback(ȳ)
+        dY = unthunk(ȳ)
+        size2ndims = ntuple(d -> isodd(d) ? get(S, 1+d÷2, 1) : get(counts, d÷2, 1), 2*ndims(dY))
+        reduced = sum(reshape(dY, size2ndims); dims = ntuple(d -> 2d, ndims(dY)))
+        return (NoTangent(), reshape(reduced, S), map(_->NoTangent(), counts)...)
+    end
+    return repeat(xs, counts...), repeat_pullback
+end
+
+# Type inference issues in removing these methods and just using the generic
+function rrule(::typeof(repeat), xs::AbstractVector, m::Integer)
+
+    d1 = size(xs, 1)
+    function repeat_pullback(ȳ)
+        Δ′ = dropdims(sum(reshape(ȳ, d1, :); dims=2); dims=2)
+        return (NoTangent(), Δ′, NoTangent())
+    end
+
+    return repeat(xs, m), repeat_pullback
+end
+
+function rrule(::typeof(repeat), xs::AbstractVecOrMat, m::Integer, n::Integer)
+    d1, d2 = size(xs, 1), size(xs, 2)
+    function repeat_pullback(ȳ)
+        ȳ′ = reshape(ȳ, d1, m, d2, n)
+        return NoTangent(), reshape(sum(ȳ′; dims=(2,4)), (d1, d2)), NoTangent(), NoTangent()
+    end
+
+    return repeat(xs, m, n), repeat_pullback
+end
+
+function rrule(T::typeof(repeat), xs::AbstractVecOrMat, m::Integer)
+
+    # Workaround use of positional default (i.e. repeat(xs, m, n = 1)))
+    y, full_pb = rrule(T, xs, m, 1)
+    repeat_pullback(ȳ) = full_pb(ȳ)[1:3]
+    return y, repeat_pullback
 end
 
 #####

--- a/src/rulesets/Base/array.jl
+++ b/src/rulesets/Base/array.jl
@@ -68,22 +68,24 @@ end
 #####
 ##### `repeat`
 #####
+function _repeat_pullback_accum(dY)
+    Δ′ = zero(xs)
+    # Loop through each element of Δ, calculate source dimensions, accumulate into Δ′
+    for (dest_idx, val) in pairs(IndexCartesian(), dY)
+        # First, round dest_idx[dim] to nearest gridpoint defined by inner[dim], then
+        # wrap around based on original size S.
+        src_idx = [mod1(div(dest_idx[dim] - 1, inner[dim]) + 1, S[dim]) for dim in 1:length(S)]
+        Δ′[src_idx...] += val
+    end
+end
 
 function rrule(::typeof(repeat), xs::AbstractArray; inner=ntuple(_->1, ndims(xs)), outer=ntuple(_->1, ndims(xs)))
 
+    project_Xs = ProjectTo(xs)
     S = size(xs)
     function repeat_pullback(ȳ)
         dY = unthunk(ȳ)
-        Δ′ = zero(xs)
-
-        # Loop through each element of Δ, calculate source dimensions, accumulate into Δ′
-        for (dest_idx, val) in pairs(IndexCartesian(), dY)
-            # First, round dest_idx[dim] to nearest gridpoint defined by inner[dim], then
-            # wrap around based on original size S.
-            src_idx = [mod1(div(dest_idx[dim] - 1, inner[dim]) + 1, S[dim]) for dim in 1:length(S)]
-            Δ′[src_idx...] += val
-        end
-        return (NoTangent(), Δ′)
+        return (NoTangent(), @thunk project_Xs(_repeat_pullback_accum(dY)))
     end
 
     return repeat(xs; inner = inner, outer = outer), repeat_pullback
@@ -91,12 +93,16 @@ end
 
 function rrule(::typeof(repeat), xs::AbstractArray, counts::Integer...)
 
+    project_Xs = ProjectTo(xs)
     S = size(xs)
     function repeat_pullback(ȳ)
         dY = unthunk(ȳ)
-        size2ndims = ntuple(d -> isodd(d) ? get(S, 1+d÷2, 1) : get(counts, d÷2, 1), 2*ndims(dY))
-        reduced = sum(reshape(dY, size2ndims); dims = ntuple(d -> 2d, ndims(dY)))
-        return (NoTangent(), reshape(reduced, S), map(_->NoTangent(), counts)...)
+        x̄ = @thunk begin
+            size2ndims = ntuple(d -> isodd(d) ? get(S, 1+d÷2, 1) : get(counts, d÷2, 1), 2*ndims(dY))
+            reduced = sum(reshape(dY, size2ndims); dims = ntuple(d -> 2d, ndims(dY)))
+            project_Xs(reshape(reduced, S), map(_->NoTangent(), counts)...)
+        end
+        return (NoTangent(), x̄)
     end
     return repeat(xs, counts...), repeat_pullback
 end

--- a/src/rulesets/Base/array.jl
+++ b/src/rulesets/Base/array.jl
@@ -89,14 +89,14 @@ function rrule(::typeof(repeat), xs::AbstractArray; inner=ntuple(_->1, ndims(xs)
     return repeat(xs; inner = inner, outer = outer), repeat_pullback
 end
 
-function rrule(::typeof(repeat), xs::AbstractArray{T, N}, counts::Integer...) where {T,N}
+function rrule(::typeof(repeat), xs::AbstractArray, counts::Integer...)
 
     S = size(xs)
-    function repeat_pullback(ȳ::AbstractArray{T2, M}) where {T2, M}
+    function repeat_pullback(ȳ)
         dY = unthunk(ȳ)
         size2ndims = ntuple(d -> isodd(d) ? get(S, 1+d÷2, 1) : get(counts, d÷2, 1), 2*ndims(dY))
         reduced = sum(reshape(dY, size2ndims); dims = ntuple(d -> 2d, ndims(dY)))
-        return (NoTangent(), reshape(reduced, S)::Array{T2, N}, map(_->NoTangent(), counts)...)
+        return (NoTangent(), reshape(reduced, S), map(_->NoTangent(), counts)...)
     end
     return repeat(xs, counts...), repeat_pullback
 end

--- a/test/rulesets/Base/array.jl
+++ b/test/rulesets/Base/array.jl
@@ -73,7 +73,6 @@ end
 
     end
 
-
     @test rrule(repeat, [1,2,3], 4)[2](ones(12))[2] == [4,4,4]
     @test rrule(repeat, [1,2,3], outer=4)[2](ones(12))[2] == [4,4,4]
 

--- a/test/rulesets/Base/array.jl
+++ b/test/rulesets/Base/array.jl
@@ -43,6 +43,13 @@ end
 end
 
 @testset "repeat" begin
+
+    test_rrule(repeat, rand(1,2,3), 2,3)
+    test_rrule(repeat, rand(1,2,3), 2,3,4)
+    test_rrule(repeat, rand(1,2,3), 2,3,4,2)
+    test_rrule(repeat, rand(1,1,1,1), 2,3,4,5)
+    test_rrule(repeat, rand(0,2,3), 2,0,4)
+
     test_rrule(repeat, rand(4, ))
     test_rrule(repeat, rand(4, ), 2)
     test_rrule(repeat, rand(4, 5))
@@ -56,14 +63,10 @@ end
     test_rrule(repeat, rand(4, 5), 2; check_inferred=VERSION>=v"1.5")
     test_rrule(repeat, rand(4, 5), 2, 3)
 
-    # zero-arrays: broken
-    @test_broken rrule(repeat, fill(1.0), 2) !== nothing
-    @test_broken rrule(repeat, fill(1.0), 2, 3) !== nothing
-
-    # These dispatch but probably needs
-    # https://github.com/JuliaDiff/FiniteDifferences.jl/issues/179
-    # test_rrule(repeat, fill(1.0); fkwargs = (inner=2,))
-    # test_rrule(repeat, fill(1.0); fkwargs = (inner=2, outer=3,))
+    test_rrule(repeat, fill(1.0), 2)
+    test_rrule(repeat, fill(1.0), 2, 3)
+    test_rrule(repeat, fill(1.0); fkwargs = (inner=2,))
+    test_rrule(repeat, fill(1.0); fkwargs = (inner=2, outer=3,))
 
     @test rrule(repeat, [1,2,3], 4)[2](ones(12))[2] == [4,4,4]
     @test rrule(repeat, [1,2,3], outer=4)[2](ones(12))[2] == [4,4,4]

--- a/test/rulesets/Base/array.jl
+++ b/test/rulesets/Base/array.jl
@@ -44,11 +44,9 @@ end
 
 @testset "repeat" begin
 
-    test_rrule(repeat, rand(1,2,3), 2,3)
-    test_rrule(repeat, rand(1,2,3), 2,3,4)
-    test_rrule(repeat, rand(1,2,3), 2,3,4,2)
-    test_rrule(repeat, rand(1,1,1,1), 2,3,4,5)
-    test_rrule(repeat, rand(0,2,3), 2,0,4)
+    test_rrule(repeat, rand(1,2,3), 2,3,4; check_inferred=VERSION>v"1.6")
+    test_rrule(repeat, rand(1,1,1,1), 2,3,4,5; check_inferred=VERSION>v"1.6")
+    test_rrule(repeat, rand(0,2,3), 2,0,4; check_inferred=VERSION>v"1.6")
 
     test_rrule(repeat, rand(4, ))
     test_rrule(repeat, rand(4, ), 2)
@@ -57,16 +55,23 @@ end
     test_rrule(repeat, rand(4, 5); fkwargs = (inner=(1,2), outer=(1,3)))
 
     if VERSION>=v"1.6"
-        # repeat([1 2; 3 4], inner=(2,4), outer=(1,1,1,3)) fails for v<1.6
+        # These are cases where repeat itself fails in earlier versions
         test_rrule(repeat, rand(4, 5); fkwargs = (inner=(2,4), outer=(1,1,1,3)))
+        test_rrule(repeat, rand(1,2,3), 2,3)
+        test_rrule(repeat, rand(1,2,3), 2,3,4,2)
+        test_rrule(repeat, fill(1.0), 2)
+        test_rrule(repeat, fill(1.0), 2, 3)
+
+        # These fail for other v1.0 related issues (add!!)
+        # v"1.0": fill(1.0) + fill(1.0) != fill(2.0)
+        # v"1.6: fill(1.0) + fill(1.0) == fill(2.0) # Expected
+        test_rrule(repeat, fill(1.0); fkwargs = (inner=2,))
+        test_rrule(repeat, fill(1.0); fkwargs = (inner=2, outer=3,))
+
     end
+
     test_rrule(repeat, rand(4, 5), 2; check_inferred=VERSION>=v"1.5")
     test_rrule(repeat, rand(4, 5), 2, 3)
-
-    test_rrule(repeat, fill(1.0), 2)
-    test_rrule(repeat, fill(1.0), 2, 3)
-    test_rrule(repeat, fill(1.0); fkwargs = (inner=2,))
-    test_rrule(repeat, fill(1.0); fkwargs = (inner=2, outer=3,))
 
     @test rrule(repeat, [1,2,3], 4)[2](ones(12))[2] == [4,4,4]
     @test rrule(repeat, [1,2,3], outer=4)[2](ones(12))[2] == [4,4,4]

--- a/test/rulesets/Base/array.jl
+++ b/test/rulesets/Base/array.jl
@@ -44,15 +44,18 @@ end
 
 @testset "repeat" begin
 
-    test_rrule(repeat, rand(1,2,3), 2,3,4; check_inferred=VERSION>v"1.6")
-    test_rrule(repeat, rand(1,1,1,1), 2,3,4,5; check_inferred=VERSION>v"1.6")
-    test_rrule(repeat, rand(0,2,3), 2,0,4; check_inferred=VERSION>v"1.6")
-
     test_rrule(repeat, rand(4, ))
-    test_rrule(repeat, rand(4, ), 2)
     test_rrule(repeat, rand(4, 5))
     test_rrule(repeat, rand(4, 5); fkwargs = (outer=(1,2),))
     test_rrule(repeat, rand(4, 5); fkwargs = (inner=(1,2), outer=(1,3)))
+
+    test_rrule(repeat, rand(4, ), 2; check_inferred=VERSION>=v"1.6")
+    test_rrule(repeat, rand(4, 5), 2; check_inferred=VERSION>=v"1.6")
+    test_rrule(repeat, rand(4, 5), 2, 3; check_inferred=VERSION>=v"1.6")
+    test_rrule(repeat, rand(1,2,3), 2,3,4; check_inferred=VERSION>v"1.6")
+    test_rrule(repeat, rand(0,2,3), 2,0,4; check_inferred=VERSION>v"1.6")
+    test_rrule(repeat, rand(1,1,1,1), 2,3,4,5; check_inferred=VERSION>v"1.6")
+    
 
     if VERSION>=v"1.6"
         # These are cases where repeat itself fails in earlier versions
@@ -70,8 +73,6 @@ end
 
     end
 
-    test_rrule(repeat, rand(4, 5), 2; check_inferred=VERSION>=v"1.5")
-    test_rrule(repeat, rand(4, 5), 2, 3)
 
     @test rrule(repeat, [1,2,3], 4)[2](ones(12))[2] == [4,4,4]
     @test rrule(repeat, [1,2,3], outer=4)[2](ones(12))[2] == [4,4,4]


### PR DESCRIPTION
Follow up from #460 

Adds in the missing `function rrule(::typeof(repeat), xs::AbstractArray, counts::Integer...)` method. 

Uses the code provided by @mcabbott in the gist [here](https://gist.github.com/mcabbott/80ac43cca3bee8f57809155a5240519f)

Some comments:
- ~There were some type infererence issues in running in 1.0 IDK how important this is is (a bunch of stuff is marked to only check inference in later versions), but to avoid regressing on the tests already implemented I've added some type hinting in the closure. It's a bit gross so there may be a better way to do it.~ EDIT: Now removed and just relaxing the 1.0 tests for typing. 
- ~Bumps finite differences so `rand_tangent{Array{T, 0}}` is now doing the correct thing and hence enables those tests. There are some differences in the behaviour of the forward pass of repeat between 1.0 and 1.6 (the CI versions) so there is a bit of version checking.~ FD has been bumped, but actually no longer needed now that rand_tangent is in CRTU





