### PR TITLE
fix for julia 1.7

### DIFF
--- a/test/rulesets/LinearAlgebra/structured.jl
+++ b/test/rulesets/LinearAlgebra/structured.jl
@@ -7,8 +7,8 @@
 
         @testset "\\ $T on LHS" for T in (Diagonal, UpperTriangular, LowerTriangular)
             LHS = T(randn(T == Diagonal ? 10 : (10, 10)))
-            test_rrule(\, LHS, randn(Float32, 10); rtol = 1.0e-4, atol = 1.0e-4)
-            test_rrule(\, LHS, randn(Float32, 10, 10); rtol = 1.0e-4, atol = 1.0e-4)
+            test_rrule(\, LHS, randn(Float32, 10); rtol = 1.0e-3, atol = 1.0e-3)
+            test_rrule(\, LHS, randn(Float32, 10, 10); rtol = 1.0e-3, atol = 1.0e-3)
         end
     end
 

--- a/test/rulesets/LinearAlgebra/symmetric.jl
+++ b/test/rulesets/LinearAlgebra/symmetric.jl
@@ -307,7 +307,7 @@
                 λ = if f in (acos, asin, atanh)
                     # generate random number between -1 and 0.9. This would be between
                     # -1 and 1 but we want to avoid domain errors from numerical error
-                    1.9 .* rand(real(T), n) .- 1
+                    T(1.9) .* rand(real(T), n) .- 1
                 elseif f in (log, sqrt)
                     abs.(randn(real(T), n))
                 elseif f === acosh

--- a/test/rulesets/LinearAlgebra/symmetric.jl
+++ b/test/rulesets/LinearAlgebra/symmetric.jl
@@ -305,7 +305,9 @@
             U = Matrix(qr(randn(T, n, n)).Q)
             if hermout # f(A) will also be a TA
                 λ = if f in (acos, asin, atanh)
-                    2 .* rand(real(T), n) .- 1
+                    # generate random number between -1 and 0.9. This would be between
+                    # -1 and 1 but we want to avoid domain errors from numerical error
+                    1.9 .* rand(real(T), n) .- 1
                 elseif f in (log, sqrt)
                     abs.(randn(real(T), n))
                 elseif f === acosh


### PR DESCRIPTION
Closes #549 

- Change in structured handles factorization becoming less accurate and thus finite differencing beween less accurate
-  Just ups out tolerance of error
- https://github.com/JuliaDiff/ChainRules.jl/runs/4390009367?check_suite_focus=true#step:6:134


And

 - Change in symmetric handles factorization becoming less accurate and thus the finite differencing escaping the domain (we possibly should fix the `_fdm` to point the right way though?)
 - This change just makes sure our initial point is less close to boundry