### PR TITLE
Add rules for sqrt(::Diagonal)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "1.10.1"
+version = "1.10.2"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/rulesets/LinearAlgebra/structured.jl
+++ b/src/rulesets/LinearAlgebra/structured.jl
@@ -41,10 +41,9 @@ _diagview(x::Tangent{<:Diagonal}) = x.diag
 function ChainRulesCore.rrule(::typeof(sqrt), d::Diagonal)
     y = sqrt(d)
     @assert y isa Diagonal
-    function sqrt_pullback(Δ_raw)
-      Δ = unthunk(Δ_raw)
-      Δ_diag = _diagview(Δ)
-      return NoTangent(), Diagonal(Δ_diag ./ (2 .* y.diag))
+    function sqrt_pullback(Δ)
+        Δ_diag = _diagview(unthunk(Δ))
+        return NoTangent(), Diagonal(Δ_diag ./ (2 .* y.diag))
     end
     return y, sqrt_pullback
 end

--- a/src/rulesets/LinearAlgebra/structured.jl
+++ b/src/rulesets/LinearAlgebra/structured.jl
@@ -35,6 +35,16 @@ end
 ##### `Diagonal`
 #####
 
+_sqrt_pullback(Δ::ChainRules.Tangent, y) = return NoTangent(), Δ / (2y)
+_sqrt_pullback(Δ::Diagonal, y) = return NoTangent(), Δ / (2y)
+_sqrt_pullback(Δ::Matrix, y) = return NoTangent(), Diagonal(Δ) / (2y)
+_sqrt_pullback(Δ::ChainRules.AbstractThunk, y) = return _sqrt_pullback(unthunk(Δ), y)
+function ChainRulesCore.rrule(::typeof(sqrt), d::Diagonal)
+    y = sqrt(d)
+    sqrt_pullback(Δ) = _sqrt_pullback(Δ, y)
+    return y, sqrt_pullback
+end
+
 # these functions are defined outside the rrule because otherwise type inference breaks
 # see https://github.com/JuliaLang/julia/issues/40990
 _Diagonal_pullback(ȳ::AbstractMatrix) = return (NoTangent(), diag(ȳ)) # should we emit a warning here? this shouldn't be called if project works right

--- a/test/rulesets/LinearAlgebra/structured.jl
+++ b/test/rulesets/LinearAlgebra/structured.jl
@@ -88,8 +88,8 @@
         end
     end
     @testset "sqrt(::Diagonal)" begin
-        test_rrule(sqrt, Diagonal([1.0, 2, 3]))
-        test_rrule(sqrt, Diagonal([1.0, 2, 3]); output_tangent=Diagonal(rand(3)) + zeros(3,3))
+        test_rrule(sqrt, Diagonal(rand(3)))
+        test_rrule(sqrt, Diagonal(rand(3)); output_tangent=rand(3, 3))
     end
     @testset "$f, $T" for
         f in (Adjoint, adjoint, Transpose, transpose),

--- a/test/rulesets/LinearAlgebra/structured.jl
+++ b/test/rulesets/LinearAlgebra/structured.jl
@@ -89,7 +89,7 @@
     end
     @testset "sqrt(::Diagonal)" begin
         test_rrule(sqrt, Diagonal(rand(3)))
-        test_rrule(sqrt, Diagonal(rand(3)); output_tangent=rand(3, 3))
+        test_rrule(sqrt, Diagonal(10*rand(3)); output_tangent=10*rand(3, 3))
     end
     @testset "$f, $T" for
         f in (Adjoint, adjoint, Transpose, transpose),

--- a/test/rulesets/LinearAlgebra/structured.jl
+++ b/test/rulesets/LinearAlgebra/structured.jl
@@ -89,6 +89,7 @@
     end
     @testset "sqrt(::Diagonal)" begin
         test_rrule(sqrt, Diagonal([1.0, 2, 3]))
+        test_rrule(sqrt, Diagonal([1.0, 2, 3]); output_tangent=Diagonal(rand(3)) + zeros(3,3))
     end
     @testset "$f, $T" for
         f in (Adjoint, adjoint, Transpose, transpose),

--- a/test/rulesets/LinearAlgebra/structured.jl
+++ b/test/rulesets/LinearAlgebra/structured.jl
@@ -89,7 +89,7 @@
     end
     @testset "sqrt(::Diagonal)" begin
         test_rrule(sqrt, Diagonal(rand(3)))
-        test_rrule(sqrt, Diagonal(10*rand(3)); output_tangent=10*rand(3, 3))
+        test_rrule(sqrt, Diagonal([1.0, 2]); output_tangent=[1.2 3.4; 1.2 4.3])
     end
     @testset "$f, $T" for
         f in (Adjoint, adjoint, Transpose, transpose),

--- a/test/rulesets/LinearAlgebra/structured.jl
+++ b/test/rulesets/LinearAlgebra/structured.jl
@@ -87,6 +87,9 @@
             end
         end
     end
+    @testset "sqrt, diag" begin
+        test_rrule(sqrt, Diagonal([1,2,3]))
+    end
     @testset "$f, $T" for
         f in (Adjoint, adjoint, Transpose, transpose),
         T in (Float64, ComplexF64)


### PR DESCRIPTION
Adding an `rrule` for `sqrt(::Diagonal)`, relating to [a comment](https://github.com/JuliaDiff/ChainRulesCore.jl/issues/441#issuecomment-902941440) in an issue discussing structural vs natural `Tangents`