### PR TITLE
Try deleting the `one(::Any)` and `zero(::Any)` non_diff methods

### DIFF
--- a/src/rulesets/Base/nondiff.jl
+++ b/src/rulesets/Base/nondiff.jl
@@ -333,7 +333,6 @@
 
 @non_differentiable occursin(::Regex, ::AbstractString)
 @non_differentiable occursin(::Union{AbstractChar, AbstractString}, ::AbstractString)
-@non_differentiable one(::Any)
 @non_differentiable ones(::Any...)
 @non_differentiable only(::Char)
 @non_differentiable open(::Any)
@@ -457,7 +456,6 @@ end
 @non_differentiable xor(::Any...)
 @non_differentiable typejoin(::Any...)
 
-@non_differentiable zero(::Any)
 @non_differentiable zeros(::Any...)
 
 #####


### PR DESCRIPTION
Attempt at alternative to https://github.com/JuliaDiff/ChainRulesCore.jl/pull/653 for fixing https://github.com/JuliaDiff/ChainRules.jl/issues/769