### PR TITLE
rrule for Dict constructor

### DIFF
--- a/src/ChainRules.jl
+++ b/src/ChainRules.jl
@@ -34,6 +34,7 @@ include("rulesets/Base/arraymath.jl")
 include("rulesets/Base/indexing.jl")
 include("rulesets/Base/sort.jl")
 include("rulesets/Base/mapreduce.jl")
+include("rulesets/Base/dict.jl")
 
 include("rulesets/Distributed/nondiff.jl")
 

--- a/src/rulesets/Base/dict.jl
+++ b/src/rulesets/Base/dict.jl
@@ -1,0 +1,15 @@
+function rrule(::Type{T}, ps::Pair...) where {T<:Dict}
+    @show ps
+    ks = map(first, ps)
+    project_ks, project_vs = map(ProjectTo, ks), map(ProjectTo∘last, ps)
+    function Dict_pullback(ȳ)
+        @show ȳ
+        dps = map(ks, project_ks, project_vs) do k, proj_k, proj_v
+            dk, dv = proj_k(getkey(ȳ, k, NoTangent())), proj_v(get(ȳ, k, NoTangent()))
+            Tangent{Pair{typeof(dk), typeof(dv)}}(first = dk, second = dv)
+        end
+        @show dps
+        return (NoTangent(), dps...)
+    end
+    return T(ps...), Dict_pullback
+end

--- a/test/rulesets/Base/dict.jl
+++ b/test/rulesets/Base/dict.jl
@@ -1,0 +1,15 @@
+@testset "Dict constructors" begin
+    test_rrule(Base.Dict)
+    @testset "homogeneous type" begin
+        test_rrule(Base.Dict, 1 => 2.0, 2 => 4.0)
+        test_rrule(Base.Dict, :a => "A", :b => "B", :c => "C")
+        test_rrule(Base.Dict, (1,) => randn(1, 1), (2,) => randn(2, 2))
+    end
+    @testset "inhomogeneous type" begin
+        test_rrule(Base.Dict, "a" => 2.0, :b => 4.0)
+        test_rrule(
+            Base.Dict, :a => 5.0, :b => 3f0;
+            atol=1e-6, rtol=1e-6,
+        ) # tolerance due to Float32.
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -57,6 +57,7 @@ end
     include_test("rulesets/Base/indexing.jl")
     include_test("rulesets/Base/mapreduce.jl")
     include_test("rulesets/Base/sort.jl")
+    include_test("rulesets/Base/dict.jl")
 
     println()
 


### PR DESCRIPTION
Zygote does not seem smart enough to handle this on its own.

Pending questions:
- [ ] How to get tests working. I assume https://github.com/JuliaDiff/ChainRulesTestUtils.jl/issues/195 would be required.
- [ ] Is storing projectors per-key and per-value overkill? Does a fast homogeneous type case like that for `vect` make sense?
- [ ] This is currently way type unstable out of concern of handling tangent sparsity. Is that a reasonable worry or does it (/ought it, thinking about how Zygote handles Dict tangents) not show up in practice?