### PR TITLE
Improve type stability of `cat_pullback`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "1.28.2"
+version = "1.28.3"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/rulesets/Base/array.jl
+++ b/src/rulesets/Base/array.jl
@@ -357,7 +357,7 @@ function rrule(::typeof(cat), Xs::Union{AbstractArray, Number}...; dims)
                 if d in cdims
                     d > ndimsX ? (prev[d]+1) : (prev[d]+1:prev[d]+sizeX[d])
                 else
-                    d > ndimsX ? 1 : (:)
+                    d > ndimsX ? 1 : 1:sizeX[d]
                 end
             end
             for d in cdims

--- a/test/rulesets/Base/array.jl
+++ b/test/rulesets/Base/array.jl
@@ -233,6 +233,8 @@ end
     test_rrule(cat, rand(1), rand(3, 2, 1); fkwargs=(dims=(1,2),), check_inferred=false) # infers Tuple{Zero, Vector{Float64}, Any}
 
     test_rrule(cat, rand(2, 2), rand(2, 2)'; fkwargs=(dims=1,))
+    # inference on exotic array types
+    test_rrule(cat, @SArray(rand(3, 2, 1)), @SArray(rand(3, 2, 1)); fkwargs=(dims=Val(2),))
 end
 
 @testset "hvcat" begin


### PR DESCRIPTION
Currently, https://github.com/JuliaDiff/ChainRules.jl/blob/8c34f19d3a8a8a224c9fbe20524d2a08c8b9bf81/src/rulesets/Base/array.jl#L356-L362 will generate a `Tuple{Union{UnitRange{Int64}, Colon}, ...}`. When the number of input dims >=3, this appears to fail some union-splitting threshold for `getindex` on certain array types. Here's a MWE with FillArrays, which Zygote uses somewhat extensively:
```julia
using Test, ChainRules, ChainRulesCore, FillArrays

function grad(x1, x2, sens, dims::Val)
  y, back = rrule(cat, x1, x2; dims)
  back(sens)
end

# Infers
@inferred grad(ones(1, 1, 1), ones(1, 1, 1), ones(1, 2, 1), Val(2))
@inferred grad(Ones(1, 1), Ones(1, 1), ones(1, 2), Val(2))

# Does not infer
@inferred grad(Ones(1, 1, 1), Ones(1, 1, 1), Ones(1, 2, 1), Val(2))
@inferred grad(ones(1, 1, 1), ones(1, 1, 1), Ones(1, 2, 1), Val(2))
```
This PR resolves the instability by always creating a `UnitRange`. However, I am not sure if this is sufficiently semantically close to `Colon` to pass muster, so RFC :) .