### PR TITLE
Allow unzip to return JLArray

### DIFF
--- a/test/unzipped.jl
+++ b/test/unzipped.jl
@@ -90,7 +90,7 @@ using ChainRules: unzip_broadcast, unzip #, unzip_map
         @test unzip(jl([(missing,2), (missing,4), (missing,6)]))[2] == jl([2, 4, 6])
         @test unzip(jl([(1,), (3,), (5,)]))[1] == jl([1, 3, 5])
 
-        # depending on Julia version may get ReinterpretArray or may get JLArray
+        # depending on Julia/package versions, may get ReinterpretArray or JLArray
         # Either is acceptable
         @test isa(
             unzip(jl([(missing, 2), (missing, 4), (missing, 6)]))[2],

--- a/test/unzipped.jl
+++ b/test/unzipped.jl
@@ -87,11 +87,12 @@ using ChainRules: unzip_broadcast, unzip #, unzip_map
         # TODO invent some tests of this rrule's pullback function
 
         @test unzip(jl([(1,2), (3,4), (5,6)])) == (jl([1, 3, 5]), jl([2, 4, 6]))
-
         @test unzip(jl([(missing,2), (missing,4), (missing,6)]))[2] == jl([2, 4, 6])
-        @test unzip(jl([(missing,2), (missing,4), (missing,6)]))[2] isa Base.ReinterpretArray
-
         @test unzip(jl([(1,), (3,), (5,)]))[1] == jl([1, 3, 5])
-        @test unzip(jl([(1,), (3,), (5,)]))[1] isa Base.ReinterpretArray
+
+        # depending on Julia version may get ReinterpretArray or may get JLArray
+        # Either is acceptable
+        @test unzip(jl([(missing,2), (missing,4), (missing,6)]))[2] isa Union{Base.ReinterpretArray, JLArray}
+        @test unzip(jl([(1,), (3,), (5,)]))[1] isa Union{Base.ReinterpretArray, JLArray}
     end
 end

--- a/test/unzipped.jl
+++ b/test/unzipped.jl
@@ -93,12 +93,8 @@ using ChainRules: unzip_broadcast, unzip #, unzip_map
         # depending on Julia version may get ReinterpretArray or may get JLArray
         # Either is acceptable
         @test isa(
-            unzip(jl([(missing,2), (missing,4), (missing,6)]))[2],
-            Union{Base.ReinterpretArray, JLArray}
-        )
-        @test isa(
-            unzip(jl([(1,), (3,), (5,)]))[1],
-            Union{Base.ReinterpretArray, JLArray}
+            unzip(jl([(missing, 2), (missing, 4), (missing, 6)]))[2],
+            Union{Base.ReinterpretArray,JLArray},
         )
     end
 end

--- a/test/unzipped.jl
+++ b/test/unzipped.jl
@@ -92,7 +92,13 @@ using ChainRules: unzip_broadcast, unzip #, unzip_map
 
         # depending on Julia version may get ReinterpretArray or may get JLArray
         # Either is acceptable
-        @test unzip(jl([(missing,2), (missing,4), (missing,6)]))[2] isa Union{Base.ReinterpretArray, JLArray}
-        @test unzip(jl([(1,), (3,), (5,)]))[1] isa Union{Base.ReinterpretArray, JLArray}
+        @test isa(
+            unzip(jl([(missing,2), (missing,4), (missing,6)]))[2],
+            Union{Base.ReinterpretArray, JLArray}
+        )
+        @test isa(
+            unzip(jl([(1,), (3,), (5,)]))[1],
+            Union{Base.ReinterpretArray, JLArray}
+        )
     end
 end


### PR DESCRIPTION
I do not know if this is the correct fix, this is just allowing it to return either.
Some change upstream i think in julia itself (since this test only failed in 1.x not in 1.6) changed something that cause this to now return a `JLArray` not a `ReinterprettedArray`.
But I think that's fine, good even.
But idk. @mcabbott ?