### PR TITLE
Indexing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,7 @@ uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
 version = "1.44.0"
 
 [deps]
+Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
@@ -16,6 +17,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
 
 [compat]
+Adapt = "3.4.0"
 ChainRulesCore = "1.15.3"
 ChainRulesTestUtils = "1.5"
 Compat = "3.42.0, 4"
@@ -30,7 +32,6 @@ StructArrays = "0.6.11"
 julia = "1.6"
 
 [extras]
-Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 ChainRulesTestUtils = "cdddcdb0-9152-4a09-a978-84456f9df70a"
 FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
 JLArrays = "27aeb0d3-9eb9-45fb-866b-73c2ecf80fcb"
@@ -40,4 +41,4 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Adapt", "ChainRulesTestUtils", "FiniteDifferences", "JLArrays", "JuliaInterpreter", "Random", "StaticArrays", "Test"]
+test = ["ChainRulesTestUtils", "FiniteDifferences", "JLArrays", "JuliaInterpreter", "Random", "StaticArrays", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "1.43.2"
+version = "1.44.0"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/ChainRules.jl
+++ b/src/ChainRules.jl
@@ -1,10 +1,11 @@
 module ChainRules
 
+using Adapt: adapt
 using Base.Broadcast: materialize, materialize!, broadcasted, Broadcasted, broadcastable
 using ChainRulesCore
 using Compat
 using Distributed
-using GPUArraysCore: AbstractGPUArrayStyle
+using GPUArraysCore: AbstractGPUArray, AbstractGPUArrayStyle
 using IrrationalConstants: logtwo, logten
 using LinearAlgebra
 using LinearAlgebra.BLAS

--- a/src/rulesets/Base/array.jl
+++ b/src/rulesets/Base/array.jl
@@ -515,15 +515,9 @@ for findm in (:findmin, :findmax)
 
     @eval function rrule(::typeof($findm), x::AbstractArray; dims=:)
         y, ind = $findm(x; dims=dims)
-        plain_inds = Base.to_indices(x, (ind,))
-        project = ProjectTo(x)
         function $findm_pullback((dy, _))  # this accepts e.g. Tangent{Tuple{Float64, Int64}}(4.0, nothing)
             dy isa AbstractZero && return (NoTangent(), NoTangent())
-            xthunk = InplaceableThunk(
-                dx -> ∇getindex!(dx, x, unthunk(dy), plain_inds...),
-                @thunk(∇getindex(x, unthunk(dy), plain_inds...)),
-            )
-            return (NoTangent(), xthunk)
+            return (NoTangent(), thunked∇getindex(x, dy, ind),)
         end
         return (y, ind), $findm_pullback
     end

--- a/src/rulesets/Base/array.jl
+++ b/src/rulesets/Base/array.jl
@@ -517,7 +517,7 @@ for findm in (:findmin, :findmax)
         y, ind = $findm(x; dims=dims)
         function $findm_pullback((dy, _))  # this accepts e.g. Tangent{Tuple{Float64, Int64}}(4.0, nothing)
             dy isa AbstractZero && return (NoTangent(), NoTangent())
-            return (NoTangent(), thunked∇getindex(x, dy, ind),)
+            return (NoTangent(), thunked_∇getindex(x, dy, ind),)
         end
         return (y, ind), $findm_pullback
     end

--- a/src/rulesets/Base/indexing.jl
+++ b/src/rulesets/Base/indexing.jl
@@ -196,9 +196,14 @@ end
 
 # This is called by e.g. `iterate(1:0.1:2)`,
 # and fixes https://github.com/FluxML/Zygote.jl/issues/1247
+# Only needs to accept AbstractRange, but AbstractVector makes testing easier.
 
-function rrule(cfg::RuleConfig{>:HasReverseMode}, ::typeof(Base.unsafe_getindex), x::AbstractRange, i::Integer)
-  return rrule_via_ad(cfg, getindex, x, i)
+function frule((_, ẋ), ::typeof(Base.unsafe_getindex), x::AbstractVector, i::Integer)
+    return Base.unsafe_getindex(x, i), getindex(ẋ, i)
+end
+
+function rrule(cfg::RuleConfig{>:HasReverseMode}, ::typeof(Base.unsafe_getindex), x::AbstractVector, i::Integer)
+    return rrule_via_ad(cfg, getindex, x, i)
 end
 
 #####

--- a/src/rulesets/Base/indexing.jl
+++ b/src/rulesets/Base/indexing.jl
@@ -52,7 +52,6 @@ function rrule(::typeof(getindex), x::Tuple, ::Colon)
     return x, getindex_back_4
 end
 
-
 #####
 ##### getindex(::AbstractArray)
 #####
@@ -172,6 +171,15 @@ function rrule(::typeof(view), x::AbstractArray, inds...)
         return (NoTangent(), thunked∇getindex(x, dy, inds...), nots...)
     end
     return view(x, inds...), view_pullback
+end
+
+function rrule(::typeof(view), x::AbstractArray, i::Integer, jkl::Integer...)
+    # This case returns a zero-dim array, unlike getindex. So we fool ∇getindex:
+    function view_pullback_0(dy)
+        nots = map(Returns(NoTangent()), (i, jkl...))
+        return (NoTangent(), thunked∇getindex(x, dy, i:i, jkl...), nots...)
+    end
+    return view(x, i, jkl...), view_pullback_0
 end
 
 #####

--- a/src/rulesets/Base/indexing.jl
+++ b/src/rulesets/Base/indexing.jl
@@ -180,6 +180,17 @@ function frule((_, ẋ, v̇), ::typeof(setindex!), x::AbstractArray, v, inds...)
 end
 
 #####
+##### unsafe_getindex
+#####
+
+# This is called by e.g. `iterate(1:0.1:2)`,
+# and fixes https://github.com/FluxML/Zygote.jl/issues/1247
+
+function rrule(cfg::RuleConfig{>:HasReverseMode}, ::typeof(Base.unsafe_getindex), x::AbstractRange, i::Integer)
+  return rrule_via_ad(cfg, getindex, x, i)
+end
+
+#####
 ##### `eachslice` and friends
 #####
 

--- a/src/rulesets/Base/sort.jl
+++ b/src/rulesets/Base/sort.jl
@@ -64,7 +64,7 @@ function rrule(::typeof(sortslices), x::AbstractArray; dims::Integer, kw...)
     function sortslices_pullback(dy)
         # No actual need to zero this, and if you didn't, then you could widen eltype
         # Also, you could use similar(dy) here not x, same size?
-        dx = _zerolike_writeat(x, unthunk(dy), (), inds...)
+        dx = ∇getindex(x, unthunk(dy), (), inds...)
         return (NoTangent(), ProjectTo(x)(dx))
     end
     return x[inds...], sortslices_pullback
@@ -94,12 +94,11 @@ function rrule(::typeof(unique), x::AbstractArray{<:Number}; dims=:)
         mask .= (mask .== cumsum(mask, dims=1) .== true)  # this implements  findfirst(mask; dims=1)
         keep = map(I -> I[1], findall(mask))
         if dims isa Colon
-            # The function `_zerolike_writeat` allows second derivatives.
-            # Should perhaps eventually be shared with `getindex`.
-            dx = reshape(_zerolike_writeat(vec(x), vec(dy), (), keep), axes_x)
+            # The function `∇getindex` allows second derivatives.
+            dx = reshape(∇getindex(vec(x), vec(dy), (), keep), axes_x)
         else
             inds = ntuple(d -> d==dims ? keep : (:), length(axes_x))
-            dx = _zerolike_writeat(x, dy, (), inds...)
+            dx = ∇getindex(x, dy, (), inds...)
         end
         return (NoTangent(), ProjectTo(x)(dx))
     end

--- a/test/rulesets/Base/array.jl
+++ b/test/rulesets/Base/array.jl
@@ -366,14 +366,6 @@ end
     @test [5 0; 6 0] == @inferred unthunk(rrule(findmin, [1 2; 3 4], dims=2)[2]((hcat([5,6]), nothing))[2])
     test_rrule(findmin, rand(3,4), fkwargs=(dims=1,), output_tangent = (rand(1,4), NoTangent()))
     test_rrule(findmin, rand(3,4), fkwargs=(dims=2,))
-
-    # Second derivatives
-    test_frule(ChainRules._zerolike_writeat, rand(2, 2), 5.0, :, CartesianIndex(2, 2))
-    test_rrule(ChainRules._zerolike_writeat, rand(2, 2), 5.0, :, CartesianIndex(2, 2))
-    @test_skip test_rrule(ChainRules._zerolike_writeat, rand(2, 2), 5.0, 1, [CartesianIndex(2, 1) CartesianIndex(2, 2)]  ⊢ NoTangent())  # MethodError: no method matching isapprox(::Matrix{Float64}, ::Float64; rtol=1.0e-9, atol=1.0e-9)
-    y, bk = rrule(ChainRules._zerolike_writeat, rand(2, 2), 5.0, 1, [CartesianIndex(2, 1) CartesianIndex(2, 2)])
-    @test y == [0 0; 5 5]
-    @test bk([1 2; 3 4]) == (NoTangent(), NoTangent(), [3 4], NoTangent(), NoTangent())
 end
 
 @testset "$imum" for imum in [maximum, minimum]

--- a/test/rulesets/Base/array.jl
+++ b/test/rulesets/Base/array.jl
@@ -366,6 +366,7 @@ end
     @test [5 0; 6 0] == @inferred unthunk(rrule(findmin, [1 2; 3 4], dims=2)[2]((hcat([5,6]), nothing))[2])
     test_rrule(findmin, rand(3,4), fkwargs=(dims=1,), output_tangent = (rand(1,4), NoTangent()))
     test_rrule(findmin, rand(3,4), fkwargs=(dims=2,))
+    test_rrule(findmin, rand(3,4), fkwargs=(dims=(1,2),))
 end
 
 @testset "$imum" for imum in [maximum, minimum]

--- a/test/rulesets/Base/indexing.jl
+++ b/test/rulesets/Base/indexing.jl
@@ -144,14 +144,13 @@
         test_rrule(∇getindex, [rand(2) for _ in 1:3], [rand(2), rand(2)], 1:2; check_inferred=false)
     end
 
-    @testset "GPU" begin
-        x_23_gpu = jl(rand(2, 3))
+    @testset "getindex(::AbstractGPUArray)" begin
+        x_23_gpu = jl(rand(2, 3))  # using JLArrays, loaded for @gpu in test_helpers.jl
     
         # Scalar indexing, copied from:  @macroexpand @allowscalar A[i]
-        # Gives an error in Pkg.test, no idea why
-        # y1, bk1 = rrule(CFG, Base.task_local_storage, () -> x_23_gpu[1], :ScalarIndexing, ScalarAllowed)
-        # @test y1 == @allowscalar x_gpu[1]
-        # bk1(1.0)  # This is zero, because finite-differencing ignores the function
+        y1, bk1 = rrule(CFG, Base.task_local_storage, () -> x_23_gpu[1], :ScalarIndexing, ScalarAllowed)
+        @test y1 == @allowscalar x_23_gpu[1]
+        bk1(1.0) # This is zero, because finite-differencing ignores the function
         # ... but this works, and calls the rule:
         # Zygote.gradient(x -> @allowscalar(x[1]), jl(rand(3)))[1]
         
@@ -159,7 +158,7 @@
         @test unthunk(bk2(jl(ones(2,2)))[2]) == jl([0 1 1; 0 1 1])
 
         y3, bk3 = rrule(getindex, x_23_gpu, 1, [1,1,2])  # slow path, copy to CPU
-        @test_skip Array(y3) == Array(x_gpu)[1, [1,1,2]]  # error in Pkg.test, no idea why
+        @test Array(y3) == Array(x_gpu)[1, [1,1,2]]
         @test unthunk(bk3(jl(ones(3)))[2]) == jl([2 1 0; 0 0 0])
     end
 end

--- a/test/rulesets/Base/indexing.jl
+++ b/test/rulesets/Base/indexing.jl
@@ -83,7 +83,7 @@
         test_frule(getindex, Symmetric(rand(3, 3)), 2, 3)
         
         test_rrule(getindex, Diagonal(rand(3)), 1)
-        @test_skip test_rrule(getindex, Diagonal(rand(3)), 2, :)  # in-place update of off-diagonal entries
+        @test_skip test_rrule(getindex, Diagonal(rand(3)), 2, :)  # https://github.com/JuliaDiff/ChainRulesTestUtils.jl/issues/260
         dgrad = rrule(getindex, Diagonal(rand(3)), 2, :)[2]([1,2,3])[2]
         @test unthunk(dgrad) ≈ Diagonal([0, 2, 0])
         

--- a/test/rulesets/Base/indexing.jl
+++ b/test/rulesets/Base/indexing.jl
@@ -177,6 +177,11 @@ end
     test_frule(setindex!, rand(3, 4), [1,10,100.0], :, 3)
 end
 
+@testset "unsafe_getindex" begin
+    test_frule(Base.unsafe_getindex, collect(1:0.1:2), 3)
+    test_rrule(Base.unsafe_getindex, collect(1:0.1:2), 3)
+end
+
 @testset "eachslice" begin
     # Testing eachrow not collect∘eachrow leads to errors, e.g.
     # test_rrule: eachrow on Vector{Float64}: Error During Test at /Users/me/.julia/packages/ChainRulesTestUtils/8dFTY/src/testers.jl:195

--- a/test/rulesets/Base/indexing.jl
+++ b/test/rulesets/Base/indexing.jl
@@ -148,10 +148,15 @@
         x_23_gpu = jl(rand(2, 3))  # using JLArrays, loaded for @gpu in test_helpers.jl
     
         # Scalar indexing, copied from:  @macroexpand @allowscalar A[i]
-        y1, bk1 = rrule(CFG, Base.task_local_storage, () -> x_23_gpu[1], :ScalarIndexing, ScalarAllowed)
-        @test y1 == @allowscalar x_23_gpu[1]
-        # bk1(1.0) # This gives a StackOverflowError! 
-        # Also gives zero in global scope, error when in a let block? But this works, and calls the rule:
+        @test_skip begin  # This gives 
+          y1, bk1 = rrule(CFG, Base.task_local_storage, () -> x_23_gpu[1], :ScalarIndexing, ScalarAllowed)
+          @test y1 == @allowscalar x_23_gpu[1]
+        end
+        @test_skip begin
+          bk1(1.0) # This gives a StackOverflowError! Or gives zero in global scope.
+          true
+        end
+        # But this works, and calls the rule:
         # Zygote.gradient(x -> @allowscalar(x[1]), jl(rand(3)))[1]
 
         y2, bk2 = rrule(getindex, x_23_gpu, :, 2:3)  # fast path, just broadcast .+=

--- a/test/rulesets/Base/indexing.jl
+++ b/test/rulesets/Base/indexing.jl
@@ -77,6 +77,15 @@
             test_rrule(getindex, x, [2,2], [3,3])
         end
     end
+    
+    @testset "second derivatives" begin
+        test_frule(ChainRules.∇getindex, rand(2, 2), 5.0, :, CartesianIndex(2, 2))
+        test_rrule(ChainRules.∇getindex, rand(2, 2), 5.0, :, CartesianIndex(2, 2))
+        @test_skip test_rrule(ChainRules.∇getindex, rand(2, 2), 5.0, 1, [CartesianIndex(2, 1) CartesianIndex(2, 2)]  ⊢ NoTangent())  # MethodError: no method matching isapprox(::Matrix{Float64}, ::Float64; rtol=1.0e-9, atol=1.0e-9)
+        y, bk = rrule(ChainRules.∇getindex, rand(2, 2), 5.0, 1, [CartesianIndex(2, 1) CartesianIndex(2, 2)])
+        @test y == [0 0; 5 5]
+        @test bk([1 2; 3 4]) == (NoTangent(), NoTangent(), [3 4], NoTangent(), NoTangent())
+    end    
 end
 
 @testset "first & tail" begin

--- a/test/rulesets/Base/indexing.jl
+++ b/test/rulesets/Base/indexing.jl
@@ -169,7 +169,7 @@ end
 
     test_rrule(view, rand(3, 4), :, 1)
     test_rrule(view, rand(3, 4), 2, [1, 1, 2])
-    @test_broken test_rrule(view, rand(3, 4), 3, 4)  # This is why ∇getindex needs one more argument, dammit
+    test_rrule(view, rand(3, 4), 3, 4)
 end
 
 @testset "setindex!" begin

--- a/test/rulesets/Base/indexing.jl
+++ b/test/rulesets/Base/indexing.jl
@@ -150,15 +150,15 @@
         # Scalar indexing, copied from:  @macroexpand @allowscalar A[i]
         y1, bk1 = rrule(CFG, Base.task_local_storage, () -> x_23_gpu[1], :ScalarIndexing, ScalarAllowed)
         @test y1 == @allowscalar x_23_gpu[1]
-        bk1(1.0) # This is zero, because finite-differencing ignores the function
-        # ... but this works, and calls the rule:
+        # bk1(1.0) # This gives a StackOverflowError! 
+        # Also gives zero in global scope, error when in a let block? But this works, and calls the rule:
         # Zygote.gradient(x -> @allowscalar(x[1]), jl(rand(3)))[1]
-        
+
         y2, bk2 = rrule(getindex, x_23_gpu, :, 2:3)  # fast path, just broadcast .+=
         @test unthunk(bk2(jl(ones(2,2)))[2]) == jl([0 1 1; 0 1 1])
 
         y3, bk3 = rrule(getindex, x_23_gpu, 1, [1,1,2])  # slow path, copy to CPU
-        @test Array(y3) == Array(x_gpu)[1, [1,1,2]]
+        @test Array(y3) == Array(x_23_gpu)[1, [1,1,2]]
         @test unthunk(bk3(jl(ones(3)))[2]) == jl([2 1 0; 0 0 0])
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,12 +2,15 @@ using Test, ChainRulesCore, ChainRulesTestUtils
 
 @nospecialize
 
+using Adapt
 using Base.Broadcast: broadcastable
 using ChainRules
 using ChainRulesCore
 using ChainRulesTestUtils
 using ChainRulesTestUtils: rand_tangent, _fdm
 using FiniteDifferences
+using GPUArraysCore
+using JLArrays
 using LinearAlgebra
 using LinearAlgebra.BLAS
 using LinearAlgebra: dot


### PR DESCRIPTION
This wants to add a rule for `A[i,j,k]` any AbstractArray.

The earlier rule was only for `Array`. I think the argument for that is that, ultimately, indexing of any linear algebra wrapper resolves to indexing the underlying array. But it resolves to *scalar* indexing, which I think will be quite inefficient for something like `gradient(x -> sum(x[:,1]), transpose(rand(3,3)))[1]`. And in practice that fails (with just the `Array` rule) as it creates & mutates an array to hold the parts.

The internal function `_zerolike_writeat` which was previously used for some other rules is re-named `∇getindex` and simplified: ~~I am not sure why it needed `dims`~~ . It has rules to allow higher derivatives. 

It also always makes a full dense array; we could consider adding something like `Zygote.OneElement` to be more efficient at scalar indexing. But once you add two of those you get an Array; perhaps InplaceableThunk is eventually going to be better?