### PR TITLE
Add rrule for NamedTuple merge

### DIFF
--- a/src/rulesets/Base/base.jl
+++ b/src/rulesets/Base/base.jl
@@ -291,3 +291,25 @@ function rrule(config::RuleConfig{>:HasReverseMode}, ::typeof(task_local_storage
     end
     return y, task_local_storage_pullback
 end
+
+
+####
+#### merge
+####
+
+function rrule(::typeof(merge), nt1::NamedTuple{F1}, nt2::NamedTuple{F2}) where {F1, F2}
+    y = merge(nt1, nt2)
+    function merge_pullback(dy)
+        dnt1 = Tangent{typeof(nt1)}(;
+            (f1 => (f1 in F2 ? ZeroTangent() : getproperty(dy, f1)) for f1 in F1)...
+        )
+        dnt2 = Tangent{typeof(nt2)}(;
+            (f2 => getproperty(dy, f2) for f2 in F2)...
+        )
+        return (NoTangent(), dnt1, dnt2)
+    end
+    merge_pullback(dy::AbstractThunk) = merge_pullback(unthunk(dy))
+    merge_pullback(x::AbstractZero) = (NoTangent(), x, x)
+	
+    return y, merge_pullback
+end

--- a/src/rulesets/Base/base.jl
+++ b/src/rulesets/Base/base.jl
@@ -296,11 +296,12 @@ end
 #### merge
 ####
 # need to work around inability to return closures from generated functions
-struct MergePullback{T1, T2}
-end
+struct MergePullback{T1,T2} end
 (this::MergePullback)(dy::AbstractThunk) = this(unthunk(dy))
 (::MergePullback)(x::AbstractZero) = (NoTangent(), x, x)
-@generated function(::MergePullback{T1,T2})(dy::Tangent) where {F1,T1<:NamedTuple{F1},F2,T2<:NamedTuple{F2}}
+@generated function (::MergePullback{T1,T2})(
+    dy::Tangent
+) where {F1,T1<:NamedTuple{F1},F2,T2<:NamedTuple{F2}}
     _getproperty_kwexpr(key) = :($key = getproperty(dy, $(Meta.quot(key))))
     quote
         dnt1 = Tangent{T1}(; $(map(_getproperty_kwexpr, setdiff(F1, F2))...))
@@ -309,7 +310,7 @@ end
     end
 end
 
-function rrule(::typeof(merge), nt1::T1, nt2::T2) where {T1<:NamedTuple, T2<:NamedTuple}
+function rrule(::typeof(merge), nt1::T1, nt2::T2) where {T1<:NamedTuple,T2<:NamedTuple}
     y = merge(nt1, nt2)
     return y, MergePullback{T1,T2}()
 end

--- a/src/rulesets/Base/base.jl
+++ b/src/rulesets/Base/base.jl
@@ -292,24 +292,20 @@ function rrule(config::RuleConfig{>:HasReverseMode}, ::typeof(task_local_storage
     return y, task_local_storage_pullback
 end
 
-
 ####
 #### merge
 ####
 
-function rrule(::typeof(merge), nt1::NamedTuple{F1}, nt2::NamedTuple{F2}) where {F1, F2}
+function rrule(::typeof(merge), nt1::NamedTuple{F1}, nt2::NamedTuple{F2}) where {F1,F2}
     y = merge(nt1, nt2)
     function merge_pullback(dy)
         dnt1 = Tangent{typeof(nt1)}(;
             (f1 => (f1 in F2 ? ZeroTangent() : getproperty(dy, f1)) for f1 in F1)...
         )
-        dnt2 = Tangent{typeof(nt2)}(;
-            (f2 => getproperty(dy, f2) for f2 in F2)...
-        )
+        dnt2 = Tangent{typeof(nt2)}(; (f2 => getproperty(dy, f2) for f2 in F2)...)
         return (NoTangent(), dnt1, dnt2)
     end
     merge_pullback(dy::AbstractThunk) = merge_pullback(unthunk(dy))
     merge_pullback(x::AbstractZero) = (NoTangent(), x, x)
-	
     return y, merge_pullback
 end

--- a/test/rulesets/Base/base.jl
+++ b/test/rulesets/Base/base.jl
@@ -259,7 +259,7 @@ end
     end
 
     @testset "merge NamedTuple" begin
-        test_rrule(merge, (; a=1.0), (; b=2.0); check_inferred=false)
-        test_rrule(merge, (; a=1.0), (; a=2.0); check_inferred=false)
+        test_rrule(merge, (;a=1.0), (;b=2.0))
+        test_rrule(merge, (;a=1.0), (;a=2.0))
     end
 end

--- a/test/rulesets/Base/base.jl
+++ b/test/rulesets/Base/base.jl
@@ -259,7 +259,7 @@ end
     end
 
     @testset "merge NamedTuple" begin
-        test_rrule(merge, (;a=1.0), (;b=2.0), check_inferred=false)
-        test_rrule(merge, (;a=1.0), (;a=2.0), check_inferred=false)
+        test_rrule(merge, (; a=1.0), (; b=2.0); check_inferred=false)
+        test_rrule(merge, (; a=1.0), (; a=2.0); check_inferred=false)
     end
 end

--- a/test/rulesets/Base/base.jl
+++ b/test/rulesets/Base/base.jl
@@ -257,4 +257,9 @@ end
             test_rrule(map, Multiplier(4.5), (6.7, 8.9), (0.1, 0.2, 0.3), check_inferred=false)
         end
     end
+
+    @testset "merge NamedTuple" begin
+        test_rrule(merge, (;a=1.0), (;b=2.0), check_inferred=false)
+        test_rrule(merge, (;a=1.0), (;a=2.0), check_inferred=false)
+    end
 end

--- a/test/rulesets/Base/base.jl
+++ b/test/rulesets/Base/base.jl
@@ -259,7 +259,7 @@ end
     end
 
     @testset "merge NamedTuple" begin
-        test_rrule(merge, (;a=1.0), (;b=2.0))
-        test_rrule(merge, (;a=1.0), (;a=2.0))
+        test_rrule(merge, (; a=1.0), (; b=2.0))
+        test_rrule(merge, (; a=1.0), (; a=2.0))
     end
 end


### PR DESCRIPTION
Based on https://github.com/LuxDL/Lux.jl/pull/659
but with some fixes up to use ChainRulesCore types.

Initial PR is not inferable.
I suspect i will need to rewrite this as a generated funcition to make it infer.


@Avik-pal do you want to test this branch against your use case, with it deleted from Lux?