### PR TITLE
new rule: copysign

### DIFF
--- a/Development/Project.toml
+++ b/Development/Project.toml
@@ -1,3 +1,0 @@
-[deps]
-ChainRules = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-ChainRulesTestUtils = "cdddcdb0-9152-4a09-a978-84456f9df70a"

--- a/Development/Project.toml
+++ b/Development/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+ChainRules = "082447d4-558c-5d27-93f4-14fc19e9eca2"
+ChainRulesTestUtils = "cdddcdb0-9152-4a09-a978-84456f9df70a"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "1.7.0"
+version = "1.8.0"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/rulesets/Base/fastmath_able.jl
+++ b/src/rulesets/Base/fastmath_able.jl
@@ -184,6 +184,8 @@ let
         @scalar_rule max(x, y) @setup(gt = x > y) (gt, !gt)
         @scalar_rule min(x, y) @setup(gt = x > y) (!gt, gt)
 
+        @scalar_rule copysign(y, x) (ifelse(signbit(x)!=signbit(y), -one(y), +one(y)), NoTangent())
+
         # Unary functions
         @scalar_rule +x true
         @scalar_rule -x -1

--- a/test/rulesets/Base/fastmath_able.jl
+++ b/test/rulesets/Base/fastmath_able.jl
@@ -192,6 +192,16 @@ const FASTABLE_AST = quote
         end
     end
 
+    @testset "copysign" begin
+        # don't go too close to zero as the numerics may jump over it yielding wrong results
+        @testset "at $y" for y in (-1.1, 0.1, 100.0)  
+            @testset "at $x" for x in (-1.1, -0.1, 33.0)
+                test_frule(copysign, y, x)
+                test_rrule(copysign, y, x)
+            end
+        end
+    end
+
     @testset "sign" begin
         @testset "real" begin
             @testset "at $x" for x in (-1.1, -1.1, 0.5, 100.0)


### PR DESCRIPTION
As opposed to the previous [discussion](https://github.com/JuliaDiff/ChainRules.jl/issues/498) the correct rule for `copysign(y,x)` should probably be:
```julia
@scalar_rule copysign(y, x) (ifelse(signbit(x)!=signbit(y), -one(y), +one(y)), NoTangent())
```
. You can also find the arguments there why `NoTangent()` is preferred over `0`. 
The testing gets into problems, if too close to zero for x or y, due to the non-continuity of this function.
