### PR TITLE
Add StructArrays@0.2 compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "1.72.0"
+version = "1.72.1"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/Project.toml
+++ b/Project.toml
@@ -36,7 +36,7 @@ SparseArrays = "1"
 SparseInverseSubset = "0.1"
 StaticArrays = "1.2"
 Statistics = "1"
-StructArrays = "0.6.11"
+StructArrays = "0.6.11, 0.7"
 SuiteSparse = "1"
 julia = "1.6"
 


### PR DESCRIPTION
This allows installing `GPUArraysCore@0.2` and other downstream packages that require it.
I've also bumped patch version, so that we can tag a release afterwards.