### PR TITLE
[WIP] Add rrule for Core._apply_iterate

### DIFF
--- a/src/rulesets/Core/core.jl
+++ b/src/rulesets/Core/core.jl
@@ -32,3 +32,34 @@ function rrule(::typeof(ifelse), c, a::Number, b::Number)
     ifelse_pullback(Δ) = (NoTangent(), NoTangent(), ifelse(c, Δ, zero(Δ)), ifelse(c, zero(Δ), Δ))
     return ifelse(c, a, b), ifelse_pullback
 end
+
+function rrule(
+    ::typeof(Core._apply_iterate), ::typeof(iterate), f::F, args...) where F
+    # flatten nested arguments
+    flat = []
+    for a in args
+        push!(flat, a...)
+    end
+    # apply rrule of the function on the flat arguments
+    y, pb = rrule(f, flat...)
+    sizes = map(length, args)
+    function _apply_iterate_pullback(dy)
+        flat_dargs = pb(dy)
+        df = flat_dargs[1]
+        # group derivatives to tuples of the same sizes as arguments
+        dargs = []
+        j = 2
+        for i=1:length(args)
+            darg_val = flat_dargs[j:j + sizes[i] - 1]
+            if length(darg_val) == 1 && darg_val[1] isa NoTangent
+                push!(dargs, darg_val[1])
+            else
+                darg = Tangent{typeof(darg_val)}(darg_val...)
+                push!(dargs, darg)
+            end
+            j = j + sizes[i]
+        end
+        return NoTangent(), NoTangent(), df, dargs...
+    end
+    return y, _apply_iterate_pullback
+end

--- a/test/rulesets/Core/core.jl
+++ b/test/rulesets/Core/core.jl
@@ -10,3 +10,10 @@ end
     test_rrule(ifelse, true, [1.1], [2.0]; check_inferred=false)
     test_frule(ifelse, false, [1.1], [2.0]; check_inferred=false)
 end
+
+@testset "_apply_iterate" begin
+    test_rrule(
+        Core._apply_iterate, iterate, reshape, (rand(3, 4),), (12,);
+        check_inferred=false
+    )
+end


### PR DESCRIPTION
This is my pretty ugly attempt to create an `rrule()` for `Core._apply_iterate()`. `_apply_iterate()` isn't really well-documented, so let me describe what it does and, consequently, what my code does. 

Apparently, Julia uses `_apply_iterate()` when you splat arguments in your function call. I encountered it while tracing [this Flux function](https://github.com/FluxML/Flux.jl/blob/master/src/layers/conv.jl#L163), here's also and MWE:

```julia
julia> f = (x, sz) -> reshape(x, sz...)
#3 (generic function with 1 method)

julia> args = (rand(3, 4), (12, ))
...

julia> @code_lowered f(args...)
CodeInfo(
1 ─ %1 = Core.tuple(x)
│   %2 = Core._apply_iterate(Base.iterate, Main.reshape, %1, sz)
└──      return %2
)
```
`_apply_iterate(iterate, f, args...)` takes arguments as tuples, unpacks them and applies `f()` to their flat version. `_apply_iterate(iterate, reshape, x, 12)` is equal to simply `reshape(x, 12)`. I couldn't find any explanation for this transformation, but perhaps it makes the compiler's job a little bit easier, so we have to deal with it. 

My `rrule()` implementation consists of 3 parts: 

* flatten arguments
* apply `rrule` to flat arguments to obtain value and function pullback
* restructure the values from the pullback to correspond to the original tuples

The implementation is pretty ugly, and I still need to test it on more examples, but suggestions of a better implementation are highly welcome!