### PR TITLE
Don't ProjectTo in reverse or circshift

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "1.11.1"
+version = "1.11.2"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/rulesets/Base/array.jl
+++ b/src/rulesets/Base/array.jl
@@ -303,10 +303,9 @@ function frule((_, xdot), ::typeof(reverse), x::AbstractArray, args...; kw...)
 end
 
 function rrule(::typeof(reverse), x::AbstractArray, args...; kw...)
-    project = ProjectTo(x)
     nots = map(_ -> NoTangent(), args)
     function reverse_pullback(dy)
-        dx = @thunk project(reverse(unthunk(dy), args...; kw...))
+        dx = @thunk reverse(unthunk(dy), args...; kw...)
         return (NoTangent(), dx, nots...)
     end
     return reverse(x, args...; kw...), reverse_pullback
@@ -321,9 +320,8 @@ function frule((_, xdot), ::typeof(circshift), x::AbstractArray, shifts)
 end
 
 function rrule(::typeof(circshift), x::AbstractArray, shifts)
-    project = ProjectTo(x)
     function circshift_pullback(dy)
-        dx = @thunk project(circshift(unthunk(dy), map(-, shifts)))
+        dx = @thunk circshift(unthunk(dy), map(-, shifts))
         # Note that circshift! is useless for InplaceableThunk, as it overwrites completely
         return (NoTangent(), dx, NoTangent())
     end

--- a/test/rulesets/Base/array.jl
+++ b/test/rulesets/Base/array.jl
@@ -171,7 +171,9 @@ end
 
         # Structured
         y, pb = rrule(reverse, Diagonal([1,2,3]))
-        @test unthunk(pb(rand(3,3))[2]) isa Diagonal
+        # We only preserve structure in this case if given structured tangent (no ProjectTo)
+        @test unthunk(pb(Diagonal([1.1, 2.1, 3.1]))[2]) isa Diagonal
+        @test unthunk(pb(rand(3, 3))[2]) isa AbstractArray
     end
 end
 


### PR DESCRIPTION
Closes #518 

ProjectTo in these rearranging linear operators seems not worth it.
It causes problems since they are often used on types that are on representing vector spaces -- and ProjectTo is not fully defined on those.
Which then error.
See #518 for more details.

These are fine if we were given good pullback inputs (i.e. if the functions called after did ensure things were good), we preserve those.

(circshift doesn't work on (any?) structurally spaces matrixes anyway)