### PR TITLE
Use handwritten rules for `zero` and `one`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "1.59.0"
+version = "1.59.1"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/rulesets/Base/base.jl
+++ b/src/rulesets/Base/base.jl
@@ -6,32 +6,24 @@
 
 # `zero`
 
-function frule((_, Δ1), ::typeof(zero), x)
-    var"∂f/∂x" = ZeroTangent()
-    return (zero(x), Δ1 * var"∂f/∂x")
+function frule((_, _), ::typeof(zero), x)
+    return (zero(x), ZeroTangent())
 end
 
 function rrule(::typeof(zero), x)
-    Ω = zero(x)
-    proj_x = ProjectTo(x)
-    var"∂f/∂x" = ZeroTangent()
-    pullback(Δ1) = (NoTangent(), proj_x(conj(var"∂f/∂x") * Δ1))
-    return (Ω, pullback)
+    zero_pullback(_) = (NoTangent(), ZeroTangent())
+    return (zero(x), zero_pullback)
 end
 
 # `one`
 
-function frule((_, Δ1), ::typeof(one), x)
-    var"∂f/∂x" = ZeroTangent()
-    return (one(x), Δ1 * var"∂f/∂x")
+function frule((_, _), ::typeof(one), x)
+    return (one(x), ZeroTangent())
 end
 
 function rrule(::typeof(one), x)
-    Ω = one(x)
-    proj_x = ProjectTo(x)
-    var"∂f/∂x" = ZeroTangent()
-    pullback(Δ1) = (NoTangent(), proj_x(conj(var"∂f/∂x") * Δ1))
-    return (Ω, pullback)
+    one_pullback(_) = (NoTangent(), ZeroTangent())
+    return (one(x), one_pullback)
 end
 
 # `adjoint`

--- a/src/rulesets/Base/base.jl
+++ b/src/rulesets/Base/base.jl
@@ -8,7 +8,7 @@
 
 function frule((_, Δ1), ::typeof(zero), x)
     var"∂f/∂x" = ZeroTangent()
-    (zero(x), Δ1 * var"∂f/∂x")
+    return (zero(x), Δ1 * var"∂f/∂x")
 end
 
 function rrule(::typeof(zero), x)
@@ -16,14 +16,14 @@ function rrule(::typeof(zero), x)
     proj_x = ProjectTo(x)
     var"∂f/∂x" = ZeroTangent()
     pullback(Δ1) = (NoTangent(), proj_x(conj(var"∂f/∂x") * Δ1))
-    (Ω, pullback)
+    return (Ω, pullback)
 end
 
 # `one`
 
 function frule((_, Δ1), ::typeof(one), x)
     var"∂f/∂x" = ZeroTangent()
-    (one(x), Δ1 * var"∂f/∂x")
+    return (one(x), Δ1 * var"∂f/∂x")
 end
 
 function rrule(::typeof(one), x)
@@ -31,7 +31,7 @@ function rrule(::typeof(one), x)
     proj_x = ProjectTo(x)
     var"∂f/∂x" = ZeroTangent()
     pullback(Δ1) = (NoTangent(), proj_x(conj(var"∂f/∂x") * Δ1))
-    (Ω, pullback)
+    return (Ω, pullback)
 end
 
 # `adjoint`

--- a/src/rulesets/Base/base.jl
+++ b/src/rulesets/Base/base.jl
@@ -2,10 +2,37 @@
 # that also have FastMath versions.
 
 @scalar_rule copysign(y, x) (ifelse(signbit(x)!=signbit(y), -one(y), +one(y)), NoTangent())
-
-@scalar_rule one(x) ZeroTangent()
-@scalar_rule zero(x) ZeroTangent()
 @scalar_rule transpose(x) true
+
+# `zero`
+
+function frule((_, Δ1), ::typeof(zero), x)
+    var"∂f/∂x" = ZeroTangent()
+    (zero(x), Δ1 * var"∂f/∂x")
+end
+
+function rrule(::typeof(zero), x)
+    Ω = zero(x)
+    proj_x = ProjectTo(x)
+    var"∂f/∂x" = ZeroTangent()
+    pullback(Δ1) = (NoTangent(), proj_x(conj(var"∂f/∂x") * Δ1))
+    (Ω, pullback)
+end
+
+# `one`
+
+function frule((_, Δ1), ::typeof(one), x)
+    var"∂f/∂x" = ZeroTangent()
+    (one(x), Δ1 * var"∂f/∂x")
+end
+
+function rrule(::typeof(one), x)
+    Ω = one(x)
+    proj_x = ProjectTo(x)
+    var"∂f/∂x" = ZeroTangent()
+    pullback(Δ1) = (NoTangent(), proj_x(conj(var"∂f/∂x") * Δ1))
+    (Ω, pullback)
+end
 
 # `adjoint`
 

--- a/test/rulesets/Base/base.jl
+++ b/test/rulesets/Base/base.jl
@@ -1,4 +1,14 @@
 @testset "base.jl" begin
+    @testset "zero/one" begin
+        for f in [zero, one]
+            for x in [1.0, 1.0im, [10.0+im 11.0-im; 12.0+2im 13.0-3im]]
+                test_frule(f, x)
+                test_rrule(f, x)
+            end
+        end
+        test_frule(zero, [1.0, 2.0, 3.0])
+        test_rrule(zero, [1.0, 2.0, 3.0])
+    end
     @testset "copysign" begin
         # don't go too close to zero as the numerics may jump over it yielding wrong results
         @testset "at $y" for y in (-1.1, 0.1, 100.0)  


### PR DESCRIPTION
Attempt to fix the problems raised in https://github.com/SciML/NeuralPDE.jl/pull/791 that was caused by https://github.com/JuliaDiff/ChainRules.jl/pull/770

I *think* this is the right way to generalize the scalar rule to any input type, and always return a `ZeroTangent()` instead of a `NoTangent()` like the old `@non_differentiable` rule did which was quite mathematically suspect. 