### PR TITLE
exclude julia 1.6 x86 from CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,6 +20,9 @@ jobs:
         arch:
           - x86
           - x64
+        exclude:
+          - version: "1.6"
+            arch: x86
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2


### PR DESCRIPTION
This has been stocastically failing more often than not. The signal to noise ratio is too low and i have just been ignoring it for like a year. It is some julia or JuliaInterpetter bug being hit