### PR TITLE
Make construtors of all AbstractRNGs as nondifferentiable

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "1.3.0"
+version = "1.4.0"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/rulesets/Random/random.jl
+++ b/src/rulesets/Random/random.jl
@@ -1,10 +1,10 @@
-frule(Δargs, ::Type{MersenneTwister}, args...) = MersenneTwister(args...), ZeroTangent()
+frule(Δargs, T::Type{<:AbstractRNG}, args...) = T(args...), ZeroTangent()
 
-function rrule(::Type{MersenneTwister}, args...)
-    function MersenneTwister_pullback(ΔΩ)
+function rrule(T::Type{<:AbstractRNG}, args...)
+    function AbstractRNG_pullback(ΔΩ)
         return (NoTangent(), map(_ -> ZeroTangent(), args)...)
     end
-    return MersenneTwister(args...), MersenneTwister_pullback
+    return T(args...), AbstractRNG_pullback
 end
 
 @non_differentiable Broadcast.broadcastable(::AbstractRNG)


### PR DESCRIPTION
In general it is pretty much nonsense to be doing AD through the constructor of any random number generator.
Not just a `MersenneTwister`.
Julia introduces a new default RNG in 1.7

can we use `@nondifferentiable` for this now?

Probably wants tests.


Hopefully fixed https://github.com/SciML/DiffEqSensitivity.jl/runs/3191036433?check_suite_focus=true#step:6:272