### PR TITLE
Rule for `mean(f,x)`

### DIFF
--- a/src/rulesets/Base/mapreduce.jl
+++ b/src/rulesets/Base/mapreduce.jl
@@ -77,19 +77,22 @@ function rrule(
     f::F,
     xs::AbstractArray{T};
     dims = :,
+    _lambda = nothing,  # This keyword set to `1/n` when using the rule for `mean`.
 ) where {F,T}
     project = ProjectTo(xs)
+    scale = _lambda === nothing ? identity : (dx -> dx * _lambda)
+    scalefun = _lambda === nothing ? identity : (f -> Base.Fix1(*, _lambda) ∘ f)
 
     if _uses_input_only(f, T)
         # Then we can compute the forward pass as usual, save nothing but `xs`:
         function sum_pullback_f1(dy)
             dxs = broadcast(unthunk(dy), xs) do dyₖ, xᵢ
                 ∂yₖ∂xᵢ = only(only(derivatives_given_output(nothing, f, xᵢ)))
-                dyₖ * conj(∂yₖ∂xᵢ)
+                scale(dyₖ * conj(∂yₖ∂xᵢ))
             end
             return (NoTangent(), NoTangent(), project(dxs))
         end
-        return sum(f, xs; dims), sum_pullback_f1
+        return sum(scalefun(f), xs; dims), sum_pullback_f1
     end
 
     # (There is an intermediate case, where `derivatives_given_output` needs to
