### PR TITLE
Simplify `frule` for `Base.tail`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "1.39.0"
+version = "1.39.1"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
@@ -14,7 +14,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-ChainRulesCore = "1.12"
+ChainRulesCore = "1.15.3"
 ChainRulesTestUtils = "1.5"
 Compat = "3.42.0, 4"
 FiniteDifferences = "0.12.20"

--- a/src/rulesets/Base/indexing.jl
+++ b/src/rulesets/Base/indexing.jl
@@ -101,7 +101,7 @@ end
 
 function frule((_, ẋ), ::typeof(Base.tail), x::Tuple)
     y = Base.tail(x)
-    return y, Tangent{typeof(y)}(Base.tail(Tuple(ẋ))...)
+    return y, Tangent{typeof(y)}(Base.tail(ẋ)...)
 end
 
 function rrule(::typeof(Base.tail), x::T) where {T<:Tuple}


### PR DESCRIPTION
Correction to https://github.com/JuliaDiff/ChainRules.jl/pull/643 to avoid this:
```
julia> frule((NoTangent(), NoTangent()), Base.tail, (3,4))
ERROR: MethodError: no method matching length(::NoTangent)

Closest candidates are:
  length(::Union{Base.KeySet, Base.ValueIterator})
   @ Base abstractdict.jl:58
  length(::Union{NNlib.BatchedAdjoint{T, S}, NNlib.BatchedTranspose{T, S}} where {T, S})
   @ NNlib ~/.julia/packages/NNlib/uDZz6/src/batched/batchedadjtrans.jl:58
  length(::Union{DataStructures.OrderedRobinDict, DataStructures.RobinDict})
   @ DataStructures ~/.julia/packages/DataStructures/59MD0/src/ordered_robin_dict.jl:86
  ...

Stacktrace:
 [1] _similar_shape(itr::NoTangent, #unused#::Base.HasLength)
   @ Base ./array.jl:660
 [2] _collect(cont::UnitRange{Int64}, itr::NoTangent, #unused#::Base.HasEltype, isz::Base.HasLength)
   @ Base ./array.jl:715
 [3] collect(itr::NoTangent)
   @ Base ./array.jl:709
 [4] _totuple(::Type{Tuple}, ::NoTangent)
   @ Base ./tuple.jl:401
 [5] Tuple(itr::NoTangent)
   @ Base ./tuple.jl:369
 [6] frule(::Tuple{NoTangent, NoTangent}, #unused#::typeof(Base.tail), x::Tuple{Int64, Int64})
   @ ChainRules ~/.julia/packages/ChainRules/BbzFc/src/rulesets/Base/indexing.jl:104
```
which shows up in Diffractor's tests, e.g. here:
https://github.com/JuliaDiff/Diffractor.jl/runs/7414875951?check_suite_focus=true#step:6:259

Relies on https://github.com/JuliaDiff/ChainRulesCore.jl/pull/567 