### PR TITLE
Rule for `map(f, ::Tuple...)`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "1.38.0"
+version = "1.39.0"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/rulesets/Base/base.jl
+++ b/src/rulesets/Base/base.jl
@@ -226,9 +226,10 @@ function rrule(config::RuleConfig{>:HasReverseMode}, ::typeof(map), f::F, xs::Tu
             rev_i = length_y - i + 1
             last(hobbits[rev_i])(dy[rev_i])
         end |> reverse
+        # This df doesn't infer, could test Base.issingletontype(F), but it's not the only inference problem.
+        df = ProjectTo(f)(sum(first, backevals))
         # Now unzip that. Because `map` like `zip` should when any `x` stops, some `dx`s may need padding.
         # Although in fact, `map(+, (1,2), (3,4,5))` is an error... https://github.com/JuliaLang/julia/issues/42216
-        df = ProjectTo(f)(sum(first, backevals))
         dxs = ntuple(num_xs) do k
             dx_short = map(bv -> bv[k+1], backevals)
             ProjectTo(xs[k])((dx_short..., paddings[k]...))  # ProjectTo makes the Tangent for us

--- a/src/rulesets/Base/base.jl
+++ b/src/rulesets/Base/base.jl
@@ -219,6 +219,7 @@ function rrule(config::RuleConfig{>:HasReverseMode}, ::typeof(map), f::F, xs::Tu
     y = map(first, hobbits)
     num_xs = Val(length(xs))
     paddings = map(x -> ntuple(Returns(NoTangent()), (length(x) - length_y)), xs)
+    all(isempty, paddings) || @error "rrule(map, f, xs::Tuple...) allows mistmatched lengths, although Base does not!"
     function map_back(dy)
         # We want to call the pullbacks in `rrule_via_ad` in reverse sequence to the forward pass:
         backevals = ntuple(length_y) do i

--- a/src/rulesets/Base/mapreduce.jl
+++ b/src/rulesets/Base/mapreduce.jl
@@ -62,6 +62,17 @@ end
 ##### `sum(f, x)`
 #####
 
+function rrule(config::RuleConfig{>:HasReverseMode}, ::typeof(sum), f::F, xs::Tuple) where {F}
+    fxs, unmap = rrule(config, map, f, xs)
+    y, unsum = rrule(config, sum, fxs)
+    function sum_pullback_f(dy)
+        _, dfxs = unsum(dy)
+        _, df, dxs = unmap(dfxs)
+        (NoTangent(), df, dxs)
+    end
+    y, sum_pullback_f
+end
+
 function rrule(
     config::RuleConfig{>:HasReverseMode},
     ::typeof(sum),

--- a/test/rulesets/Base/base.jl
+++ b/test/rulesets/Base/base.jl
@@ -222,5 +222,10 @@
         test_rrule(map, +, (1.0, 2.0), (3.0, 4.0), check_inferred=false)
         test_rrule(map, make_two_vec, (4.0, 5.0 + 6im), check_inferred=false)
         test_rrule(map, Multiplier(rand() + im), Tuple(rand(3)), check_inferred=false)
+
+        if try map(+, (1,), (2,3)); true catch e; false end
+            # True when https://github.com/JuliaLang/julia/issues/42216 has been fixed
+            test_rrule(map, Multiplier(4.5), (6.7, 8.9), (0.1, 0.2, 0.3), check_inferred=false)
+        end
     end
 end

--- a/test/rulesets/Base/base.jl
+++ b/test/rulesets/Base/base.jl
@@ -217,8 +217,10 @@
         @test rrule(NoRules, 1.0) === nothing
     end
     
-    @testset "map" begin
-        test_rrule(map, identity, (1, 2), check_inferred=false)
-        test_rrule(map, +, (1, 2), (3, 4), check_inferred=false)
+    @testset "map(f, ::Tuple...)" begin
+        test_rrule(map, identity, (1.0, 2.0), check_inferred=false)
+        test_rrule(map, +, (1.0, 2.0), (3.0, 4.0), check_inferred=false)
+        test_rrule(map, make_two_vec, (4.0, 5.0 + 6im), check_inferred=false)
+        test_rrule(map, Multiplier(rand() + im), Tuple(rand(3)), check_inferred=false)
     end
 end

--- a/test/rulesets/Base/base.jl
+++ b/test/rulesets/Base/base.jl
@@ -216,4 +216,9 @@
         @test frule(NoRules, 1.0) === nothing
         @test rrule(NoRules, 1.0) === nothing
     end
+    
+    @testset "map" begin
+        test_rrule(map, identity, (1, 2), check_inferred=false)
+        test_rrule(map, +, (1, 2), (3, 4), check_inferred=false)
+    end
 end

--- a/test/rulesets/Base/mapreduce.jl
+++ b/test/rulesets/Base/mapreduce.jl
@@ -68,7 +68,7 @@ const CFG = ChainRulesTestUtils.ADviaRuleConfig()
     end  # sum abs2
 
     @testset "sum(f, xs::Tuple)" begin
-        test_rrule(sum, sqrt, Tuple(rand(3)))
+        test_rrule(sum, sqrt, Tuple(rand(3)), check_inferred=false)
     end
 
     @testset "sum(f, xs)" begin

--- a/test/rulesets/Base/mapreduce.jl
+++ b/test/rulesets/Base/mapreduce.jl
@@ -67,6 +67,10 @@ const CFG = ChainRulesTestUtils.ADviaRuleConfig()
         end
     end  # sum abs2
 
+    @testset "sum(f, xs::Tuple)" begin
+        test_rrule(sum, sqrt, Tuple(rand(3)))
+    end
+
     @testset "sum(f, xs)" begin
         # This calls back into AD
         test_rrule(sum, abs, [-4.0, 2.0, 2.0])


### PR DESCRIPTION
I wrote this some time ago, but playing with Yota today, it came up as a missing rule. Diffractor also fails to differentiate this without the rule:
```julia
julia> Yota.grad(x -> map(*, x, (4,5,6), (7,8,9))[2], (2,3,4))  # with PR
(120, (ZeroTangent(), Tangent{Tuple{Int64, Int64, Int64}}(ZeroTangent(), 40.0, ZeroTangent())))

julia> Diffractor.gradient(x -> map(*, x, (4,5,6), (7,8,9))[2], (2,3,4))  # with PR
(Tangent{Tuple{Int64, Int64, Int64}}(ZeroTangent(), 40.0, ZeroTangent()),)
```

This is simpler than `map` for arrays, and judging by how `foldl` went, it's probably better to treat them separately. 

* This reverses the iteration, since `map` on tuples is unrolled, and maybe people rely on it working in order. 
* ~~It allows mismatched lengths,~~ like `zip`, although Base currently gives an error, I didn't realise when I wrote it. [Now this prints an `@error`.]

* Possibly inference can be improved.