### PR TITLE
make ∇eachslice accept AbstractZero

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "1.36.1"
+version = "1.36.2"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/rulesets/Base/indexing.jl
+++ b/src/rulesets/Base/indexing.jl
@@ -93,6 +93,7 @@ function ∇eachslice(dys_raw, x::AbstractArray, vd::Val{dim}) where {dim}
     end
     return ProjectTo(x)(dx)
 end
+∇eachslice(dys::AbstractZero, x::AbstractArray, vd::Val{dim}) where {dim} = dys
 
 _zero_fill!(dx::AbstractArray{<:Number}) = fill!(dx, zero(eltype(dx)))
 _zero_fill!(dx::AbstractArray) = map!(zero, dx, dx)


### PR DESCRIPTION
This fixes an error found in downstream tests when removing Zygote's rule, https://github.com/FluxML/Zygote.jl/pull/1253 

I did think this was supposed to be handled upstream?

Before:
```julia
julia> rrule(eachcol, [1 2; 3 4])  # looks OK
(SubArray{Int64, 1, Matrix{Int64}, Tuple{Base.Slice{Base.OneTo{Int64}}, Int64}, true}[[1, 3], [2, 4]], ChainRules.var"#allcols#1468"{Matrix{Int64}}([1 2; 3 4]))

julia> rrule(eachcol, [1 2; 3 4])[2](ZeroTangent())  # produces the error seen in 1253
ERROR: MethodError: no method matching keys(::ZeroTangent)
Closest candidates are:
  keys(::Tuple)
   @ Base tuple.jl:71
  keys(::Tuple, ::Tuple...)
   @ Base tuple.jl:76
  keys(::IOContext)
   @ Base show.jl:397
  ...
Stacktrace:
 [1] pairs(collection::ZeroTangent)
   @ Base ./abstractdict.jl:172
 [2] findfirst(testf::ChainRules.var"#1471#1472", A::ZeroTangent)
   @ Base ./array.jl:2080
 [3] ∇eachslice(dys_raw::ZeroTangent, x::Matrix{Int64}, vd::Val{2})
   @ ChainRules ~/.julia/dev/ChainRules/src/rulesets/Base/indexing.jl:150
```
After:
```julia
julia> rrule(eachcol, [1 2; 3 4])[2](ZeroTangent())
(NoTangent(), ZeroTangent())
```