### PR TITLE
remove ambig in nondiff cumprod(::Vector{AbstractBool}) on julia 1.6

### DIFF
--- a/src/rulesets/Base/nondiff.jl
+++ b/src/rulesets/Base/nondiff.jl
@@ -34,6 +34,7 @@
 @non_differentiable circshift!(::AbstractArray{Bool}, ::Any)
 @non_differentiable conj(::AbstractArray{Bool})
 @non_differentiable conj!(::AbstractArray{Bool})
+@non_differentiable cumprod(::AbstractVector{Bool})
 @non_differentiable cumprod(::AbstractArray{Bool})
 @non_differentiable cumprod!(::Any, ::AbstractArray{Bool})
 @non_differentiable cumsum(::AbstractArray{Bool})


### PR DESCRIPTION
This doesn't reproduce locally for me.
And doesn't show up on never julia versions.
Possibly dispatch changed subtly to prevent this.
But lets see if it fixes it on CI