### PR TITLE
`@opt_out of sum(array, array)`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "1.11.4"
+version = "1.11.5"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "1.11.3"
+version = "1.11.4"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/rulesets/Base/mapreduce.jl
+++ b/src/rulesets/Base/mapreduce.jl
@@ -89,7 +89,15 @@ function rrule(
 end
 
 # https://github.com/JuliaDiff/ChainRules.jl/issues/522
-@opt_out ChainRulesCore.rrule(config::RuleConfig{>:HasReverseMode}, ::typeof(sum), x::AbstractArray, y::AbstractArray; dims=:)
+# The rule above assumes `f` is callable. Arrays are not, this came up when summing
+# arrays with weights in StatsBase
+@opt_out ChainRulesCore.rrule(
+    config::RuleConfig{>:HasReverseMode},
+    ::typeof(sum),
+    x::AbstractArray,
+    y::AbstractArray;
+    dims=:
+)
 
 function frule(
     (_, _, Δx),

--- a/src/rulesets/Base/mapreduce.jl
+++ b/src/rulesets/Base/mapreduce.jl
@@ -88,6 +88,9 @@ function rrule(
     return y, sum_pullback
 end
 
+# https://github.com/JuliaDiff/ChainRules.jl/issues/522
+@opt_out ChainRulesCore.rrule(config::RuleConfig{>:HasReverseMode}, ::typeof(sum), x::AbstractArray, y::AbstractArray; dims=:)
+
 function frule(
     (_, _, Δx),
     ::typeof(sum),

--- a/test/rulesets/Base/mapreduce.jl
+++ b/test/rulesets/Base/mapreduce.jl
@@ -90,6 +90,16 @@
         @test_skip test_rrule(sum, iszero, randn(5))  # DimensionMismatch("second dimension of A, 1, does not match length of x, 0")
     end
 
+    # https://github.com/JuliaDiff/ChainRules.jl/issues/522
+    @begin "sum(xs, weights) (#522)" begin
+        xs = rand(5)
+        weights = rand(5)
+        Base.sum(xs::AbstractArray, weights::AbstractArray) = dot(xs, weights)
+        struct MyRuleConfig <: RuleConfig{Union{HasReverseMode}} end
+
+        @test rrule(MyRuleConfig(), Base.sum, xs, weights) isa Nothing
+    end
+
     @testset "prod" begin
         @testset "Array{$T}" for T in [Float64, ComplexF64]
             @testset "size = $sz, dims = $dims" for (sz, dims) in [

--- a/test/rulesets/Base/mapreduce.jl
+++ b/test/rulesets/Base/mapreduce.jl
@@ -1,3 +1,7 @@
+# for sum(xs, weights) (#522)
+Base.sum(xs::AbstractArray, weights::AbstractArray) = dot(xs, weights)
+struct SumRuleConfig <: RuleConfig{Union{HasReverseMode}} end
+
 @testset "Maps and Reductions" begin
     @testset "sum(x; dims=$dims)" for dims in (:, 2, (1,3))
         # Forward
@@ -94,10 +98,8 @@
     @testset "sum(xs, weights) (#522)" begin
         xs = rand(5)
         weights = rand(5)
-        Base.sum(xs::AbstractArray, weights::AbstractArray) = dot(xs, weights)
-        struct MyRuleConfig <: RuleConfig{Union{HasReverseMode}} end
 
-        @test rrule(MyRuleConfig(), Base.sum, xs, weights) isa Nothing
+        @test rrule(SumRuleConfig(), Base.sum, xs, weights) isa Nothing
     end
 
     @testset "prod" begin

--- a/test/rulesets/Base/mapreduce.jl
+++ b/test/rulesets/Base/mapreduce.jl
@@ -91,7 +91,7 @@
     end
 
     # https://github.com/JuliaDiff/ChainRules.jl/issues/522
-    @begin "sum(xs, weights) (#522)" begin
+    @testset "sum(xs, weights) (#522)" begin
         xs = rand(5)
         weights = rand(5)
         Base.sum(xs::AbstractArray, weights::AbstractArray) = dot(xs, weights)


### PR DESCRIPTION
closes #522 

This will still error if `f` in `sum(f, xs)` is a non-callable struct, but we can cross that bridge once (if ever) we actually get to it.