### PR TITLE
Add rule for `Base.unsafe_trunc`

### DIFF
--- a/src/rulesets/Base/nondiff.jl
+++ b/src/rulesets/Base/nondiff.jl
@@ -445,6 +445,7 @@ end
 @non_differentiable unique(::AbstractArray{Symbol})
 @non_differentiable unmark(::IO)
 @non_differentiable unsafe_string(::Cstring)
+@non_differentiable unsafe_trunc(::Any...)
 @non_differentiable uppercase(::AbstractString)
 @non_differentiable uppercase(::AbstractChar)
 @non_differentiable uppercasefirst(::AbstractString)


### PR DESCRIPTION
This is to match `Base.trunc` and notably is used in `convert(::Type{Int64}, ::Float64)`