### PR TITLE
Mark allunique non_differentiable

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "1.27.1"
+version = "1.28.0"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "1.27.0"
+version = "1.27.1"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 [compat]
 ChainRulesCore = "1.12"
 ChainRulesTestUtils = "1.5"
-Compat = "3.35"
+Compat = "3.42.0"
 FiniteDifferences = "0.12.20"
 IrrationalConstants = "0.1.1"
 JuliaInterpreter = "0.8" # latest is "0.9.1"

--- a/src/rulesets/Base/nondiff.jl
+++ b/src/rulesets/Base/nondiff.jl
@@ -96,6 +96,7 @@
 @non_differentiable abspath(::AbstractString...)
 @non_differentiable all(::Any)
 @non_differentiable all(::Any, ::Any)
+@non_differentiable allequal(::Any)
 @non_differentiable allunique(::Any)
 @non_differentiable any(::Any)
 @non_differentiable any(::Any, ::Any)

--- a/src/rulesets/Base/nondiff.jl
+++ b/src/rulesets/Base/nondiff.jl
@@ -96,6 +96,7 @@
 @non_differentiable abspath(::AbstractString...)
 @non_differentiable all(::Any)
 @non_differentiable all(::Any, ::Any)
+@non_differentiable allunique(::Any)
 @non_differentiable any(::Any)
 @non_differentiable any(::Any, ::Any)
 @non_differentiable argmax(::Any)


### PR DESCRIPTION
This PR marks the Bool-valued `Base.allunique` as non-differentiable.