### PR TITLE
Use `_return_type` from Base, not from `Core.Compiler`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "1.72.2"
+version = "1.72.3"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/rulesets/Base/broadcast.jl
+++ b/src/rulesets/Base/broadcast.jl
@@ -48,7 +48,7 @@ end
 # Path 2: This is roughly what `derivatives_given_output` is designed for, should be fast.
 
 function may_bc_derivatives(::Type{T}, f::F, args::Vararg{Any,N}) where {T,F,N}
-    TΔ = Core.Compiler._return_type(derivatives_given_output, Tuple{T, F, map(_eltype, args)...})
+    TΔ = Base._return_type(derivatives_given_output, Tuple{T, F, map(_eltype, args)...})
     return isconcretetype(TΔ)
 end
 
@@ -98,7 +98,7 @@ function may_bc_forwards(cfg::C, f::F, arg) where {C,F}
     TA = _eltype(arg)
     TA <: Real || return false
     cfg isa RuleConfig{>:HasForwardsMode} && return true  # allows frule_via_ad
-    TF = Core.Compiler._return_type(frule, Tuple{C, Tuple{NoTangent, TA}, F, TA})
+    TF = Base._return_type(frule, Tuple{C, Tuple{NoTangent, TA}, F, TA})
     return isconcretetype(TF) && TF <: Tuple
 end
 

--- a/src/rulesets/Base/broadcast.jl
+++ b/src/rulesets/Base/broadcast.jl
@@ -48,7 +48,7 @@ end
 # Path 2: This is roughly what `derivatives_given_output` is designed for, should be fast.
 
 function may_bc_derivatives(::Type{T}, f::F, args::Vararg{Any,N}) where {T,F,N}
-    TΔ = Base._return_type(derivatives_given_output, Tuple{T, F, map(_eltype, args)...})
+    TΔ = Core.Compiler.return_type(derivatives_given_output, Tuple{T, F, map(_eltype, args)...})
     return isconcretetype(TΔ)
 end
 
@@ -98,7 +98,7 @@ function may_bc_forwards(cfg::C, f::F, arg) where {C,F}
     TA = _eltype(arg)
     TA <: Real || return false
     cfg isa RuleConfig{>:HasForwardsMode} && return true  # allows frule_via_ad
-    TF = Base._return_type(frule, Tuple{C, Tuple{NoTangent, TA}, F, TA})
+    TF = Core.Compiler.return_type(frule, Tuple{C, Tuple{NoTangent, TA}, F, TA})
     return isconcretetype(TF) && TF <: Tuple
 end
 

--- a/src/rulesets/Base/mapreduce.jl
+++ b/src/rulesets/Base/mapreduce.jl
@@ -139,7 +139,7 @@ Works by seeing if the result of `derivatives_given_output(nothing, f, x)` can b
 The method of `derivatives_given_output` usually comes from `@scalar_rule`.
 """
 function _uses_input_only(f::F, ::Type{xT}) where {F,xT}
-    gT = Core.Compiler._return_type(derivatives_given_output, Tuple{Nothing, F, xT})
+    gT = Base._return_type(derivatives_given_output, Tuple{Nothing, F, xT})
     # Here we must check `<: Number`, to avoid this, the one rule which can return the `nothing`:
     # ChainRules.derivatives_given_output("anything", exp, 1) == (("anything",),)
     return isconcretetype(gT) && gT <: Tuple{Tuple{Number}}

--- a/src/rulesets/Base/mapreduce.jl
+++ b/src/rulesets/Base/mapreduce.jl
@@ -139,7 +139,7 @@ Works by seeing if the result of `derivatives_given_output(nothing, f, x)` can b
 The method of `derivatives_given_output` usually comes from `@scalar_rule`.
 """
 function _uses_input_only(f::F, ::Type{xT}) where {F,xT}
-    gT = Base._return_type(derivatives_given_output, Tuple{Nothing, F, xT})
+    gT = Core.Compiler.return_type(derivatives_given_output, Tuple{Nothing, F, xT})
     # Here we must check `<: Number`, to avoid this, the one rule which can return the `nothing`:
     # ChainRules.derivatives_given_output("anything", exp, 1) == (("anything",),)
     return isconcretetype(gT) && gT <: Tuple{Tuple{Number}}


### PR DESCRIPTION
Starting from https://github.com/JuliaLang/julia/pull/56409, we [no longer have](https://github.com/JuliaLang/julia/blob/e026affc3ad49ac199cf22ce05aeb412d50fcb21/base/Base_compiler.jl#L305) `Base._return_type === Core.Compiler._return_type`, and therefore `Core.Compiler._return_type` calls the wrong function on nightly, triggering an error. This PR should ensure a more stable access to this binding.