### PR TITLE
Added differentiation rule for `promote_type`

### DIFF
--- a/src/rulesets/Base/nondiff.jl
+++ b/src/rulesets/Base/nondiff.jl
@@ -350,6 +350,7 @@
 @non_differentiable println(::Any...)
 @non_differentiable process_exited(::Any)
 @non_differentiable process_running(::Any)
+@non_differentiable promote_type(::Type...)
 @non_differentiable pushdisplay(::AbstractDisplay)
 
 @non_differentiable read(::IO)


### PR DESCRIPTION
This is intended to fix https://github.com/FluxML/Zygote.jl/issues/1372