@@ -97,7 +100,7 @@ function rrule(
 
     # In the general case, we need to save all the pullbacks:
     fx_and_pullbacks = map(xᵢ -> rrule_via_ad(config, f, xᵢ), xs)
-    y = sum(first, fx_and_pullbacks; dims)
+    y = sum(scalefun(first), fx_and_pullbacks; dims)
 
     function sum_pullback_f2(dy)
         # For arrays of arrays, we ought to protect the element against broadcasting:
@@ -106,7 +109,7 @@ function rrule(
             # Then at least `f` has no gradient. 
             # Broadcasting here gets the shape right with or without `dims` keyword.
             dxs = broadcast(fx_and_pullbacks, broadcast_dy) do (_, pbᵢ), dyₖ
-                unthunk(last(pbᵢ(dyₖ)))
+                scale(unthunk(last(pbᵢ(dyₖ))))
             end
             return (NoTangent(), NoTangent(), project(dxs))
 
@@ -117,8 +120,8 @@ function rrule(
             df_and_dxs = broadcast(fx_and_pullbacks, broadcast_dy) do (_, pbᵢ), dyₖ
                 pbᵢ(dyₖ)
             end
-            df = sum(first, df_and_dxs)
-            dxs = map(unthunk ∘ last, df_and_dxs)
+            df = scale(sum(first, df_and_dxs))
+            dxs = map(scalefun(unthunk ∘ last), df_and_dxs)
             return (NoTangent(), df, project(dxs))
         end
     end

--- a/src/rulesets/Statistics/statistics.jl
+++ b/src/rulesets/Statistics/statistics.jl
@@ -21,14 +21,14 @@ function rrule(
     ::typeof(mean),
     f::F,
     x::AbstractArray{T};
-    dims = :,
+    dims=:,
 ) where {F, T<:Union{Real,Complex,AbstractArray}}
     y_sum, sum_pullback = rrule(config, sum, f, x; dims)
     n = _denom(x, dims)
     function mean_pullback_f(ȳ)
         return sum_pullback(unthunk(ȳ) / n)
     end
-    y_sum / n, mean_pullback_f
+    return y_sum / n, mean_pullback_f
 end
 
 #####

--- a/src/rulesets/Statistics/statistics.jl
+++ b/src/rulesets/Statistics/statistics.jl
@@ -6,19 +6,27 @@ _denom(x, dims::Colon) = length(x)
 _denom(x, dims::Integer) = size(x, dims)
 _denom(x, dims) = mapreduce(i->size(x, i), Base.mul_prod, unique(dims), init=1)
 
-# TODO: We have `mean(f, x; dims)` as of 1.3.0-DEV.36
-# https://github.com/JuliaDiff/ChainRules.jl/issues/85
-function rrule(::typeof(mean), x::AbstractArray{<:Real}; dims=:)
-    y_sum, sum_pullback = rrule(sum, x; dims=dims)
+function rrule(::typeof(mean), x::AbstractArray{<:Union{Real,Complex,AbstractArray}}; dims=:)
+    y_sum, sum_pullback = rrule(sum, x; dims)
     n = _denom(x, dims)
     function mean_pullback(ȳ)
-        _, ∂sum_x = sum_pullback(ȳ)
-        ∂x = unthunk(∂sum_x) / n
+        _, ∂x = sum_pullback(unthunk(ȳ) / n)
         return (NoTangent(), ∂x)
     end
     return y_sum / n, mean_pullback
 end
 
+function rrule(
+    config::RuleConfig{>:HasReverseMode},
+    ::typeof(mean),
+    f::F,
+    x::AbstractArray{T};
+    dims = :,
+) where {F, T<:Union{Real,Complex,AbstractArray}}
+    λ = one(real(eltype(T))) / _denom(x, dims)
+    # λ = 1 // _denom(x, dims)
+    y, back = rrule(config, sum, f, x; dims, _lambda = λ)
+end
 #####
 ##### variance
 #####

--- a/src/rulesets/Statistics/statistics.jl
+++ b/src/rulesets/Statistics/statistics.jl
@@ -23,10 +23,14 @@ function rrule(
     x::AbstractArray{T};
     dims = :,
 ) where {F, T<:Union{Real,Complex,AbstractArray}}
-    λ = one(real(eltype(T))) / _denom(x, dims)
-    # λ = 1 // _denom(x, dims)
-    y, back = rrule(config, sum, f, x; dims, _lambda = λ)
+    y_sum, sum_pullback = rrule(config, sum, f, x; dims)
+    n = _denom(x, dims)
+    function mean_pullback_f(ȳ)
+        return sum_pullback(unthunk(ȳ) / n)
+    end
+    y_sum / n, mean_pullback_f
 end
+
 #####
 ##### variance
 #####

--- a/test/rulesets/Statistics/statistics.jl
+++ b/test/rulesets/Statistics/statistics.jl
@@ -16,6 +16,7 @@
         test_rrule(mean, log, rand(3, 4) .+ 1)
         test_rrule(mean, cbrt, randn(5))
         test_rrule(mean, Multiplier(2.0), [2.0, 4.0, 8.0])  # defined in test_helpers.jl
+        test_rrule(mean, Divider(1 + rand()), randn(5)) 
 
         test_rrule(mean, sum, [[2.0, 4.0], [4.0,1.9]]; check_inferred=false)
 

--- a/test/rulesets/Statistics/statistics.jl
+++ b/test/rulesets/Statistics/statistics.jl
@@ -1,11 +1,31 @@
 @testset "mean" begin
-    n = 9
-    @testset "Basic" begin
-        test_rrule(mean, randn(n))
+    @testset "mean(x)" begin
+        test_rrule(mean, randn(9))
+        test_rrule(mean, randn(ComplexF64,2,4))
+        test_rrule(mean, transpose(rand(3)))
+        test_rrule(mean, [rand(3) for _ in 1:4]; check_inferred=false)
     end
     @testset "with dims kwargs" begin
-        test_rrule(mean, randn(n); fkwargs=(;dims=1))
-        test_rrule(mean, randn(n,4); fkwargs=(;dims=2))
+        test_rrule(mean, randn(9); fkwargs=(;dims=1))
+        test_rrule(mean, randn(9,4); fkwargs=(;dims=2))
+        test_rrule(mean, [rand(2) for _ in 1:3, _ in 1:4]; fkwargs=(;dims=2), check_inferred=false)
+    end
+    @testset "mean(f, x)" begin
+        # This shares its implementation with sum(f, x). Similar tests should cover all cases:
+        test_rrule(mean, abs, [-4.0, 2.0, 2.0])
+        test_rrule(mean, log, rand(3, 4) .+ 1)
+        test_rrule(mean, cbrt, randn(5))
+        test_rrule(mean, Multiplier(2.0), [2.0, 4.0, 8.0])  # defined in test_helpers.jl
+
+        test_rrule(mean, sum, [[2.0, 4.0], [4.0,1.9]]; check_inferred=false)
+
+        test_rrule(mean, log, rand(ComplexF64, 5))
+        test_rrule(mean, sqrt, rand(ComplexF64, 5))
+        test_rrule(mean, abs, rand(ComplexF64, 3, 4))
+        
+        test_rrule(mean, abs, [-2.0 4.0; 5.0 1.9]; fkwargs=(;dims=1))
+        test_rrule(mean, abs, [-2.0 4.0; 5.0 1.9]; fkwargs=(;dims=2))
+        test_rrule(mean, sqrt, rand(ComplexF64, 3, 4); fkwargs=(;dims=(1,)))
     end
 end
 

--- a/test/test_helpers.jl
+++ b/test/test_helpers.jl
@@ -36,6 +36,28 @@ function ChainRulesCore.rrule(m::Multiplier, y, z)
 end
 
 """
+    Divider(x)
+
+Stores a fixed `x` and divides by it, then squares the result.
+
+Especially for testing the gradient of higher order functions with respect to `x`.
+```
+julia> map(Divider(2), [1 2 3 4 10])
+1×5 Matrix{Float64}:
+ 0.25  1.0  2.25  4.0  25.0
+```
+"""
+struct Divider{T<:Real}
+    x::T
+end
+(d::Divider)(y::Real) = (y / d.x)^2
+
+function ChainRulesCore.rrule(d::Divider, y::Real)
+    Divider_pullback(dΩ) = (Tangent{typeof(d)}(; x = -2 * dΩ * y^2 / d.x^3), 2 * dΩ * y / d.x^2)
+    return d(y), Divider_pullback
+end
+
+"""
     Counter()
 
 Multiplies its input by number that increments on each call,
@@ -87,6 +109,11 @@ end
         test_rrule(Multiplier(1.2), 3.4, 5.6)
         test_rrule(Multiplier(1.0 + 2im), 3.0 + 4im, 5.0 - 6im)
         test_rrule(Multiplier(rand(2,3)), rand(3,4), rand(4,5))
+    end
+    
+    @testset "Divider" begin
+        test_rrule(Divider(2.3), 4.5)
+        test_rrule(Divider(0.2), -3.4)
     end
 
     @testset "Counter" begin


### PR DESCRIPTION
Closes #85, closes https://github.com/FluxML/Zygote.jl/issues/1128 

Builds on #529, similar performance:
```julia
julia> using Statistics

julia> @btime gradient(x -> mean(abs, x), $(rand(30,30)));
  30.583 μs (108 allocations: 152.05 KiB)  # before
  2.056 μs (17 allocations: 7.73 KiB)      # after -- uses derivatives_given_output

julia> @btime gradient(x -> sum(mean(log, x, dims=1)), $(rand(30,30)));  # was an error
  9.583 μs (18 allocations: 8.11 KiB)  # after -- uses derivatives_given_output

julia> @btime gradient(x -> mean(log∘exp, x), $(rand(300,300))); 
  1.035 s (6930185 allocations: 198.45 MiB)     # before
  825.696 ms (5940068 allocations: 142.83 MiB)  # after -- stores Zygote pullbacks, unstable

julia> @btime mean((log∘exp).(x)) setup=(x=$(rand(300,300)));
  1.578 ms (2 allocations: 703.17 KiB)  # dual number broadcasting

```