### PR TITLE
`rrule` for many-arg `*`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "1.14.0"
+version = "1.15.0"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/rulesets/Base/fastmath_able.jl
+++ b/src/rulesets/Base/fastmath_able.jl
@@ -231,7 +231,7 @@ let
             # Optimized version of `Δx .* y .+ x .* Δy`. Also, it is potentially more
             # accurate on machines with FMA instructions, since there are only two
             # rounding operations, one in `muladd/fma` and the other in `*`.
-            ∂xy = muladd(Δx, y, x .* Δy)
+            ∂xy = muladd.(Δx, y, x .* Δy)
             return x * y, ∂xy
         end
 

--- a/src/rulesets/Base/fastmath_able.jl
+++ b/src/rulesets/Base/fastmath_able.jl
@@ -231,7 +231,7 @@ let
             # Optimized version of `Δx .* y .+ x .* Δy`. Also, it is potentially more
             # accurate on machines with FMA instructions, since there are only two
             # rounding operations, one in `muladd/fma` and the other in `*`.
-            ∂xy = muladd.(Δx, y, x .* Δy)
+            ∂xy = muladd(Δx, y, x .* Δy)
             return x * y, ∂xy
         end
 

--- a/src/rulesets/Base/fastmath_able.jl
+++ b/src/rulesets/Base/fastmath_able.jl
@@ -231,9 +231,10 @@ let
             # Optimized version of `Δx .* y .+ x .* Δy`. Also, it is potentially more
             # accurate on machines with FMA instructions, since there are only two
             # rounding operations, one in `muladd/fma` and the other in `*`.
-            ∂xy = muladd.(Δx, y, x .* Δy)
+            ∂xy = muladd(Δx, y, x * Δy)
             return x * y, ∂xy
         end
+        frule((_, Δx), ::typeof(*), x::Number) = x, Δx
 
         function rrule(::typeof(*), x::Number, y::Number)
             function times_pullback2(Ω̇)

--- a/test/rulesets/Base/base.jl
+++ b/test/rulesets/Base/base.jl
@@ -105,11 +105,13 @@
             test_rrule(*, x, y)
         end
         @testset "*($x, $y, ...)" for x in test_points, y in test_points
+            # This promotion is only for FiniteDifferences, the rules allow mixtures:
             x, y = Base.promote(x, y)
 
-            test_rrule(*, x, y, x+y)
-            test_rrule(*, x, y, 17x, 23y)
-            test_rrule(*, x, y, 7x, 3y, x+y+pi)
+            # Inference fails on 1.0, passes on 1.6
+            test_rrule(*, x, y, x+y; check_inferred=VERSION>v"1.5")
+            test_rrule(*, x, y, 17x, 23y; check_inferred=VERSION>v"1.5")
+            test_rrule(*, x, y, 7x, 3y, x+y+pi; check_inferred=VERSION>v"1.5")
         end
     end
 

--- a/test/rulesets/Base/base.jl
+++ b/test/rulesets/Base/base.jl
@@ -104,6 +104,13 @@
             test_frule(*, x, y)
             test_rrule(*, x, y)
         end
+        @testset "*($x, $y, ...)" for x in test_points, y in test_points
+            x, y = Base.promote(x, y)
+
+            test_rrule(*, x, y, x+y)
+            test_rrule(*, x, y, 17x, 23y)
+            test_rrule(*, x, y, 7x, 3y, x+y+pi)
+        end
     end
 
     @testset "ldexp" begin

--- a/test/rulesets/Base/fastmath_able.jl
+++ b/test/rulesets/Base/fastmath_able.jl
@@ -120,6 +120,7 @@ const FASTABLE_AST = quote
             test_scalar(+, x)
             test_scalar(-, x)
             test_scalar(atan, x)
+            test_scalar(*, x)
         end
     end
 
@@ -132,7 +133,7 @@ const FASTABLE_AST = quote
             test_rrule(f, (rand(0:10) + .6rand() + .2) * base, base)
         end
 
-        @testset "$f(x::$T, y::$T)" for f in (/, +, -, hypot), T in (Float64, ComplexF64)
+        @testset "$f(x::$T, y::$T)" for f in (/, +, -, *, hypot), T in (Float64, ComplexF64)
             test_frule(f, 10rand(T), rand(T))
             test_rrule(f, 10rand(T), rand(T))
         end


### PR DESCRIPTION
Closes #544

This makes an `rrule` for 3, and one for many arguments which peels off 3. It's possible that 2 and many would be as good, I don't think I tried that.

Also adds a trivial rule for unary `*` although I'm not sure it's necessary.