### PR TITLE
Disable + and - rules on mixed numeric types

### DIFF
--- a/src/rulesets/Base/fastmath_able.jl
+++ b/src/rulesets/Base/fastmath_able.jl
@@ -164,19 +164,53 @@ let
             return (Ω, hypot_pullback)
         end
 
-        @scalar_rule x + y (true, true)
-        @scalar_rule x - y (true, -1)
-        @scalar_rule x / y (one(x) / y, -(Ω / y))
-        
-        ## many-arg +
-        function frule(Δs, ::typeof(+), x::Number, ys::Number...)
+        ###
+        ### +
+        ###
+        # Same type so must have same tangent type
+        function frule(Δs, ::typeof(+), x::T, ys::T...) where {T<:Number}
             +(x, ys...), +(Base.tail(Δs)...)
         end
         
-        function rrule(::typeof(+), x::Number, ys::Number...)
+        function rrule(::typeof(+), x::T, ys::T...) where {T<:Number}
             plus_back(dz) = (NoTangent(), dz, map(Returns(dz), ys)...)
             +(x, ys...), plus_back
-        end        
+        end
+
+        #Or Tangent type is same as primal type so op must be defined on it too
+        function frule((_, ẋ, ẏ)::Tuple{<:Any, A, B}, ::typeof(+), x::A, y::B) where {A<:Number, B<:Number}
+            return +(x, y), +(ẋ, ẏ)
+        end
+
+        # Both cases (break ambiguity)
+        function frule((_, ẋ, ẏ)::Tuple{<:Any, T, T}, ::typeof(+), x::T, y::T) where {T<:Number}
+            return +(x, y), +(ẋ, ẏ)
+        end
+        
+
+        ###
+        ### - 
+        ###
+        # Same type so must have same tangent type
+        function rrule(::typeof(-), x::T, y::T) where {T<:Number}
+            minus_pullback(z̄) = NoTangent(), z̄, -(z̄)
+            return x - y, minus_pullback
+        end
+        frule((_, ẋ, ẏ), ::typeof(-), x::T, y::T) where {T<:Number} = -(x, y), -(ẋ, ẏ)
+
+        #Or Tangent type is same as primal type so op must be defined on it too
+        function frule((_, ẋ, ẏ)::Tuple{<:Any, A, B}, ::typeof(-), x::A, y::B) where {A<:Number, B<:Number}
+            return -(x, y), -(ẋ, ẏ)
+        end
+
+        # Both cases (break ambiguity)
+        function frule((_, ẋ, ẏ)::Tuple{<:Any, T, T}, ::typeof(-), x::T, y::T) where {T<:Number}
+            return -(x, y), -(ẋ, ẏ)
+        end
+                
+
+        @scalar_rule x / y (one(x) / y, -(Ω / y))
+
 
         ## power
         # literal_pow is in base.jl

--- a/test/rulesets/Base/fastmath_able.jl
+++ b/test/rulesets/Base/fastmath_able.jl
@@ -144,17 +144,17 @@ const FASTABLE_AST = quote
             @assert T == typeof(f(x, y))
             Δz = randn(typeof(f(x, y)))
 
-            @test frule((ZeroTangent(), Δx, Δy), f, x, y) isa Tuple{T, T}
+            @test frule((NoTangent(), Δx, Δy), f, x, y) isa Tuple{T, T}
             _, ∂x, ∂y = rrule(f, x, y)[2](Δz)
             @test (∂x, ∂y) isa Tuple{T, T}
 
-            if f != hypot
+            if f ∉ (hypot, +, -)
                 # Issue #233
-                @test frule((ZeroTangent(), Δx, Δy), f, x, 2) isa Tuple{T, T}
+                @test frule((NoTangent(), Δx, Δy), f, x, 2) isa Tuple{T, T}
                 _, ∂x, ∂y = rrule(f, x, 2)[2](Δz)
                 @test (∂x, ∂y) isa Tuple{T, Float64}
 
-                @test frule((ZeroTangent(), Δx, Δy), f, 2, y) isa Tuple{T, T}
+                @test frule((NoTangent(), Δx, Δy), f, 2, y) isa Tuple{T, T}
                 _, ∂x, ∂y = rrule(f, 2, y)[2](Δz)
                 @test (∂x, ∂y) isa Tuple{Float64, T}
             end
@@ -282,6 +282,28 @@ const FASTABLE_AST = quote
                 @test Ω̇ == 0.0 + 0.0im
             end
         end
+    end
+
+    @testset "+,- on weird types" begin
+        
+        struct StoreHalfed <: Number
+            val::Float64
+            StoreHalfed(x) = new(x/2)
+        end
+        Base.:-(x::StoreHalfed, y::Number) = 2*x.val - y
+        Base.:+(x::StoreHalfed, y::Number) = 2*x.val + y
+        
+        sh1 = StoreHalfed(4.0)
+        sh2 = StoreHalfed(8.0)
+        f1 = 40.0
+        f2 = 80.0
+
+        # We have had issues with mixed number types before
+        # So these should not hit
+        @test rrule(+, sh1, f1) == nothing
+        @test rrule(-, sh1, f1) == nothing
+        @test frule((NoTangent(), Tangent{StoreHalfed}(val=2.0), 20.0),+,  sh1, f1) == nothing
+        @test frule((NoTangent(), Tangent{StoreHalfed}(val=2.0), 20.0),-,  sh1, f1) == nothing
     end
 end
 


### PR DESCRIPTION
This is that constant tension in ChainRules between wanting to implement very general rules,
but not being sure you can rely on them to work for types that you can't trust to follow your epxectations.

This is the companion to https://github.com/JuliaDiff/Diffractor.jl/pull/272


The version of this I have seen in the wild is calling Diffractor forwards mode over ForwardDiff,
and then getting `-(::Dual, Float64)` which is defined, but this can result in `-(::Tangent{<:Dual}, Float64)` which is not defined.

I am not convinced this is the best point to chose.
I think it might be argued that Diffractor's handling of `Dual` is aberant, 
and it should be constructing either a Tangent which is a `Dual` 
or it should be `@opt_out frule(::typeof(-), ::Dual, Float64)`