### PR TITLE
non_differentiable unique

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "1.54.1"
+version = "1.55.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/rulesets/Base/nondiff.jl
+++ b/src/rulesets/Base/nondiff.jl
@@ -441,6 +441,8 @@ end
 
 @non_differentiable unescape_string(::AbstractString)
 @non_differentiable unescape_string(::IO, ::AbstractString)
+@non_differentiable unique(::AbstractArray{<:Union{Regex, AbstractChar, AbstractString}})
+@non_differentiable unique(::AbstractArray{Symbol})
 @non_differentiable unmark(::IO)
 @non_differentiable unsafe_string(::Cstring)
 @non_differentiable uppercase(::AbstractString)


### PR DESCRIPTION
Some array types for which it is safe to assume non differrentiability of `unique`. 
I don't see the test file corresponding to the `nondiff.jl` source file. It is ok to leave these untested?

The need for these rules arised in https://github.com/CarloLucibello/GraphNeuralNetworks.jl/pull/333