### PR TITLE
support arbitary types for vect -- use zero_tangent for _instantiate_zeros

### DIFF
--- a/src/rulesets/Base/array.jl
+++ b/src/rulesets/Base/array.jl
@@ -31,7 +31,7 @@ end
 
 @non_differentiable Base.vect()
 
-function frule((_, ẋs...), ::typeof(Base.vect), xs::Number...)
+function frule((_, ẋs...), ::typeof(Base.vect), xs...)
     return Base.vect(xs...), Base.vect(_instantiate_zeros(ẋs, xs)...)
 end
 

--- a/src/rulesets/Base/array.jl
+++ b/src/rulesets/Base/array.jl
@@ -71,9 +71,7 @@ materialises each zero `ẋ` to be `zero(x)`.
 """
 _instantiate_zeros(ẋs, xs) = map(_i_zero, ẋs, xs)
 _i_zero(ẋ, x) = ẋ
-_i_zero(ẋ::AbstractZero, x) = zero(x)
-# Possibly this won't work for partly non-diff arrays, something like `gradient(x -> ["abc", x][end], 1)`
-# may give a MethodError for `zero` but won't be wrong.
+_i_zero(ẋ::AbstractZero, x) = zero_tangent(x)
 
 # Fast paths. Should it also collapse all-Zero cases?
 _instantiate_zeros(ẋs::Tuple{Vararg{Number}}, xs) = ẋs

--- a/test/rulesets/Base/array.jl
+++ b/test/rulesets/Base/array.jl
@@ -35,8 +35,8 @@ end
 @testset "vect" begin
     test_rrule(Base.vect)
     @testset "homogeneous type" begin
-        test_rrule(Base.vect, (5.0, ), (4.0, ))
-        test_frule(Base.vect, (5.0, ), (4.0, ))
+        test_rrule(Base.vect, (5.0,), (4.0,))
+        test_frule(Base.vect, (5.0,), (4.0,))
         test_rrule(Base.vect, 5.0, 4.0, 3.0)
         test_frule(Base.vect, 5.0, 4.0, 3.0)
         test_rrule(Base.vect, randn(2, 2), randn(3, 3))

--- a/test/rulesets/Base/array.jl
+++ b/test/rulesets/Base/array.jl
@@ -36,8 +36,15 @@ end
     test_rrule(Base.vect)
     @testset "homogeneous type" begin
         test_rrule(Base.vect, (5.0, ), (4.0, ))
+        test_frule(Base.vect, (5.0, ), (4.0, ))
         test_rrule(Base.vect, 5.0, 4.0, 3.0)
+        test_frule(Base.vect, 5.0, 4.0, 3.0)
         test_rrule(Base.vect, randn(2, 2), randn(3, 3))
+        test_frule(Base.vect, randn(2, 2), randn(3, 3))
+
+        # Nonnumber types
+        test_frule(Base.vect, (1.0, 2.0), (1.0, 2.0))
+        test_rrule(Base.vect, (1.0, 2.0), (1.0, 2.0))
     end
     @testset "inhomogeneous type" begin
         # fwd
@@ -52,7 +59,7 @@ end
     end
     @testset "_instantiate_zeros" begin
         # This is an internal function also used for `cat` etc.
-        @eval using ChainRules: _instantiate_zeros
+        _instantiate_zeros = ChainRules._instantiate_zeros
         # Check these hit the fast path, unrealistic input so that map would fail:
         @test _instantiate_zeros((true, 2 , 3.0), ()) == (1, 2, 3)
         @test _instantiate_zeros((1:2, [3, 4]), ()) == (1:2, 3:4)


### PR DESCRIPTION
`zero_tangent` correctly handles zeros for things that do not have `zero` implemented, by using it in `_instantitate_zeros` we can support anything being passed to `vect`

Without this rule, anything with a vector being constructed is very annoying, makes Diffractor very sad.

Not sure if should go further and also knock out some of the array cases.
Especially arrays of arrays. But that can always be a follow up
