### PR TITLE
Don't use UnionAlls in Varargs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "1.43.0"
+version = "1.43.1"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/rulesets/Base/array.jl
+++ b/src/rulesets/Base/array.jl
@@ -76,8 +76,8 @@ _i_zero(ẋ::AbstractZero, x) = zero(x)
 # may give a MethodError for `zero` but won't be wrong.
 
 # Fast paths. Should it also collapse all-Zero cases?
-_instantiate_zeros(ẋs::Tuple{Vararg{<:Number}}, xs) = ẋs
-_instantiate_zeros(ẋs::Tuple{Vararg{<:AbstractArray}}, xs) = ẋs
+_instantiate_zeros(ẋs::Tuple{Vararg{Number}}, xs) = ẋs
+_instantiate_zeros(ẋs::Tuple{Vararg{AbstractArray}}, xs) = ẋs
 _instantiate_zeros(ẋs::AbstractArray{<:Number}, xs) = ẋs
 _instantiate_zeros(ẋs::AbstractArray{<:AbstractArray}, xs) = ẋs
 

--- a/src/rulesets/Base/indexing.jl
+++ b/src/rulesets/Base/indexing.jl
@@ -12,7 +12,7 @@ function frule((_, ẋ), ::typeof(getindex), x::Tuple, i)
 end
 
 "for a given typle type, returns a Val{N} where N is the length of the tuple"
-_tuple_N(::Type{<:Tuple{Vararg{<:Any, N}}}) where {N} = Val(N)
+_tuple_N(::Type{<:Tuple{Vararg{Any, N}}}) where {N} = Val(N)
 
 function rrule(::typeof(getindex), x::T, i::Integer) where {T<:Tuple}
     function getindex_back_1(dy)


### PR DESCRIPTION
This has been deprecated. I think it would be helpful to users to test with `--depwarn=error` but I'm not sure how to enable that when using `julia-runtest`. @DilumAluthge Do you know if that is possible?