### PR TITLE
make `rrule` return identical pullback for `zero` as for `one`

### DIFF
--- a/src/rulesets/Base/base.jl
+++ b/src/rulesets/Base/base.jl
@@ -4,6 +4,11 @@
 @scalar_rule copysign(y, x) (ifelse(signbit(x)!=signbit(y), -one(y), +one(y)), NoTangent())
 @scalar_rule transpose(x) true
 
+# TODO: define using `Returns((NoTangent(), ZeroTangent()))` when support for Julia v1.6 is dropped
+function _pullback_for_constant(::Any)
+    (NoTangent(), ZeroTangent())
+end
+
 # `zero`
 
 function frule((_, _), ::typeof(zero), x)
@@ -11,8 +16,7 @@ function frule((_, _), ::typeof(zero), x)
 end
 
 function rrule(::typeof(zero), x)
-    zero_pullback(_) = (NoTangent(), ZeroTangent())
-    return (zero(x), zero_pullback)
+    return (zero(x), _pullback_for_constant)
 end
 
 # `one`
@@ -22,8 +26,7 @@ function frule((_, _), ::typeof(one), x)
 end
 
 function rrule(::typeof(one), x)
-    one_pullback(_) = (NoTangent(), ZeroTangent())
-    return (one(x), one_pullback)
+    return (one(x), _pullback_for_constant)
 end
 
 

--- a/test/rulesets/Base/base.jl
+++ b/test/rulesets/Base/base.jl
@@ -4,6 +4,7 @@ end
 
 @testset "base.jl" begin
     @testset "zero/one" begin
+        @test last(rrule(zero, 0.1)) === last(rrule(one, 0.2f0))
         for f in [zero, one]
             for x in [1.0, 1.0im, [10.0+im 11.0-im; 12.0+2im 13.0-3im]]
                 test_frule(f, x)


### PR DESCRIPTION
Could be a minor compilation latency and/or type stability win for some uses.