### PR TITLE
Avoid lowering to `Base.rest()`, as it infers poorly

### DIFF
--- a/src/rulesets/Base/fastmath_able.jl
+++ b/src/rulesets/Base/fastmath_able.jl
@@ -169,8 +169,8 @@ let
         @scalar_rule x / y (one(x) / y, -(Ω / y))
         
         ## many-arg +
-        function frule((_, Δx, Δy...), ::typeof(+), x::Number, ys::Number...)
-            +(x, ys...), +(Δx, Δy...)
+        function frule(Δs, ::typeof(+), x::Number, ys::Number...)
+            +(x, ys...), +(Base.tail(Δs)...)
         end
         
         function rrule(::typeof(+), x::Number, ys::Number...)


### PR DESCRIPTION
While it would be best to fix `Base.rest()` to be able to infer properly, at the moment the destructuring with a splat in the arguments to this `frule` end up causing inference issues in Diffractor.