### PR TITLE
Limit evalpoly rule signatures to those in Base

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "1.20" 
+version = "1.20.1" 
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/rulesets/Base/evalpoly.jl
+++ b/src/rulesets/Base/evalpoly.jl
@@ -1,6 +1,6 @@
 
 if VERSION ≥ v"1.4"
-    function frule((_, ẋ, ṗ), ::typeof(evalpoly), x, p)
+    function frule((_, ẋ, ṗ), ::typeof(evalpoly), x, p::Union{Tuple,AbstractVector})
         Δx, Δp = ẋ, unthunk(ṗ)
         N = length(p)
         @inbounds y = p[N]
@@ -12,7 +12,7 @@ if VERSION ≥ v"1.4"
         return y, Δy
     end
 
-    function rrule(::typeof(evalpoly), x, p)
+    function rrule(::typeof(evalpoly), x, p::Union{Tuple,AbstractVector})
         y, ys = _evalpoly_intermediates(x, p)
         project_x = ProjectTo(x)
         project_p = p isa Tuple ? identity : ProjectTo(p)


### PR DESCRIPTION
As noted in https://github.com/JuliaDiff/ChainRules.jl/pull/564#issuecomment-1015540993, `evalpoly` in base only has the following methods:
```julia
[1] evalpoly(z::Complex, p::Tuple{Any}) in Base.Math at math.jl:201
[2] evalpoly(z::Complex, p::Tuple) in Base.Math at math.jl:176
[3] evalpoly(x, p::Tuple) in Base.Math at math.jl:152
[4] evalpoly(z::Complex, p::AbstractVector) in Base.Math at math.jl:204
[5] evalpoly(x, p::AbstractVector) in Base.Math at math.jl:165
```

This PR limits our `evalpoly` definition to only cover these signatures. This fixes #533.