### PR TITLE
don't try an Inplace unknown matrixes in *

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "1.0.0"
+version = "1.0.1"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/test/rulesets/Base/arraymath.jl
+++ b/test/rulesets/Base/arraymath.jl
@@ -27,31 +27,38 @@
             end
         end
 
-        @testset "AbstractMatrix-AbstractMatrix" begin
-            @testset "Matrix * Matrix n=$n, m=$m, p=$p" for n in (2, 5), m in (2, 4), p in (2, 3)
-                @testset "Array" begin
-                    test_rrule(*, (n⋆m), (m⋆p))
-                end
-
-                @testset "SubArray - $indexname" for (indexname, m_index) in (
-                    ("fast", :), ("slow", m:-1:1)
-                )
-                    test_rrule(*, view(n⋆m, :, m_index), view(m⋆p, m_index, :))
-                    test_rrule(*, n⋆m, view(m⋆p, m_index, :))
-                    test_rrule(*, view(n⋆m, :, m_index), m⋆p)
-                end
-
-                @testset "Adjoints and Transposes" begin
-                    test_rrule(*, Transpose(m⋆n) ⊢ Transpose(m⋆n), Transpose(p⋆m) ⊢ Transpose(p⋆m))
-                    test_rrule(*, Adjoint(m⋆n) ⊢ Adjoint(m⋆n), Adjoint(p⋆m) ⊢ Adjoint(p⋆m))
-
-                    test_rrule(*, Transpose(m⋆n) ⊢ Transpose(m⋆n), (m⋆p))
-                    test_rrule(*, Adjoint(m⋆n) ⊢ Adjoint(m⋆n), (m⋆p))
-
-                    test_rrule(*, (n⋆m), Transpose(p⋆m) ⊢ Transpose(p⋆m))
-                    test_rrule(*, (n⋆m), Adjoint(p⋆m) ⊢ Adjoint(p⋆m))
-                end
+        @testset "dense-matrix n=$n, m=$m, p=$p" for n in (2, 5), m in (2, 4), p in (2, 3)
+            @testset "Array" begin
+                test_rrule(*, (n⋆m), (m⋆p))
             end
+
+            @testset "SubArray - $indexname" for (indexname, m_index) in (
+                ("fast", :), ("slow", m:-1:1)
+            )
+                test_rrule(*, view(n⋆m, :, m_index), view(m⋆p, m_index, :))
+                test_rrule(*, n⋆m, view(m⋆p, m_index, :))
+                test_rrule(*, view(n⋆m, :, m_index), m⋆p)
+            end
+
+            @testset "Adjoints and Transposes" begin
+                test_rrule(*, Transpose(m⋆n) ⊢ Transpose(m⋆n), Transpose(p⋆m) ⊢ Transpose(p⋆m))
+                test_rrule(*, Adjoint(m⋆n) ⊢ Adjoint(m⋆n), Adjoint(p⋆m) ⊢ Adjoint(p⋆m))
+
+                test_rrule(*, Transpose(m⋆n) ⊢ Transpose(m⋆n), (m⋆p))
+                test_rrule(*, Adjoint(m⋆n) ⊢ Adjoint(m⋆n), (m⋆p))
+
+                test_rrule(*, (n⋆m), Transpose(p⋆m) ⊢ Transpose(p⋆m))
+                test_rrule(*, (n⋆m), Adjoint(p⋆m) ⊢ Adjoint(p⋆m))
+            end
+        end
+
+        @testset "Diagonal" begin
+            test_rrule(*, Diagonal([1.0, 2.0, 3.0]), Diagonal([4.0, 5.0, 6.0]))
+            test_rrule(*, Diagonal([1.0, 2.0, 3.0]), rand(3))
+
+            # Needs to not try and inplace, as `mul!` will do wrong.
+            # see https://github.com/JuliaDiff/ChainRulesCore.jl/issues/411
+            test_rrule(*, Diagonal([1.0, 2.0, 3.0]), rand(3,3))
         end
 
         @testset "Covector * Vector n=$n" for n in (3, 5)


### PR DESCRIPTION
@AlexRobson this should fix your thing.
We basically need to be pretty careful not to use InplaceableThunks when we don't know that sensible things will be happening for the input.
So this PR basically just removed buggy code, and adds back a special-case that is known not buggy.
A downside is that some places were we could inplace we don't anymore. e.g. `*(::Diagonal, ::Diagonal)`
and `*::(StridedVector, StridedMatrix)`. Could add those back if we really wanted.
But since noone is really using the InplaceableThunk in anger, just holding off on that for now.
solving it generally is https://github.com/JuliaDiff/ChainRulesCore.jl/issues/411


I recommend Turning off showing whitespace when reveiwing