### PR TITLE
Eliminate redundant call to `norm`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "1.30.0"
+version = "1.31.0"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/rulesets/LinearAlgebra/norm.jl
+++ b/src/rulesets/LinearAlgebra/norm.jl
@@ -4,7 +4,7 @@
 
 function frule((_, Δx), ::typeof(norm), x)
     y = norm(x)
-    return y, _norm2_forward(x, Δx, norm(x))
+    return y, _norm2_forward(x, Δx, y)
 end
 
 function frule((_, ẋ), ::typeof(norm), x::Number, p::Real)


### PR DESCRIPTION
Was staring at code and noticed this