### PR TITLE
Use `Returns`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 [compat]
 ChainRulesCore = "1.1"
 ChainRulesTestUtils = "1"
-Compat = "3.33"
+Compat = "3.35"
 FiniteDifferences = "0.12.8"
 JuliaInterpreter = "0.8"
 StaticArrays = "1.2"

--- a/src/rulesets/Base/indexing.jl
+++ b/src/rulesets/Base/indexing.jl
@@ -20,7 +20,7 @@ function rrule(::typeof(getindex), x::Array{<:Number}, inds...)
             getindex_add!,
             @thunk(getindex_add!(zero(x))),
         )
-        īnds = broadcast(_ -> NoTangent(), inds)
+        īnds = broadcast(Returns(NoTangent()), inds)
         return (NoTangent(), x̄, īnds...)
     end
 

--- a/src/rulesets/Random/random.jl
+++ b/src/rulesets/Random/random.jl
@@ -2,7 +2,7 @@ frule(Δargs, T::Type{<:AbstractRNG}, args...) = T(args...), ZeroTangent()
 
 function rrule(T::Type{<:AbstractRNG}, args...)
     function AbstractRNG_pullback(ΔΩ)
-        return (NoTangent(), map(_ -> ZeroTangent(), args)...)
+        return (NoTangent(), map(Returns(ZeroTangent()), args)...)
     end
     return T(args...), AbstractRNG_pullback
 end


### PR DESCRIPTION
Minor tweak to do things like `map(Returns(ZeroTangent()), args)` instead of having a separate anonymous function each time. 