### PR TITLE
Some rules for `UniformScaling`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ RealDot = "c1ae055f-0cd5-4b69-90a6-9a35b1a98df9"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-ChainRulesCore = "1.11.5"
+ChainRulesCore = "1.12"
 ChainRulesTestUtils = "1.5"
 Compat = "3.35"
 FiniteDifferences = "0.12.20"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "1.25"
+version = "1.26"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/ChainRules.jl
+++ b/src/ChainRules.jl
@@ -41,6 +41,7 @@ include("rulesets/LinearAlgebra/matfun.jl")
 include("rulesets/LinearAlgebra/structured.jl")
 include("rulesets/LinearAlgebra/symmetric.jl")
 include("rulesets/LinearAlgebra/factorization.jl")
+include("rulesets/LinearAlgebra/uniformscaling.jl")
 
 include("rulesets/Random/random.jl")
 

--- a/src/rulesets/LinearAlgebra/uniformscaling.jl
+++ b/src/rulesets/LinearAlgebra/uniformscaling.jl
@@ -13,11 +13,11 @@ end
 #####
 
 function frule((_, Δx, ΔJ), ::typeof(+), x::AbstractMatrix, J::UniformScaling)
-    return x + J, Δx + ΔJ
+    return x + J, Δx + (zero(J) + ΔJ)  # This (0 + ΔJ) allows for ΔJ::Tangent{UniformScaling}
 end
 
 function frule((_, ΔJ, Δx), ::typeof(+), J::UniformScaling, x::AbstractMatrix)
-    return J + x, ΔJ + Δx
+    return J + x, (zero(J) + ΔJ) + Δx
 end
 
 function rrule(::typeof(+), x::AbstractMatrix, J::UniformScaling)
@@ -44,11 +44,11 @@ end
 #####
 
 function frule((_, Δx, ΔJ), ::typeof(-), x::AbstractMatrix, J::UniformScaling)
-    return x - J, Δx - ΔJ
+    return x - J, Δx - (zero(J) + ΔJ)
 end
 
 function frule((_, ΔJ, Δx), ::typeof(-), J::UniformScaling, x::AbstractMatrix)
-    return J - x, ΔJ - Δx
+    return J - x, (zero(J) + ΔJ) - Δx
 end
 
 function rrule(::typeof(-), x::AbstractMatrix, J::UniformScaling)

