### PR TITLE
remove broken marking on max/min-imum gpu tests

### DIFF
--- a/test/rulesets/Base/array.jl
+++ b/test/rulesets/Base/array.jl
@@ -379,14 +379,14 @@ end
     # Forward
     test_frule(imum, rand(10))
     test_frule(imum, rand(3,4))
-    test_frule(imum, rand(3,4), fkwargs=(dims=1,))
+    @gpu test_frule(imum, rand(3,4), fkwargs=(dims=1,))
     test_frule(imum, [rand(2) for _ in 1:3])
     test_frule(imum, [rand(2) for _ in 1:3, _ in 1:4]; fkwargs=(dims=1,))
 
     # Reverse
     test_rrule(imum, rand(10))
     test_rrule(imum, rand(3,4))
-    test_rrule(imum, rand(3,4), fkwargs=(dims=1,))
+    @gpu test_rrule(imum, rand(3,4), fkwargs=(dims=1,))
     test_rrule(imum, rand(3,4,5), fkwargs=(dims=(1,3),))
 
     # Arrays of arrays

--- a/test/rulesets/Base/array.jl
+++ b/test/rulesets/Base/array.jl
@@ -366,7 +366,7 @@ end
     test_rrule(findmax, rand(5,3))
     @test [0 0; 0 5] == @inferred unthunk(rrule(findmax, [1 2; 3 4])[2]((5.0, nothing))[2])
     @test [0 0; 0 5] == @inferred unthunk(rrule(findmax, [1 2; 3 4])[2]((5.0, NoTangent()))[2])
-    
+
     # Reverse with dims:
     @test [0 0; 5 6] == @inferred unthunk(rrule(findmax, [1 2; 3 4], dims=1)[2](([5 6], nothing))[2])
     @test [5 0; 6 0] == @inferred unthunk(rrule(findmin, [1 2; 3 4], dims=2)[2]((hcat([5,6]), nothing))[2])
@@ -379,14 +379,14 @@ end
     # Forward
     test_frule(imum, rand(10))
     test_frule(imum, rand(3,4))
-    @gpu_broken test_frule(imum, rand(3,4), fkwargs=(dims=1,))
+    test_frule(imum, rand(3,4), fkwargs=(dims=1,))
     test_frule(imum, [rand(2) for _ in 1:3])
     test_frule(imum, [rand(2) for _ in 1:3, _ in 1:4]; fkwargs=(dims=1,))
 
     # Reverse
     test_rrule(imum, rand(10))
     test_rrule(imum, rand(3,4))
-    @gpu_broken test_rrule(imum, rand(3,4), fkwargs=(dims=1,))
+    test_rrule(imum, rand(3,4), fkwargs=(dims=1,))
     test_rrule(imum, rand(3,4,5), fkwargs=(dims=(1,3),))
 
     # Arrays of arrays


### PR DESCRIPTION
As noted in https://github.com/JuliaDiff/ChainRules.jl/pull/691 these now pass.
I don't know why, but its good

This does not need a version bump as it isn't changing package behavour