### PR TITLE
More efficient projection in svd pullback

### DIFF
--- a/src/rulesets/LinearAlgebra/factorization.jl
+++ b/src/rulesets/LinearAlgebra/factorization.jl
@@ -262,16 +262,16 @@ function svd_rev(USV::SVD, Ū, s̄, V̄)
     Ut = U'
     FUᵀŪ = _mulsubtrans!!(Ut*Ū, F)  # F .* (UᵀŪ - ŪᵀU)
     FVᵀV̄ = _mulsubtrans!!(Vt*V̄, F)  # F .* (VᵀV̄ - V̄ᵀV)
-    ImUUᵀ = _eyesubx!(U*Ut)  # I - UUᵀ
-    ImVVᵀ = _eyesubx!(V*Vt)  # I - VVᵀ
 
     S = Diagonal(s)
     S̄ = s̄ isa AbstractZero ? s̄ : Diagonal(s̄)
 
     # TODO: consider using MuladdMacro here
-    Ā = add!!(U * FUᵀŪ * S, ImUUᵀ * (Ū / S)) * Vt
+    Ūs = Ū / S
+    V̄ts = S \ V̄'
+    Ā = add!!(U * FUᵀŪ * S, Ūs - U * (Ut * Ūs)) * Vt
     Ā = add!!(Ā, U * S̄ * Vt)
-    Ā = add!!(Ā, U * add!!(S * FVᵀV̄ * Vt, (S \ V̄') * ImVVᵀ))
+    Ā = add!!(Ā, U * add!!(S * FVᵀV̄ * Vt, V̄ts - (V̄ts * V) * Vt))
 
     return Ā
 end

--- a/src/rulesets/LinearAlgebra/utils.jl
+++ b/src/rulesets/LinearAlgebra/utils.jl
@@ -19,15 +19,6 @@ _mulsubtrans!!(X::AbstractZero, F::AbstractZero) = X
 _mulsubtrans!!(X::AbstractZero, F::AbstractMatrix{<:Real}) = X
 _mulsubtrans!!(X::AbstractMatrix{<:Real}, F::AbstractZero) = F
 
-# I - X, overwrites X
-function _eyesubx!(X::AbstractMatrix)
-    n, m = size(X)
-    @inbounds for j = 1:m, i = 1:n
-        X[i,j] = (i == j) - X[i,j]
-    end
-    return X
-end
-
 _extract_imag(x) = complex(0, imag(x))
 
 """

--- a/test/rulesets/LinearAlgebra/factorization.jl
+++ b/test/rulesets/LinearAlgebra/factorization.jl
@@ -151,7 +151,6 @@ end
             X = randn(10, 10)
             Y = randn(10, 10)
             @test ChainRules._mulsubtrans!!(copy(X), Y) ≈ Y .* (X - X')
-            @test ChainRules._eyesubx!(copy(X)) ≈ I - X
 
             Z = randn(Float32, 10, 10)
             result = ChainRules._mulsubtrans!!(copy(Z), Y)


### PR DESCRIPTION
This change makes the pullback for `svd` faster and more memory efficient when taking the SVD of very tall or very wide matrices (which is a common application).

The issue is that the "textbook" formula `(I - U*U')*X` can be extremely slow and memory-intensive when `U` is
tall. The mathematically equivalent form `X - U*(U'*X)` avoids creating and then multiplying by the large matrix `U*U'`.

Example:
```
using LinearAlgebra, Zygote
f(x) = sum(svd(x).U)
X = randn(20000, 10);
@time Zygote.gradient(f, X);
```
Without this PR, the above runs in about 2 seconds and allocates 3 GB.
With this PR, it runs in less than 0.01 seconds and allocates 11 MB.

There is further room for improvement: When the input is to `svd` wide, then `I - U*U'` is zero. Conversely, when the input is tall, then `I - V*V'` is zero. This means that it would be possible to avoid some unnecessary computation by adding a couple of if-statements.

(This PR also removes the undocumented, unexported utility function `_eyesubx!` that is not used elsewhere in the package.)