--- a/src/rulesets/LinearAlgebra/uniformscaling.jl
+++ b/src/rulesets/LinearAlgebra/uniformscaling.jl
@@ -1,0 +1,97 @@
+
+#####
+##### `+`
+#####
+
+function frule((_, Δx, ΔI), ::typeof(+), x::AbstractMatrix, I::UniformScaling)
+    return x + I, Δx + ΔI
+end
+
+function frule((_, ΔI, Δx), ::typeof(+), I::UniformScaling, x::AbstractMatrix)
+    return I + x, ΔI + Δx
+end
+
+function rrule(::typeof(+), x::AbstractMatrix, I::UniformScaling)
+    project_x = ProjectTo(x)
+    project_λ = ProjectTo(I.λ)
+    y = x + I
+    function plus_back(dy)
+        dx = unthunk(dy)
+        dλ = if I.λ isa Bool
+            NoTangent()
+        else
+            Tangent{typeof(I)}(; λ = project_λ(tr(dx)))
+        end
+        return (NoTangent(), project_x(dx), dλ)
+    end
+    return y, plus_back
+end
+
+function rrule(::typeof(+), I::UniformScaling, x::AbstractMatrix)
+    y, back = rrule(+, x, I)
+    function plus_back_2(dy)
+        df, dx, dI = back(dy)
+        return (df, dI, dx)
+    end
+    return y, plus_back_2
+end
+
+#####
+##### `-`
+#####
+
+function frule((_, Δx, ΔI), ::typeof(-), x::AbstractMatrix, I::UniformScaling)
+    return x - I, Δx - ΔI
+end
+
+function frule((_, ΔI, Δx), ::typeof(-), I::UniformScaling, x::AbstractMatrix)
+    return I - x, ΔI - Δx
+end
+
+function rrule(::typeof(-), x::AbstractMatrix, I::UniformScaling)
+    y, back = rrule(+, x, -I)
+    function minus_back_1(dy)
+        df, dx, dImaybe = back(dy)
+        dI = I.λ isa Bool ? NoTangent() : dImaybe  # as -true isa Int
+        return (df, dx, -dI)
+    end
+    return y, minus_back_1
+end
+
+function rrule(::typeof(-), I::UniformScaling, x::AbstractMatrix)
+    project_x = ProjectTo(x)
+    project_λ = ProjectTo(I.λ)
+    y = I - x
+    function minus_back_2(dy)
+        dx = -unthunk(dy)
+        dλ = if I.λ isa Bool
+            NoTangent()
+        else
+            Tangent{typeof(I)}(; λ = project_λ(-tr(dx)))
+        end
+        return (NoTangent(), dλ, project_x(dx))
+    end
+    return y, minus_back_2
+end
+
+#####
+##### `Matrix`
+#####
+
+function rrule(::Type{T}, I::UniformScaling, (m, n)) where {T<:AbstractMatrix}
+    project_λ = ProjectTo(I.λ)
+    function Matrix_back_I(dy)
+        if I.λ isa Bool
+            return (NoTangent(), NoTangent(), NoTangent())
+        end
+        dλ = if m == n
+            project_λ(tr(unthunk(dy)))
+        else
+            project_λ(sum(diag(unthunk(dy))))
+        end
+        return (NoTangent(), Tangent{typeof(I)}(; λ = dλ), NoTangent())
+    end
+    return T(I, m, n), Matrix_back_I
+end
+
+

--- a/src/rulesets/LinearAlgebra/uniformscaling.jl
+++ b/src/rulesets/LinearAlgebra/uniformscaling.jl
@@ -25,7 +25,7 @@ function rrule(::typeof(+), x::AbstractMatrix, J::UniformScaling)
     project_J = ProjectTo(J)
     function plus_back(dy)
         dx = unthunk(dy)
-        (NoTangent(), project_x(dx), project_J(I * tr(dx)))
+        return (NoTangent(), project_x(dx), project_J(I * tr(dx)))
     end
     return x + J, plus_back
 end

--- a/src/rulesets/LinearAlgebra/uniformscaling.jl
+++ b/src/rulesets/LinearAlgebra/uniformscaling.jl
@@ -1,5 +1,14 @@
 
 #####
+##### constructor
+#####
+
+function rrule(::Type{T}, x::Number) where {T<:UniformScaling}
+    UniformScaling_back(dx) = (NoTangent(), ProjectTo(x)(unthunk(dx).λ))
+    return T(x), UniformScaling_back
+end
+
+#####
 ##### `+`
 #####
 

--- a/test/rulesets/LinearAlgebra/uniformscaling.jl
+++ b/test/rulesets/LinearAlgebra/uniformscaling.jl
@@ -1,0 +1,33 @@
+@testset "UniformScaling rules" begin
+
+    @testset "+" begin
+        # Forward
+        @test_skip test_frule(+, rand(3,3), I * rand(ComplexF64))  # MethodError: no method matching +(::Matrix{Float64}, ::Tangent{UniformScaling{ComplexF64}, NamedTuple{(:λ,), Tuple{ComplexF64}}})
+        test_frule(+, I, rand(3,3))
+
+        # Reverse
+        test_rrule(+, rand(3,3), I)
+        test_rrule(+, rand(3,3), I * rand(ComplexF64))
+        test_rrule(+, I, rand(3,3))
+        test_rrule(+, I * rand(), rand(ComplexF64, 3,3))
+    end
+
+    @testset "-" begin
+        # Forward
+        @test_skip test_frule(-, rand(3,3), I * rand(ComplexF64))  # MethodError: no method matching +(::Matrix{Float64}, ::Tangent{UniformScaling{ComplexF64}, NamedTuple{(:λ,), Tuple{ComplexF64}}})
+        test_frule(-, I, rand(3,3))
+
+        # Reverse
+        test_rrule(-, rand(3,3), I)
+        test_rrule(-, rand(3,3), I * rand(ComplexF64))
+        test_rrule(-, I, rand(3,3))
+        test_rrule(-, I * rand(), rand(ComplexF64, 3,3))
+    end
+
+    @testset "Matrix" begin
+        test_rrule(Matrix, I, (2, 2))
+        test_rrule(Matrix{ComplexF64}, rand()*I, (3, 3))
+        test_rrule(Matrix, rand(ComplexF64)*I, (2, 4))
+    end
+
+end

