### PR TITLE
Add rule for `sincospi`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "1.5.1"
+version = "1.5.2"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "1.5.2"
+version = "1.6.0"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/rulesets/Base/fastmath_able.jl
+++ b/src/rulesets/Base/fastmath_able.jl
@@ -49,7 +49,7 @@ let
         @scalar_rule atan(y, x) @setup(u = x ^ 2 + y ^ 2) (x / u, -y / u)
         @scalar_rule sincos(x) @setup((sinx, cosx) = Ω) cosx -sinx
         # the position of the minus sign below warrants the correct type for π  
-        @scalar_rule sincospi(x) @setup((sinpix, cospix) = Ω) (π * cospix, π * (-sinpix))
+        @scalar_rule sincospi(x) @setup((sinpix, cospix) = Ω) (π * cospix)  (π * (-sinpix))
 
         # exponents
         @scalar_rule cbrt(x) inv(3 * Ω ^ 2)

--- a/src/rulesets/Base/fastmath_able.jl
+++ b/src/rulesets/Base/fastmath_able.jl
@@ -48,6 +48,8 @@ let
         # Trig-Multivariate
         @scalar_rule atan(y, x) @setup(u = x ^ 2 + y ^ 2) (x / u, -y / u)
         @scalar_rule sincos(x) @setup((sinx, cosx) = Ω) cosx -sinx
+        # the position of the minus sign below warrants the correct type for π  
+        @scalar_rule sincospi(x) @setup((sinpix, cospix) = Ω) (π * cospix, π * (-sinpix))
 
         # exponents
         @scalar_rule cbrt(x) inv(3 * Ω ^ 2)

--- a/src/rulesets/Base/fastmath_able.jl
+++ b/src/rulesets/Base/fastmath_able.jl
@@ -49,7 +49,9 @@ let
         @scalar_rule atan(y, x) @setup(u = x ^ 2 + y ^ 2) (x / u, -y / u)
         @scalar_rule sincos(x) @setup((sinx, cosx) = Ω) cosx -sinx
         # the position of the minus sign below warrants the correct type for π  
-        @scalar_rule sincospi(x) @setup((sinpix, cospix) = Ω) (π * cospix)  (π * (-sinpix))
+        if VERSION ≥ v"1.6"
+            @scalar_rule sincospi(x) @setup((sinpix, cospix) = Ω) (π * cospix)  (π * (-sinpix))
+        end
 
         # exponents
         @scalar_rule cbrt(x) inv(3 * Ω ^ 2)

--- a/test/rulesets/Base/fastmath_able.jl
+++ b/test/rulesets/Base/fastmath_able.jl
@@ -64,11 +64,13 @@ const FASTABLE_AST = quote
                 test_frule(sincos, randn(T))
                 test_rrule(sincos, randn(T); output_tangent=Δz)
             end
-            @testset "sincospi(x::$T)" for T in (Float64, ComplexF64)
-                Δz = Tangent{Tuple{T,T}}(randn(T), randn(T))
+            if VERSION ≥ v"1.6"
+                @testset "sincospi(x::$T)" for T in (Float64, ComplexF64)
+                    Δz = Tangent{Tuple{T,T}}(randn(T), randn(T))
 
-                test_frule(sincospi, randn(T))
-                test_rrule(sincospi, randn(T); output_tangent=Δz)
+                    test_frule(sincospi, randn(T))
+                    test_rrule(sincospi, randn(T); output_tangent=Δz)
+                end
             end
         end
     end

--- a/test/rulesets/Base/fastmath_able.jl
+++ b/test/rulesets/Base/fastmath_able.jl
@@ -64,6 +64,12 @@ const FASTABLE_AST = quote
                 test_frule(sincos, randn(T))
                 test_rrule(sincos, randn(T); output_tangent=Δz)
             end
+            @testset "sincospi(x::$T)" for T in (Float64, ComplexF64)
+                Δz = Tangent{Tuple{T,T}}(randn(T), randn(T))
+
+                test_frule(sincospi, randn(T))
+                test_rrule(sincospi, randn(T); output_tangent=Δz)
+            end
         end
     end
 


### PR DESCRIPTION
Hello,
as discussed on [discourse](https://discourse.julialang.org/t/automatic-differentiation-of-cispi/66075), differentiation of `cispi` fails, which is due to `copysign` being non differentiable. This problem is avoided by defining a rule for `sincospi` in `fastmath_able.jl`. Note the the sign was moved from `\pi` to the sine term (`sinpix`), to warrant that `\pi` does not enforce Float64 as result type, which `-\pi` would do.
Hope that the edit is acceptable, but happy to adapt, if needed.