### PR TITLE
restrict strided array multiplication `rrule`

### DIFF
--- a/src/rulesets/Base/arraymath.jl
+++ b/src/rulesets/Base/arraymath.jl
@@ -46,9 +46,9 @@ end
 # https://github.com/JuliaDiff/ChainRulesCore.jl/issues/411
 function rrule(
     ::typeof(*),
-    A::StridedMatrix{<:CommutativeMulNumber},
-    B::StridedVecOrMat{<:CommutativeMulNumber},
-)
+    A::StridedMatrix{T},
+    B::StridedVecOrMat{T},
+) where {T<:CommutativeMulNumber}
     function times_pullback(ȳ)
         Ȳ = unthunk(ȳ)
         dA = InplaceableThunk(


### PR DESCRIPTION
Fix the specialized `rrule` for `StridedArray` multiplication to equal `eltype`. Fixes issue [#625](https://github.com/JuliaDiff/ChainRules.jl/issues/625).