### PR TITLE
RFC: add GPU testing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -29,7 +29,6 @@ julia = "1.6"
 
 [extras]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
-CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 ChainRulesTestUtils = "cdddcdb0-9152-4a09-a978-84456f9df70a"
 FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
 JLArrays = "27aeb0d3-9eb9-45fb-866b-73c2ecf80fcb"
@@ -39,4 +38,4 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Adapt", "CUDA", "ChainRulesTestUtils", "FiniteDifferences", "JLArrays", "JuliaInterpreter", "Random", "StaticArrays", "Test"]
+test = ["Adapt", "ChainRulesTestUtils", "FiniteDifferences", "JLArrays", "JuliaInterpreter", "Random", "StaticArrays", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -21,6 +21,7 @@ Compat = "3.42.0, 4"
 FiniteDifferences = "0.12.20"
 GPUArraysCore = "0.1.0"
 IrrationalConstants = "0.1.1"
+JLArrays = "0.1"
 JuliaInterpreter = "0.8,0.9"
 RealDot = "0.1"
 StaticArrays = "1.2"
@@ -31,11 +32,11 @@ Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 ChainRulesTestUtils = "cdddcdb0-9152-4a09-a978-84456f9df70a"
 FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
-GPUArrays = "0c68f7d7-f131-5f86-a1c3-88cf8149b2d7"
+JLArrays = "27aeb0d3-9eb9-45fb-866b-73c2ecf80fcb"
 JuliaInterpreter = "aa1ae85d-cabe-5617-a682-6adf51b2e16a"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Adapt", "CUDA", "ChainRulesTestUtils", "FiniteDifferences", "GPUArrays", "JuliaInterpreter", "Random", "StaticArrays", "Test"]
+test = ["Adapt", "CUDA", "ChainRulesTestUtils", "FiniteDifferences", "JLArrays", "JuliaInterpreter", "Random", "StaticArrays", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "1.39.2"
+version = "1.40.0"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "1.39.2"
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+GPUArraysCore = "46192b85-c4d5-4398-a991-12ede77f4527"
 IrrationalConstants = "92d709cd-6900-40b7-9082-c6be49f344b6"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
@@ -18,6 +19,7 @@ ChainRulesCore = "1.15.3"
 ChainRulesTestUtils = "1.5"
 Compat = "3.42.0, 4"
 FiniteDifferences = "0.12.20"
+GPUArraysCore = "0.1.0"
 IrrationalConstants = "0.1.1"
 JuliaInterpreter = "0.8,0.9"
 RealDot = "0.1"
@@ -25,12 +27,15 @@ StaticArrays = "1.2"
 julia = "1.6"
 
 [extras]
+Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 ChainRulesTestUtils = "cdddcdb0-9152-4a09-a978-84456f9df70a"
 FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
+GPUArrays = "0c68f7d7-f131-5f86-a1c3-88cf8149b2d7"
 JuliaInterpreter = "aa1ae85d-cabe-5617-a682-6adf51b2e16a"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["ChainRulesTestUtils", "FiniteDifferences", "JuliaInterpreter", "Random", "StaticArrays", "Test"]
+test = ["Adapt", "CUDA", "ChainRulesTestUtils", "FiniteDifferences", "GPUArrays", "JuliaInterpreter", "Random", "StaticArrays", "Test"]

--- a/test/rulesets/Base/array.jl
+++ b/test/rulesets/Base/array.jl
@@ -68,12 +68,12 @@ end
 
 @testset "reshape" begin
     # Forward
-    test_frule(reshape, rand(4, 3), 2, :)
+    @gpu test_frule(reshape, rand(4, 3), 2, :)
     test_frule(reshape, rand(4, 3), axes(rand(6, 2)))
     @test_skip test_frule(reshape, Diagonal(rand(4)), 2, :) # https://github.com/JuliaDiff/ChainRulesTestUtils.jl/issues/239
 
     # Reverse
-    test_rrule(reshape, rand(4, 5), (2, 10))
+    @gpu test_rrule(reshape, rand(4, 5), (2, 10))
     test_rrule(reshape, rand(4, 5), 2, 10)
     test_rrule(reshape, rand(4, 5), 2, :)
     test_rrule(reshape, rand(4, 5), axes(rand(10, 2)))
@@ -84,11 +84,6 @@ end
     @test rrule(reshape, Diagonal(rand(4)), (2, :))[2](ones(2,8))[2] isa Diagonal
     @test_skip test_rrule(reshape, Diagonal(rand(4)), 2, :)  # DimensionMismatch("second dimension of A, 22, does not match length of x, 16")
     @test_skip test_rrule(reshape, UpperTriangular(rand(4,4)), (8, 2)) # https://github.com/JuliaDiff/ChainRulesTestUtils.jl/issues/239
-    
-    @testset "gpu" begin
-        @gpu_test frule(reshape, rand(Float32, 4, 3), 2, :)
-        @gpu_test rrule(reshape, rand(Float32, 4, 5), 2, 10)
-    end
 end
 
 @testset "dropdims" begin
@@ -103,14 +98,14 @@ end
 
 @testset "permutedims + PermutedDimsArray" begin
     # Forward
-    test_frule(permutedims, rand(5))
-    test_frule(permutedims, rand(3, 4), (2, 1))
+    @gpu test_frule(permutedims, rand(5))
+    @gpu test_frule(permutedims, rand(3, 4), (2, 1))
     test_frule(permutedims!, rand(4,3), rand(3, 4), (2, 1))
     test_frule(PermutedDimsArray, rand(3, 4, 5), (3, 1, 2))
 
     # Reverse
-    test_rrule(permutedims, rand(5))
-    test_rrule(permutedims, rand(3, 4), (2, 1))
+    @gpu test_rrule(permutedims, rand(5))
+    @gpu test_rrule(permutedims, rand(3, 4), (2, 1))
     test_rrule(permutedims, Diagonal(rand(5)), (2, 1))
     # Note BTW that permutedims(Diagonal(rand(5))) does not use the rule at all
 
@@ -132,12 +127,12 @@ end
     test_rrule(repeat, rand(4, ))
     test_rrule(repeat, rand(4, 5))
     test_rrule(repeat, rand(4, 5); fkwargs = (outer=(1,2),))
-    test_rrule(repeat, rand(4, 5); fkwargs = (inner=(1,2), outer=(1,3)))
-    test_rrule(repeat, rand(4, 5); fkwargs = (outer=2,))
+    @gpu_broken test_rrule(repeat, rand(4, 5); fkwargs = (inner=(1,2), outer=(1,3)))
+    @gpu_broken test_rrule(repeat, rand(4, 5); fkwargs = (outer=2,))
 
-    test_rrule(repeat, rand(4, ), 2)
-    test_rrule(repeat, rand(4, 5), 2)
-    test_rrule(repeat, rand(4, 5), 2, 3)
+    @gpu test_rrule(repeat, rand(4, ), 2)
+    @gpu test_rrule(repeat, rand(4, 5), 2)
+    @gpu test_rrule(repeat, rand(4, 5), 2, 3)
     test_rrule(repeat, rand(1,2,3), 2,3,4; check_inferred=VERSION>v"1.6")
     test_rrule(repeat, rand(0,2,3), 2,0,4; check_inferred=VERSION>v"1.6")
     test_rrule(repeat, rand(1,1,1,1), 2,3,4,5; check_inferred=VERSION>v"1.6")
@@ -158,31 +153,22 @@ end
 
     @test rrule(repeat, [1,2,3], 4)[2](ones(12))[2] == [4,4,4]
     @test rrule(repeat, [1,2,3], outer=4)[2](ones(12))[2] == [4,4,4]
-    
-    @testset "gpu" begin
-        @gpu_test rrule(repeat, rand(Float32, 4), 2)
-        @test_broken @gpu_test rrule(repeat, rand(Float32, 2, 3), inner=(1,2), outer=(1,3))
-    end
 end
 
 @testset "hcat" begin
     # forward
-    test_frule(hcat, randn(3, 2), randn(3))
-    test_frule(hcat, randn(), randn(1,3))
+    @gpu test_frule(hcat, randn(3, 2), randn(3))
+    @gpu test_frule(hcat, randn(), randn(1,3))
 
     # reverse
-    test_rrule(hcat, randn(3, 2), randn(3), randn(3, 3))
+    @gpu test_rrule(hcat, randn(3, 2), randn(3), randn(3, 3))
+    @gpu test_rrule(hcat, rand(1,2), rand(), rand(1,3))
     test_rrule(hcat, rand(), rand(1,2), rand(1,2,1))
     test_rrule(hcat, rand(3,1,1,2), rand(3,3,1,2))
 
     # mix types
     test_rrule(hcat, rand(1, 3), rand(2)')
     test_rrule(hcat, rand(1), (nothing, rand()), check_inferred=false)
-    
-    @testset "gpu" begin
-        @gpu_test rrule(hcat, randn(Float32, 3, 2), randn(Float32, 3), randn(Float32, 3, 3))
-        @gpu_test rrule(hcat, rand(Float32), rand(Float32, 1,2))
-    end
 end
 
 @testset "reduce hcat" begin
@@ -208,13 +194,14 @@ end
 end
 
 @testset "vcat" begin
-
     # forward
     test_frule(vcat, randn(), randn(3), rand())
-    test_frule(vcat, randn(3, 1), randn(3))
+    @gpu test_frule(vcat, randn(3), rand(), randn(3))
+    @gpu test_frule(vcat, randn(3, 1), randn(3))
 
     # reverse
-    test_rrule(vcat, randn(2, 4), randn(1, 4), randn(3, 4))
+    @gpu test_rrule(vcat, randn(3), rand(), randn(3))
+    @gpu test_rrule(vcat, randn(2, 4), randn(1, 4), randn(3, 4))
     test_rrule(vcat, rand(), rand())
     test_rrule(vcat, rand(), rand(3), rand(3,1,1))
     test_rrule(vcat, rand(3,1,2), rand(4,1,2))
@@ -223,10 +210,6 @@ end
     test_rrule(vcat, rand(2, 2), rand(2, 2)')
     test_rrule(vcat, rand(), rand() => rand(); check_inferred=false)
     test_rrule(vcat, rand(3), (rand(), nothing), pi/2; check_inferred=false)
-    
-    @testset "gpu" begin
-        @gpu_test rrule(vcat, randn(Float32, 2, 4), randn(Float32, 1, 4), randn(Float32, 3, 4))
-    end
 end
 
 @testset "reduce vcat" begin
@@ -248,8 +231,8 @@ end
     test_frule(cat, rand(), rand(2,3); fkwargs=(dims=(1,2),))
 
     # reverse
-    test_rrule(cat, rand(2, 4), rand(1, 4); fkwargs=(dims=1,))
-    test_rrule(cat, rand(2, 4), rand(2); fkwargs=(dims=Val(2),))
+    @gpu test_rrule(cat, rand(2, 4), rand(1, 4); fkwargs=(dims=1,))
+    @gpu test_rrule(cat, rand(2, 4), rand(2); fkwargs=(dims=Val(2),))
     test_rrule(cat, rand(), rand(2, 3); fkwargs=(dims=[1,2],))
     test_rrule(cat, rand(1), rand(3, 2, 1); fkwargs=(dims=(1,2),), check_inferred=false) # infers Tuple{Zero, Vector{Float64}, Any}
 
@@ -281,7 +264,7 @@ end
     end
     @testset "Array" begin
         # Forward
-        test_frule(reverse, rand(5))
+        @gpu_broken test_frule(reverse, rand(5))
         test_frule(reverse, rand(5), 2, 4)
         test_frule(reverse, rand(5), fkwargs=(dims=1,))
         test_frule(reverse, rand(3,4), fkwargs=(dims=2,))
@@ -293,7 +276,7 @@ end
         test_frule(reverse!, rand(3,4), fkwargs=(dims=2,))
 
         # Reverse
-        test_rrule(reverse, rand(5))
+        @gpu_broken test_rrule(reverse, rand(5))
         test_rrule(reverse, rand(5), 2, 4)
         test_rrule(reverse, rand(5), fkwargs=(dims=1,))
 
@@ -307,15 +290,11 @@ end
         @test unthunk(pb(Diagonal([1.1, 2.1, 3.1]))[2]) isa Diagonal
         @test unthunk(pb(rand(3, 3))[2]) isa AbstractArray
     end
-    
-    @testset "gpu" begin
-        @test_broken @gpu_test rrule(reverse, rand(Float32, 5))
-    end
 end
 
 @testset "circshift" begin
     # Forward
-    test_frule(circshift, rand(10), 1)
+    @gpu test_frule(circshift, rand(10), 1)
     test_frule(circshift, rand(10), (1,))
     test_frule(circshift, rand(3,4), (-7,2))
 
@@ -323,7 +302,7 @@ end
     test_frule(circshift!, rand(3,4), rand(3,4), (-7,2))
 
     # Reverse
-    test_rrule(circshift, rand(10), 1)
+    @gpu test_rrule(circshift, rand(10), 1)
     test_rrule(circshift, rand(10) .+ im, -2)
     test_rrule(circshift, rand(10), (1,))
     test_rrule(circshift, rand(3,4), (-7,2))
@@ -401,14 +380,14 @@ end
     # Forward
     test_frule(imum, rand(10))
     test_frule(imum, rand(3,4))
-    test_frule(imum, rand(3,4), fkwargs=(dims=1,))
+    @gpu_broken test_frule(imum, rand(3,4), fkwargs=(dims=1,))
     test_frule(imum, [rand(2) for _ in 1:3])
     test_frule(imum, [rand(2) for _ in 1:3, _ in 1:4]; fkwargs=(dims=1,))
 
     # Reverse
     test_rrule(imum, rand(10))
     test_rrule(imum, rand(3,4))
-    test_rrule(imum, rand(3,4), fkwargs=(dims=1,))
+    @gpu_broken test_rrule(imum, rand(3,4), fkwargs=(dims=1,))
     test_rrule(imum, rand(3,4,5), fkwargs=(dims=(1,3),))
 
     # Arrays of arrays

--- a/test/rulesets/Base/arraymath.jl
+++ b/test/rulesets/Base/arraymath.jl
@@ -64,7 +64,7 @@
             @gpu test_frule(*, Diagonal([1.0, 2.0, 3.0]), rand(3))
 
             # rev
-            @gpu_broken test_rrule(*, Diagonal([1.0, 2.0, 3.0]), Diagonal([4.0, 5.0, 6.0]))
+            @gpu test_rrule(*, Diagonal([1.0, 2.0, 3.0]), Diagonal([4.0, 5.0, 6.0]))
             @gpu test_rrule(*, Diagonal([1.0, 2.0, 3.0]), rand(3))
 
             # Needs to not try and inplace, as `mul!` will do wrong.

--- a/test/rulesets/Base/arraymath.jl
+++ b/test/rulesets/Base/arraymath.jl
@@ -1,8 +1,13 @@
 @testset "arraymath.jl" begin
     @testset "inv(::Matrix{$T})" for T in (Float64, ComplexF64)
         B = generate_well_conditioned_matrix(T, 3)
-        @gpu test_frule(inv, B)
-        @gpu test_rrule(inv, B)
+        if VERSION >= v"1.7"
+          @gpu test_frule(inv, B)
+          @gpu test_rrule(inv, B)
+        else
+          @gpu_broken test_frule(inv, B)
+          @gpu_broken test_rrule(inv, B)
+        end
     end
 
     @testset "*: $T" for T in (Float64, ComplexF64)

--- a/test/rulesets/Base/arraymath.jl
+++ b/test/rulesets/Base/arraymath.jl
@@ -196,17 +196,17 @@
         A = randn(4, 4)
         Ā = randn(4, 4)
         # fwd
-        test_frule(-, A)
+        @gpu test_frule(-, A)
         # rev
-        test_rrule(-, A)
+        @gpu test_rrule(-, A)
         test_rrule(-, Diagonal(A); output_tangent=Diagonal(Ā))
     end
 
     @testset "addition" begin
         # fwd
-        test_frule(+, randn(2), randn(2), randn(2))
+        @gpu test_frule(+, randn(2), randn(2), randn(2))
         # rev
-        test_rrule(+, randn(4, 4), randn(4, 4), randn(4, 4))
+        @gpu test_rrule(+, randn(4, 4), randn(4, 4), randn(4, 4))
         test_rrule(+, randn(3), randn(3,1), randn(3,1,1))
     end
 end

--- a/test/rulesets/LinearAlgebra/dense.jl
+++ b/test/rulesets/LinearAlgebra/dense.jl
@@ -33,6 +33,9 @@
             # Inference failure due to https://github.com/JuliaDiff/ChainRulesCore.jl/issues/407
             test_rrule(dot, Diagonal(rand(2)), rand(2, 2); check_inferred=false)
         end
+        @testset "gpu" begin
+            @test_broken @gpu_test rrule(dot, randn(Float32, 3, 5), randn(Float32, 5, 3))
+        end
     end
 
     @testset "mul!" begin

--- a/test/rulesets/LinearAlgebra/dense.jl
+++ b/test/rulesets/LinearAlgebra/dense.jl
@@ -1,8 +1,8 @@
 @testset "dense LinearAlgebra" begin
     @testset "dot" begin
         @testset "Vector{$T}" for T in (Float64, ComplexF64)
-            test_frule(dot, randn(T, 3), randn(T, 3))
-            test_rrule(dot, randn(T, 3), randn(T, 3))
+            @gpu test_frule(dot, randn(T, 3), randn(T, 3))
+            @gpu test_rrule(dot, randn(T, 3), randn(T, 3))
         end
         @testset "Array{$T, 3}" for T in (Float64, ComplexF64)
             test_frule(dot, randn(T, 3, 4, 5), randn(T, 3, 4, 5))
@@ -10,15 +10,15 @@
         end
         @testset "mismatched shapes" begin
            # forward
-           test_frule(dot, randn(3, 5), randn(5, 3))             
-           test_frule(dot, randn(15), randn(5, 3))             
+           @gpu test_frule(dot, randn(3, 5), randn(5, 3))             
+           @gpu test_frule(dot, randn(15), randn(5, 3))             
            # reverse
-           test_rrule(dot, randn(3, 5), randn(5, 3))             
-           test_rrule(dot, randn(15), randn(5, 3))             
+           @gpu test_rrule(dot, randn(3, 5), randn(5, 3))             
+           @gpu test_rrule(dot, randn(15), randn(5, 3))             
         end
         @testset "3-arg dot, Array{$T}" for T in (Float64, ComplexF64)
-            test_frule(dot, randn(T, 3), randn(T, 3, 4), randn(T, 4))
-            test_rrule(dot, randn(T, 3), randn(T, 3, 4), randn(T, 4))
+            @gpu_broken test_frule(dot, randn(T, 3), randn(T, 3, 4), randn(T, 4))
+            @gpu test_rrule(dot, randn(T, 3), randn(T, 3, 4), randn(T, 4))
         end
         permuteddimsarray(A) = PermutedDimsArray(A, (2,1))
         @testset "3-arg dot, $F{$T}" for T in (Float32, ComplexF32), F in (adjoint, permuteddimsarray)
@@ -32,9 +32,6 @@
 
             # Inference failure due to https://github.com/JuliaDiff/ChainRulesCore.jl/issues/407
             test_rrule(dot, Diagonal(rand(2)), rand(2, 2); check_inferred=false)
-        end
-        @testset "gpu" begin
-            @test_broken @gpu_test rrule(dot, randn(Float32, 3, 5), randn(Float32, 5, 3))
         end
     end
 
@@ -128,6 +125,9 @@
             test_frule(f, U)
             test_rrule(f, U)
         end
+        @testset "gpu" begin
+            @gpu_broken test_rrule(f, reshape(1:9, 3, 3)+I*pi)
+        end
     end
     @testset "logabsdet(::Matrix{$T})" for T in (Float64, ComplexF64)
         B = randn(T, 4, 4)
@@ -138,8 +138,8 @@
         test_rrule(logabsdet, -B)
     end
     @testset "tr" begin
-        test_frule(tr, randn(4, 4))
-        test_rrule(tr, randn(4, 4))
+        @gpu test_frule(tr, randn(4, 4))
+        @gpu test_rrule(tr, randn(4, 4))
     end
     @testset "sylvester" begin
         @testset "T=$T, m=$m, n=$n" for T in (Float64, ComplexF64), m in (2, 3), n in (1, 3)

--- a/test/rulesets/LinearAlgebra/norm.jl
+++ b/test/rulesets/LinearAlgebra/norm.jl
@@ -176,6 +176,14 @@
             @test back(ZeroTangent()) == (NoTangent(), ZeroTangent(), ZeroTangent())
         end
     end
+    
+    # GPU tests
+    # =========
+    
+    @testset "gpu: $p" for p in (-1, 0, 0.5, 1, 2, 2.5, Inf)
+        @test_broken @gpu_test rrule(norm, randn(ComplexF32, 5), p)
+    end
+    
 end
 
 # normalise(x, p) and normalise(A, p)
@@ -198,5 +206,8 @@ end
 
         test_rrule(normalize, rand(T, 3, 4), p)
         test_rrule(normalize, adjoint(rand(T, 5)), p)
+    end
+    @testset "gpu, p=$p" for p in (1.0, 2.0, -Inf, Inf, 2.5)
+        @test_broken @gpu_test rrule(normalize, randn(ComplexF32, 5), p)
     end
 end

--- a/test/rulesets/LinearAlgebra/norm.jl
+++ b/test/rulesets/LinearAlgebra/norm.jl
@@ -149,6 +149,16 @@
         ȳ = rand_tangent(norm(x, p))
         @test unthunk(rrule(norm, x, p)[2](ȳ)[2]) isa typeof(x)
     end
+    @testset "gpu test norm" begin
+        @gpu test_rrule(norm, rand(2,3).+im)
+
+        @gpu test_rrule(norm, rand(2,3).+im, 1.0)
+        @gpu test_rrule(norm, rand(2,3).+im, 2.0)
+        @gpu test_rrule(norm, rand(2,3).+im, 2.5)
+
+        @gpu_broken test_rrule(norm, rand(2,3), Inf)
+        @gpu_broken test_rrule(norm, rand(2,3), -Inf)
+    end
 
     # Scalar norm(x, p)
     # =================
@@ -175,15 +185,7 @@
             @test back(ȳ) == (NoTangent(), zero(x), ZeroTangent())
             @test back(ZeroTangent()) == (NoTangent(), ZeroTangent(), ZeroTangent())
         end
-    end
-    
-    # GPU tests
-    # =========
-    
-    @testset "gpu: $p" for p in (-1, 0, 0.5, 1, 2, 2.5, Inf)
-        @test_broken @gpu_test rrule(norm, randn(ComplexF32, 5), p)
-    end
-    
+    end  
 end
 
 # normalise(x, p) and normalise(A, p)
@@ -195,7 +197,7 @@ end
         test_rrule(normalize, x)
         @test rrule(normalize, x)[2](ZeroTangent()) === (NoTangent(), ZeroTangent())
 
-        test_rrule(normalize, rand(T, 3, 4))
+        @gpu_broken test_rrule(normalize, rand(T, 3, 4))
         test_rrule(normalize, adjoint(rand(T, 5)))
     end
     @testset "x::Array{$T}, p=$p" for T in (Float64, ComplexF64), p in (1.0, 2.0, -Inf, Inf, 2.5)
@@ -204,10 +206,7 @@ end
         test_rrule(normalize, x, p)
         @test rrule(normalize, x, p)[2](ZeroTangent()) === (NoTangent(), ZeroTangent(), ZeroTangent())
 
-        test_rrule(normalize, rand(T, 3, 4), p)
+        @gpu_broken test_rrule(normalize, rand(T, 3, 4), p)
         test_rrule(normalize, adjoint(rand(T, 5)), p)
-    end
-    @testset "gpu, p=$p" for p in (1.0, 2.0, -Inf, Inf, 2.5)
-        @test_broken @gpu_test rrule(normalize, randn(ComplexF32, 5), p)
     end
 end

--- a/test/rulesets/Statistics/statistics.jl
+++ b/test/rulesets/Statistics/statistics.jl
@@ -1,17 +1,16 @@
 @testset "mean" begin
-    n = 9
     @testset "Basic" begin
-        test_rrule(mean, randn(n))
+        @gpu test_rrule(mean, randn(9))
     end
     @testset "with dims kwargs" begin
-        test_rrule(mean, randn(n); fkwargs=(;dims=1))
-        test_rrule(mean, randn(n,4); fkwargs=(;dims=2))
+        @gpu test_rrule(mean, randn(9); fkwargs=(;dims=1))
+        @gpu test_rrule(mean, randn(9,4); fkwargs=(;dims=2))
     end
 end
 
 @testset "variation: $var" for var in (std, var)
-    test_rrule(var, randn(3))
-    test_rrule(var, randn(4, 5); fkwargs=(; corrected=false))
+    @gpu test_rrule(var, randn(3))
+    @gpu test_rrule(var, randn(4, 5); fkwargs=(; corrected=false))
     test_rrule(var, randn(ComplexF64, 6))
     test_rrule(var, Diagonal(randn(6)))
 


### PR DESCRIPTION
This wants to start adding GPU tests...

* This uses the fake `JLArray` from https://github.com/JuliaRegistries/General/pull/64443 so that this can run on github actions / random laptops.
* Adding `@gpu` in front of `test_rrule(sum, rand(3))` expands to first run the test as before, then check the GPU result. No attempt is made to run all the tests this way.

Xref #617 -- note that there is now GPUArraysCore.jl, so CR can use `@allowscalar`, and dispatch on `AbstractGPUArray`, without loading anything heavy.

Xref #645 -- that particular rule needs to be re-written, marked broken here.