### PR TITLE
add remaining `@nograd` from Zygote

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,10 +1,11 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "1.36"
+version = "1.37.0"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
+Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 IrrationalConstants = "92d709cd-6900-40b7-9082-c6be49f344b6"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/src/ChainRules.jl
+++ b/src/ChainRules.jl
@@ -3,6 +3,7 @@ module ChainRules
 using Base.Broadcast: materialize, materialize!, broadcasted, Broadcasted, broadcastable
 using ChainRulesCore
 using Compat
+using Distributed
 using IrrationalConstants: logtwo, logten
 using LinearAlgebra
 using LinearAlgebra.BLAS
@@ -33,6 +34,8 @@ include("rulesets/Base/arraymath.jl")
 include("rulesets/Base/indexing.jl")
 include("rulesets/Base/sort.jl")
 include("rulesets/Base/mapreduce.jl")
+
+include("rulesets/Distributed/nondiff.jl")
 
 include("rulesets/Statistics/statistics.jl")
 

--- a/src/ChainRules.jl
+++ b/src/ChainRules.jl
@@ -39,6 +39,7 @@ include("rulesets/Distributed/nondiff.jl")
 
 include("rulesets/Statistics/statistics.jl")
 
+include("rulesets/LinearAlgebra/nondiff.jl")
 include("rulesets/LinearAlgebra/utils.jl")
 include("rulesets/LinearAlgebra/blas.jl")
 include("rulesets/LinearAlgebra/lapack.jl")

--- a/src/rulesets/Base/nondiff.jl
+++ b/src/rulesets/Base/nondiff.jl
@@ -114,7 +114,6 @@
 @non_differentiable CartesianIndices(::Any)
 @non_differentiable Channel(::Any...)
 @non_differentiable cd(::AbstractString)
-@non_differentiable ceil(::Any...)
 @non_differentiable chomp(::AbstractString)
 @non_differentiable chop(::AbstractString)
 @non_differentiable cld(::Any, ::Any)
@@ -188,7 +187,6 @@
 @non_differentiable fld(::Any, ::Any, ::RoundingMode)
 @non_differentiable floatmax(::Any)
 @non_differentiable floatmin(::Any)
-@non_differentiable floor(::Any...)
 @non_differentiable flush(::Any)
 
 @non_differentiable gensym(::Symbol)
@@ -383,7 +381,6 @@ end
 @non_differentiable reset(::IO)
 @non_differentiable reverse(::AbstractString)
 @non_differentiable rm(::AbstractString)
-@non_differentiable round(::Any...)
 @non_differentiable rsplit(::AbstractString)
 @non_differentiable rsplit(::AbstractString, ::AbstractChar)
 @non_differentiable rstrip(::AbstractString)

--- a/src/rulesets/Base/nondiff.jl
+++ b/src/rulesets/Base/nondiff.jl
@@ -93,6 +93,8 @@
 ##### Exported functions, alphabetically
 #####
 
+@non_differentiable (:)(::Any...) # same as the Colon() singleton instance
+
 @non_differentiable abspath(::AbstractString...)
 @non_differentiable all(::Any)
 @non_differentiable all(::Any, ::Any)
@@ -110,6 +112,7 @@
 @non_differentiable bytesavailable(::Any)
 
 @non_differentiable CartesianIndices(::Any)
+@non_differentiable Channel(::Any...)
 @non_differentiable cd(::AbstractString)
 @non_differentiable ceil(::Any...)
 @non_differentiable chomp(::AbstractString)
@@ -470,6 +473,7 @@ elseif isdefined(Base, :cumulative_compile_time_ns)
     @non_differentiable Base.cumulative_compile_time_ns()
 end
 @non_differentiable Base.time_print(::Any...)
+@non_differentiable Base.OneTo(::Any...)
 
 @non_differentiable Broadcast.combine_styles(::Any...)
 @non_differentiable Broadcast.result_style(::Any)

--- a/src/rulesets/Distributed/nondiff.jl
+++ b/src/rulesets/Distributed/nondiff.jl
@@ -1,0 +1,3 @@
+@non_differentiable Distributed.CachingPool(::Any...)
+@non_differentiable Distributed.WorkerPool(::Any...)
+@non_differentiable workers()

--- a/src/rulesets/LinearAlgebra/nondiff.jl
+++ b/src/rulesets/LinearAlgebra/nondiff.jl
@@ -1,0 +1,1 @@
+@non_differentiable isposdef(::Any)


### PR DESCRIPTION
Closes #635 

Also removes `floor`, `ceil`, and `round` non-diff from [previous PR](#636). I overlooked that we already have

```julia
# rouding related,
# we use `zero` rather than `ZeroTangent()` for scalar, and avoids issues with map etc
@scalar_rule round(x) zero(x)
@scalar_rule floor(x) zero(x)
@scalar_rule ceil(x) zero(x)
```
which looks like there is a reason we don't use `@non_differentiable`, though it isn't clear to me why. 
