### PR TITLE
Don't mutate cotangent in rule for `exp`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "1.26"
+version = "1.26.1"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/rulesets/LinearAlgebra/matfun.jl
+++ b/src/rulesets/LinearAlgebra/matfun.jl
@@ -132,7 +132,7 @@ function rrule(::typeof(exp), A0::StridedMatrix{<:BlasFloat})
             # Ensures ∂X is mutable. The outer `adjoint` is unwrapped without copy by
             # the default _matfun_frechet_adjoint!
             ΔX = unthunk(X̄)
-            ∂X = ChainRulesCore.is_inplaceable_destination(ΔX) ? ΔX : convert(Matrix, ΔX')'
+            ∂X = ChainRulesCore.is_inplaceable_destination(ΔX) ? copy(ΔX) : convert(Matrix, ΔX')'
             ∂A = _matfun_frechet_adjoint!(exp, ∂X, A, X, intermediates)
             return NoTangent(), ∂A
         end

--- a/test/rulesets/LinearAlgebra/matfun.jl
+++ b/test/rulesets/LinearAlgebra/matfun.jl
@@ -35,6 +35,15 @@
             Y, back = rrule(exp, A)
             @maybe_inferred back(rand_tangent(Y))
         end
+        @testset "cotangent not mutated" begin
+            # https://github.com/JuliaDiff/ChainRules.jl/issues/512
+            A = [1.0 2.0; 3.0 4.0]
+            Y, back = rrule(exp, A)
+            ΔY′ = rand_tangent(Y)'
+            ΔY′copy = copy(ΔY′)
+            back(ΔY′)
+            @test ΔY′ == ΔY′copy
+        end
         @testset "imbalanced A" begin
             A = Float64[0 10 0 0; -1 0 0 0; 0 0 0 0; -2 0 0 0]
             test_rrule(exp, A; check_inferred=false)


### PR DESCRIPTION
Fixes #512.

I'm not certain how to test this, since I was unable to replicate in ChainRules the bug observed in Zygote in that issue, but with the fix here, we get
```julia
julia> using Zygote

julia> gradient(x -> sum(abs, exp(x)' + exp(x)'), [1 2; 3 4.0])
([226.54923657197995 427.40643795569565; 309.84981350932094 579.219109950626],)

julia> gradient(x -> sum(abs, 2 * exp(x)'), [1 2; 3 4.0])
([226.54923657197995 427.40643795569565; 309.84981350932094 579.219109950626],)
``` 