### PR TITLE
Fix type inference failure in norm on structural matrix

### DIFF
--- a/src/rulesets/LinearAlgebra/utils.jl
+++ b/src/rulesets/LinearAlgebra/utils.jl
@@ -58,7 +58,9 @@ for S in [
     :UnitLowerTriangular,
 ]
     @eval withsomezeros_rewrap(::$S, x) = $S(x)
+    @eval maybe_withsomezeros_rewrap(::$S, x) = $S(x)
 end
+maybe_withsomezeros_rewrap(::AbstractArray, x) = x
 
 # Bidiagonal, Tridiagonal have more complicated storage.
 # AdjOrTransUpperOrUnitUpperTriangular would need adjoint(parent(parent()))


### PR DESCRIPTION
This fixes the 1.11 failures on CI.

Not sure its the best way,
but it basically boils down to 

Julia 1.11 introduced a minor regression in inference of: `zero.(Diagonal(Float64[;])) .* 0.0)`
This used to infer to `Diagonal{Float64}` now it infers to `Union(Diagonal{Float64}, Matrix{Float64})`
Similar to others.

Not sure this is exactly the cleanest or best way but this does fix it.

We also could change it not to test this.
But small type inference failures do easily grow into big ones -- union splitting isn't a silver bullet.


----

I am not stepping up to primary maintainer duties,
I am just on leave and thought i would check something and I saw CI was broken.
hopefully someone can review this