### PR TITLE
do not differentiate through the construction of BitArray

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "1.9.1"
+version = "1.10.0"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "1.9"
+version = "1.9.1"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/rulesets/Base/nondiff.jl
+++ b/src/rulesets/Base/nondiff.jl
@@ -84,6 +84,7 @@
 @non_differentiable Vector(::AbstractArray{Bool})
 
 @non_differentiable Array(::AbstractArray{Bool})
+@non_differentiable BitArray(::Any)
 @non_differentiable IndexStyle(::AbstractArray{Bool})
 
 #####


### PR DESCRIPTION
Based on @oxinabox 's reply here: https://github.com/SciML/DiffEqFlux.jl/issues/502#issuecomment-902023817 .

This solves also the issues with the callback construction in https://github.com/SciML/DiffEqFlux.jl/issues/502.

Does it need a test? Should I maybe add one from https://github.com/SciML/DiffEqFlux.jl/issues/502#issuecomment-902015247 in here: https://github.com/JuliaDiff/ChainRules.jl/blob/master/test/rulesets/Base/array.jl ?