### PR TITLE
Unthunk each element in `∇eachslice`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "1.72.1"
+version = "1.72.2"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/test/rulesets/Base/indexing.jl
+++ b/test/rulesets/Base/indexing.jl
@@ -261,4 +261,17 @@ end
         Val(3);
         check_inferred=(VERSION >= v"1.7"),
     )
+
+    # eachslice: Make sure pulling back an array of thunks unthunks them and does not return all zeros.
+    x = ones(Float32, 3)
+    Δ = ones(Float32, 1)
+    _, norm_back = ChainRules.rrule(norm, x)
+    dx = norm_back(Δ)[2]
+    @test dx isa AbstractThunk
+
+    x = ones(Float32, 3, 1)
+    _, eachcol_back = ChainRules.rrule(eachcol, x)
+    Δ2 = [dx]
+    dx2 = eachcol_back(Δ2)[2]
+    @test all(dx2 .≉ 0f0)
 end


### PR DESCRIPTION
This is required to make Zygote work with thunks (using this PR https://github.com/FluxML/Zygote.jl/pull/966).

MWE:
```julia
x = ones(Float32, 3, 2)
Zygote.gradient(x) do x
    sum(map(norm, eachcol(x)))
end
```
Returns:
```
(Float32[0.0 0.0; 0.0 0.0; 0.0 0.0],)
```

The reason this happens is because `ZBack` no longer unthunks `Thunks` when being called (in `wrap_chainrules_output`), so [rrule for eachcol](https://github.com/JuliaDiff/ChainRules.jl/blob/e05500931b5424897d49ae184ed8e796e6e5357f/src/rulesets/Base/indexing.jl#L264) receives `dy` as:
```
Vector{ChainRulesCore.InplaceableThunk{ChainRulesCore.Thunk{ChainRules.var"#1071#1074"{Float32, SubArray{Float32, 1, Matrix{Float32}, Tuple{Base.Slice{Base.OneTo{Int64}}, Int64}, true}, Float32}}, ChainRules.var"#1070#1073"{Float32, SubArray{Float32, 1, Matrix{Float32}, Tuple{Base.Slice{Base.OneTo{Int64}}, Int64}, true}, Float32}}}
```

Where each element of `Vector` is produced by [`norm_pullback_2`](https://github.com/JuliaDiff/ChainRules.jl/blob/e05500931b5424897d49ae184ed8e796e6e5357f/src/rulesets/LinearAlgebra/norm.jl#L65).
While previously due to unthunking in `ZBack` we'd get for `dy`:
```
Vector{Vector{Float32}}
```

And so the execution of `∇eachslice` woudn't terminate [here](https://github.com/JuliaDiff/ChainRules.jl/blob/e05500931b5424897d49ae184ed8e796e6e5357f/src/rulesets/Base/indexing.jl#L268).