### PR TITLE
Add a few rules needed for higher-order AD of ProjectTo

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "1.4.0"
+version = "1.5.0"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
@@ -10,7 +10,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-ChainRulesCore = "1"
+ChainRulesCore = "1.1"
 ChainRulesTestUtils = "1"
 Compat = "3.31"
 FiniteDifferences = "0.12.8"

--- a/src/rulesets/Base/base.jl
+++ b/src/rulesets/Base/base.jl
@@ -26,6 +26,13 @@ function rrule(::typeof(real), z::Number)
     return (real(z), real_pullback)
 end
 
+# Conversions to Float
+
+@scalar_rule float(x) true
+@scalar_rule Float64(x::Real) true
+@scalar_rule Float32(x::Real) true
+@scalar_rule AbstractFloat(x::Real) true
+
 # `imag`
 
 @scalar_rule imag(x::Real) ZeroTangent()

--- a/src/rulesets/Core/core.jl
+++ b/src/rulesets/Core/core.jl
@@ -10,6 +10,12 @@
 @non_differentiable Core.apply_type(::Any, ::Any...)
 @non_differentiable Core.typeof(::Any)
 
+if isdefined(Core, :_typevar)
+    @non_differentiable Core._typevar(::Any...)
+end
+@non_differentiable TypeVar(::Any...)
+@non_differentiable UnionAll(::Any, ::Any)
+
 frule((_, ẋ, _), ::typeof(typeassert), x, T) = (typeassert(x, T), ẋ)
 function rrule(::typeof(typeassert), x, T)
     typeassert_pullback(Δ) = (NoTangent(), Δ, NoTangent())

--- a/test/rulesets/Base/base.jl
+++ b/test/rulesets/Base/base.jl
@@ -174,4 +174,21 @@
         test_frule(Base.literal_pow, ^, 3.5, Val(3))
         test_rrule(Base.literal_pow, ^, 3.5, Val(3))
     end
+
+    @testset "Float conversions" begin
+        for f in (float, Float32, Float64, AbstractFloat)
+            test_frule(f, 1.2; rtol=1.0e-3, atol=1.0e-3)
+            test_frule(f, 1⊢1.7; rtol=1.0e-3, atol=1.0e-3)
+            test_rrule(f, 1.2; rtol=1.0e-3, atol=1.0e-3)
+
+            # test_rrule doesn't like integers, so test that case manually
+            let y = rand(Int), x = randn()
+                @test rrule(f, y)[2](x)[2] == x
+            end
+        end
+
+        # Make sure that we didn't accidentally define a rule for all DataTypes
+        @test frule(NoRules, 1.0) === nothing
+        @test rrule(NoRules, 1.0) === nothing
+    end
 end

--- a/test/test_helpers.jl
+++ b/test/test_helpers.jl
@@ -8,6 +8,9 @@ function ChainRulesCore.rrule(m::Multiplier, y)
     return m(y), Multiplier_pullback
 end
 
+# NoRules - has no rules defined
+struct NoRules; end
+
 @testset "test_helpers.jl" begin
     @testset "Multiplier functor test-helper" begin
         test_rrule(Multiplier(4.0), 3.0)


### PR DESCRIPTION
The ProjectTo constructors use a few functions/builtins
that did not previously have rules breaking higher order
AD, since these constructors are now called by the first
order rules.