### PR TITLE
Fix VersionVigilante action

### DIFF
--- a/.github/workflows/VersionVigilante_pull_request.yml
+++ b/.github/workflows/VersionVigilante_pull_request.yml
@@ -11,8 +11,11 @@ jobs:
       - name: VersionVigilante.main
         id: versionvigilante_main
         run: |
-          julia -e 'using Pkg; Pkg.add("VersionVigilante")'
-          julia -e 'using VersionVigilante; VersionVigilante.main("https://github.com/${{ github.repository }}")'
+          using Pkg
+          Pkg.add("VersionVigilante")
+          using VersionVigilante
+          VersionVigilante.main("https://github.com/${{ github.repository }}", master_branch="main")
+        shell: julia {0}
       - name: ✅ Un-Labeller (if success)
         if: (steps.versionvigilante_main.outputs.compare_versions == 'success') && (success() || failure())
         continue-on-error: true


### PR DESCRIPTION
The VersionVigilante action fails currently since master was renamed to main: https://github.com/JuliaDiff/ChainRules.jl/runs/3988054388?check_suite_focus=true

This PR should fix the issue.

Edit: It seems to work: https://github.com/JuliaDiff/ChainRules.jl/runs/3988077098?check_suite_focus=true