### PR TITLE
use begin/end for linear indexing in _evalpoly_indeterminates

### DIFF
--- a/src/rulesets/Base/evalpoly.jl
+++ b/src/rulesets/Base/evalpoly.jl
@@ -144,7 +144,7 @@ if VERSION ≥ v"1.4"
                 ∂p[i] = _evalpoly_backp(p[firstindex(p) - 1 + i], ∂yi)
                 ∂yi = x′ * ∂yi
             end
-            ∂p[N] = _evalpoly_backp(p[end], ∂yi)
+            ∂p[N] = _evalpoly_backp(p[lastindex(p)], ∂yi)
         end
         return ∂x, ∂p
     end

--- a/src/rulesets/Base/evalpoly.jl
+++ b/src/rulesets/Base/evalpoly.jl
@@ -61,6 +61,7 @@ if VERSION ≥ v"1.4"
         return y, ys
     end
     function _evalpoly_intermediates(x, p)
+        @show :hi, p
         N = length(p)
         @inbounds yn = one(x) * p[lastindex(p)]
         ys = similar(p, typeof(yn), N - 1)
@@ -133,7 +134,7 @@ if VERSION ≥ v"1.4"
         x′ = x'
         ∂yi = one(x′) * Δy
         N = length(p)
-        @inbounds ∂p1 = _evalpoly_backp(p[1], ∂yi)
+        @inbounds ∂p1 = _evalpoly_backp(p[firstindex(p)], ∂yi)
         ∂p = similar(p, typeof(∂p1))
         @inbounds begin
             ∂x = _evalpoly_backx(x, ys[N - 1], ∂yi)
@@ -141,10 +142,10 @@ if VERSION ≥ v"1.4"
             ∂p[1] = ∂p1
             for i in 2:(N - 1)
                 ∂x = _evalpoly_backx(x, ys[N - i], ∂x, ∂yi)
-                ∂p[i] = _evalpoly_backp(p[i], ∂yi)
+                ∂p[i] = _evalpoly_backp(p[firstindex(p) - 1 + i], ∂yi)
                 ∂yi = x′ * ∂yi
             end
-            ∂p[N] = _evalpoly_backp(p[N], ∂yi)
+            ∂p[N] = _evalpoly_backp(p[end], ∂yi)
         end
         return ∂x, ∂p
     end

--- a/src/rulesets/Base/evalpoly.jl
+++ b/src/rulesets/Base/evalpoly.jl
@@ -62,13 +62,13 @@ if VERSION ≥ v"1.4"
     end
     function _evalpoly_intermediates(x, p)
         N = length(p)
-        @inbounds yn = one(x) * p[end]
+        @inbounds yn = one(x) * p[lastindex(p)]
         ys = similar(p, typeof(yn), N - 1)
         @inbounds ys[1] = yn
         @inbounds for i in 2:(N - 1)
-            ys[i] = muladd(x, ys[i - 1], p[end - i + 1])
+            ys[i] = muladd(x, ys[i - 1], p[lastindex(p) - i + 1])
         end
-        @inbounds y = muladd(x, ys[N - 1], p[begin])
+        @inbounds y = muladd(x, ys[N - 1], p[firstindex(p)])
         return y, ys
     end
 

--- a/src/rulesets/Base/evalpoly.jl
+++ b/src/rulesets/Base/evalpoly.jl
@@ -3,11 +3,11 @@ if VERSION ≥ v"1.4"
     function frule((_, ẋ, ṗ), ::typeof(evalpoly), x, p)
         Δx, Δp = ẋ, unthunk(ṗ)
         N = length(p)
-        @inbounds y = p[N]
+        @inbounds y = p[end]
         Δy = Δp[N]
         @inbounds for i in (N - 1):-1:1
             Δy = muladd(Δx, y, muladd(x, Δy, Δp[i]))
-            y = muladd(x, y, p[i])
+            y = muladd(x, y, p[firstindex(p) - 1 + i])
         end
         return y, Δy
     end

--- a/src/rulesets/Base/evalpoly.jl
+++ b/src/rulesets/Base/evalpoly.jl
@@ -62,13 +62,13 @@ if VERSION ≥ v"1.4"
     end
     function _evalpoly_intermediates(x, p)
         N = length(p)
-        @inbounds yn = one(x) * p[N]
+        @inbounds yn = one(x) * p[end]
         ys = similar(p, typeof(yn), N - 1)
         @inbounds ys[1] = yn
         @inbounds for i in 2:(N - 1)
-            ys[i] = muladd(x, ys[i - 1], p[N - i + 1])
+            ys[i] = muladd(x, ys[i - 1], p[end - i + 1])
         end
-        @inbounds y = muladd(x, ys[N - 1], p[1])
+        @inbounds y = muladd(x, ys[N - 1], p[begin])
         return y, ys
     end
 

--- a/src/rulesets/Base/evalpoly.jl
+++ b/src/rulesets/Base/evalpoly.jl
@@ -61,7 +61,6 @@ if VERSION ≥ v"1.4"
         return y, ys
     end
     function _evalpoly_intermediates(x, p)
-        @show :hi, p
         N = length(p)
         @inbounds yn = one(x) * p[lastindex(p)]
         ys = similar(p, typeof(yn), N - 1)


### PR DESCRIPTION
This uses `begin`/`end` for linear indexing in `_evalpoly_indeterminates`. This should close https://github.com/JuliaMath/Polynomials.jl/issues/313. (The object passed has 0-based indexing for which the current usage is not appropriate.)