### PR TITLE
Backport: handle sum(f, xs) where f returns a Vector

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "0.8.24"
+version = "0.8.25"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/rulesets/Base/mapreduce.jl
+++ b/src/rulesets/Base/mapreduce.jl
@@ -49,8 +49,10 @@ function rrule(
     pullbacks = last.(fx_and_pullbacks)
 
     function sum_pullback(ȳ)
-        call(f, x) = f(x)  # we need to broadcast this to handle dims kwarg
-        f̄_and_x̄s = call.(pullbacks, ȳ)
+        call(f, x) = f(x)
+        # if dims is :, then need only left-handed only broadcast
+        broadcast_ȳ = dims isa Colon  ? (ȳ,) : ȳ
+        f̄_and_x̄s = call.(pullbacks, broadcast_ȳ)
         # no point thunking as most of work is in f̄_and_x̄s which we need to compute for both
         f̄ = if fieldcount(typeof(f)) === 0 # Then don't need to worry about derivative wrt f
             NoTangent()

--- a/test/rulesets/Base/mapreduce.jl
+++ b/test/rulesets/Base/mapreduce.jl
@@ -50,6 +50,15 @@
         # see https://github.com/JuliaDiff/ChainRules.jl/issues/232 etc
         _, pb = rrule(ADviaRuleConfig(), sum, abs, Diagonal([1.0, -3.0]))
         @test_broken pb(1.0)[3] isa Diagonal
+
+
+        # Functions that return a Vector
+        # see https://github.com/FluxML/Zygote.jl/issues/1074
+        test_rrule(sum, make_two_vec, [1.0, 3.0, 5.0, 7.0])
+        test_rrule(sum, make_two_vec, [1.0 2.0; 3.0 4.0]; fkwargs=(;dims=2))
+        test_rrule(sum, make_two_vec, [1.0 2.0; 3.0 4.0])
+        test_rrule(sum, make_two_vec, [1.0 2.0; 3.0 4.0]; fkwargs=(;dims=1))
+        test_rrule(sum, make_two_vec, [1.0 2.0; 3.0 4.0]; fkwargs=(;dims=(3, 4)))
     end
 
     @testset "prod" begin

--- a/test/test_helpers.jl
+++ b/test/test_helpers.jl
@@ -8,8 +8,18 @@ function ChainRulesCore.rrule(m::Multiplier, y)
     return m(y), Multiplier_pullback
 end
 
+"A function that outputs a vector from a scalar for testing"
+make_two_vec(x) = [x, x]
+    make_two_vec_pullback(ȳ) = (NoTangent(), sum(ȳ))
+function ChainRulesCore.rrule(::typeof(make_two_vec), x)
+    return make_two_vec(x), make_two_vec_pullback
+end
+
 @testset "test_helpers.jl" begin
-    @testset "Multiplier functor test-helper" begin
+    @testset "Multiplier functor" begin
         test_rrule(Multiplier(4.0), 3.0)
+    end
+    @testset "make_two_vec" begin
+        test_rrule(make_two_vec, 1.5)
     end
 end


### PR DESCRIPTION
This is a backport of #534  to the release-0.8 branch.
Thus closing https://github.com/FluxML/Zygote.jl/issues/1074
which required it to work in Zygote v0.6.13

As this is just a backport and #534 has already been reviewed this does not require review