--- a/test/rulesets/LinearAlgebra/uniformscaling.jl
+++ b/test/rulesets/LinearAlgebra/uniformscaling.jl
@@ -1,5 +1,9 @@
 @testset "UniformScaling rules" begin
 
+    @testset "constructor" begin
+        test_rrule(UniformScaling, rand(3))
+    end
+
     @testset "+" begin
         # Forward
         @test_skip test_frule(+, rand(3,3), I * rand(ComplexF64))  # MethodError: no method matching +(::Matrix{Float64}, ::Tangent{UniformScaling{ComplexF64}, NamedTuple{(:λ,), Tuple{ComplexF64}}})

--- a/test/rulesets/LinearAlgebra/uniformscaling.jl
+++ b/test/rulesets/LinearAlgebra/uniformscaling.jl
@@ -6,7 +6,7 @@
 
     @testset "+" begin
         # Forward
-        @test_skip test_frule(+, rand(3,3), I * rand(ComplexF64))  # MethodError: no method matching +(::Matrix{Float64}, ::Tangent{UniformScaling{ComplexF64}, NamedTuple{(:λ,), Tuple{ComplexF64}}})
+        test_frule(+, rand(3,3), I * rand(ComplexF64))
         test_frule(+, I, rand(3,3))
 
         # Reverse
@@ -18,7 +18,7 @@
 
     @testset "-" begin
         # Forward
-        @test_skip test_frule(-, rand(3,3), I * rand(ComplexF64))  # MethodError: no method matching +(::Matrix{Float64}, ::Tangent{UniformScaling{ComplexF64}, NamedTuple{(:λ,), Tuple{ComplexF64}}})
+        test_frule(-, rand(3,3), I * rand(ComplexF64))
         test_frule(-, I, rand(3,3))
 
         # Reverse

--- a/test/rulesets/LinearAlgebra/uniformscaling.jl
+++ b/test/rulesets/LinearAlgebra/uniformscaling.jl
@@ -1,7 +1,7 @@
 @testset "UniformScaling rules" begin
 
     @testset "constructor" begin
-        test_rrule(UniformScaling, rand(3))
+        test_rrule(UniformScaling, rand())
     end
 
     @testset "+" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -71,6 +71,7 @@ end
     include_test("rulesets/LinearAlgebra/factorization.jl")
     include_test("rulesets/LinearAlgebra/blas.jl")
     include_test("rulesets/LinearAlgebra/lapack.jl")
+    include_test("rulesets/LinearAlgebra/uniformscaling.jl")
 
     println()
 


### PR DESCRIPTION
These were at first made a Tangent because:
```
julia> gradient(x -> sum([1 2; 3 4] * x), I*3.14)
(Tangent{UniformScaling{Float64}}(λ = Thunk(ChainRules.var"#1360#1364"{Matrix{Float64}, Matrix{Int64}, ProjectTo{Float64, NamedTuple{(), Tuple{}}}}([1.0 1.0; 1.0 1.0], [1 2; 3 4], ProjectTo{Float64}())),),)
```
But perhaps `I` in fact represents its own gradient Done in  https://github.com/JuliaDiff/ChainRulesCore.jl/pull/533