### PR TITLE
Use `eltype` to determine the proper zero to `fill!` in _zerolike_writeat

### DIFF
--- a/src/rulesets/Base/array.jl
+++ b/src/rulesets/Base/array.jl
@@ -537,9 +537,11 @@ end
 # This function is roughly `setindex!(zero(x), dy, inds...)`:
 
 function _zerolike_writeat(x::AbstractArray{<:Number}, dy, dims, inds...)
+    _zero_fill = eltype(dy) == Any ? 0 : zero(eltype(dy))
+
     # It's unfortunate to close over `x`, but `similar(typeof(x), axes(x))` doesn't 
     # allow `eltype(dy)`, nor does it work for many structured matrices.
-    dx = fill!(similar(x, eltype(dy), axes(x)), 0)
+    dx = fill!(similar(x, eltype(dy), axes(x)), _zero_fill)
     view(dx, inds...) .= dy  # possibly 0-dim view, allows dy::Number and dy::Array, and dx::CuArray
     dx
 end


### PR DESCRIPTION
Fixes, e.g, the example below:
```julia
using Unitful, UnitfulChainRules
using Zygote

Zygote.gradient(A -> ustrip.(maximum(A)), [1.0, 2.0, 3.0] * u"m")
# ERROR: DimensionError: m^-1 and 0 are not dimensionally compatible.
```
This occurs because we hardcode the `0` in `_zerolike_writeat`, which ends up getting called through the `maximum` `rrule`, among others. Using `zero(eltype(dy))` we can fill with the proper `0`-like. 

I included a check just in case `eltype(dy) == Any`, in which case we default to the previous behavior as `zero(Any)` is undefined. 

Is there a better way to determine when `zero(eltype(dy))` wouldn't be valid? Maybe defaulting to `ZeroTangent()` would be better in the case where `eltype` doesn't concretely define a `zero`?