### PR TITLE
Add `Core.has_free_typevars` rule

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRules"
 uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "1.72.4"
+version = "1.72.5"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/rulesets/Core/core.jl
+++ b/src/rulesets/Core/core.jl
@@ -13,6 +13,9 @@
 if isdefined(Core, :_typevar)
     @non_differentiable Core._typevar(::Any...)
 end
+if isdefined(Core, :has_free_typevars)
+    @non_differentiable Core.has_free_typevars(::Any)
+end
 @non_differentiable TypeVar(::Any...)
 @non_differentiable UnionAll(::Any, ::Any)
 


### PR DESCRIPTION
Needed for closure support in 1.12 due to https://github.com/JuliaLang/julia/pull/40985